### PR TITLE
NOREF: Two small fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,11 @@
 const config = require('config')
 const swaggerDocs = require('./swagger.v0.1.json')
 const pjson = require('./package.json')
-const logger = require('./lib/logger')
 
 require('dotenv').config()
+// Load logger after running above to ensure we respect LOG_LEVEL if set
+const logger = require('./lib/logger')
+
 require('./lib/preflight_check')
 
 var express = require('express')

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -109,7 +109,7 @@ class DeliveryLocationsResolver {
             let ellapsed = ((new Date()) - __start)
             logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
 
-            if (response && response.searchResultRows) {
+            if (response && response.searchResultRows && response.searchResultRows.length) {
               let results = response.searchResultRows
               let customerCode = null
 


### PR DESCRIPTION
Fixes two small unrelated things:

### 1. Move lib/logger require to respect LOG_LEVEL

Moves where lib/logger is required to ensure that dotenv first loads
environmental config so that (when running locally) LOG_LEVEL is
respected by lib/logger. (Note this has no effect on deployed code
because ENV is populated outside the app.)

### 2. Fix: don't flood logs with erroneous scsb errors

This just adds a conditional to scsb api handling to ensure that we
don't hit a propery access error, which adds noise to discovery-api
logs.