### PR TITLE
Scc 2667

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -467,7 +467,7 @@ module.exports = function (app, _private = null) {
 }
 
 const queryHasParams = function (params) {
-  return params.q || ADVANCED_SEARCH_PARAMS.some(param => params[param])
+  return params.q || ADVANCED_SEARCH_PARAMS.some((param) => params[param])
 }
 
 /**
@@ -713,8 +713,8 @@ const buildElasticQuery = function (params) {
   }
 
   const advancedParamQueries = ADVANCED_SEARCH_PARAMS
-    .filter(param => params[param])
-    .map(param =>
+    .filter((param) => params[param])
+    .map((param) =>
       buildElasticQueryForKeywords({ q: params[param], search_scope: param }).bool.should
     )
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -108,6 +108,9 @@ const QUERY_STRING_QUERY_FIELDS = {
 // The following fields can be excluded from ES responses because we don't pass them to client:
 const EXCLUDE_FIELDS = ['uris', '*_packed', '*_sort', 'items.*_packed', 'contentsTitle']
 
+// The following maps search scopes can occur as parameters in the advanced search
+const ADVANCED_SEARCH_PARAMS = ['title', 'subject', 'contributor']
+
 // Configure controller-wide parameter parsing:
 var parseSearchParams = function (params) {
   return util.parseParams(params, {
@@ -120,7 +123,10 @@ var parseSearchParams = function (params) {
     search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' },
     filters: { type: 'hash', fields: FILTER_CONFIG },
     items_size: { type: 'int', default: 100, range: [0, 200] },
-    items_from: { type: 'int', default: 0 }
+    items_from: { type: 'int', default: 0 },
+    contributor: { type: 'string' },
+    title: { type: 'string' },
+    subject: { type: 'string' }
   })
 }
 
@@ -460,6 +466,10 @@ module.exports = function (app, _private = null) {
   }
 }
 
+const queryHasParams = function (params) {
+  return params.q || ADVANCED_SEARCH_PARAMS.some(param => params[param])
+}
+
 /**
  *  Given GET params, returns a plainobject with `from`, `size`, `query`,
  *  `sort`, and any other params necessary to perform the ES query based
@@ -473,11 +483,11 @@ const buildElasticBody = function (params) {
     size: params.per_page
   }
 
-  if (params.q || params.filters) {
+  if (params.filters || queryHasParams(params)) {
     var query = buildElasticQuery(params)
 
     // contains query: give it a score
-    if (params.q) {
+    if (queryHasParams(params)) {
       body.query = {
         function_score: {
           query: query
@@ -700,6 +710,19 @@ const buildElasticQuery = function (params) {
   if (params.q) {
     // Merge keyword-specific ES query into the query we're building:
     query.bool = buildElasticQueryForKeywords(params).bool
+  }
+
+  const advancedParamQueries = ADVANCED_SEARCH_PARAMS
+    .filter(param => params[param])
+    .map(param =>
+      buildElasticQueryForKeywords({ q: params[param], search_scope: param }).bool.should
+    )
+
+  if (advancedParamQueries.length) {
+    query.bool = query.bool || { should: [] }
+    query.bool.should = query.bool.should.concat(advancedParamQueries.reduce((acc, el) =>
+      acc.concat(el)
+    ))
   }
 
   if (params.filters) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -299,7 +299,7 @@ exports.objectEntries = (obj) => {
 exports.gatherParams = function (req, acceptedParams) {
   // If specific params configured, pass those to handler
   // otherwise just pass `value` param (i.e. keyword search)
-  acceptedParams = (typeof acceptedParams === 'undefined') ? ['page', 'per_page', 'value', 'q', 'filters'] : acceptedParams
+  acceptedParams = (typeof acceptedParams === 'undefined') ? ['page', 'per_page', 'value', 'q', 'filters', 'contributor', 'subject', 'title'] : acceptedParams
 
   var params = {}
   acceptedParams.forEach((k) => {

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
     next()
   })
 
-  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction', 'search_scope', 'items_size', 'items_from']
+  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction', 'search_scope', 'items_size', 'items_from', 'contributor', 'title', 'subject']
 
   const respond = (res, _resp, params) => {
     var contentType = 'application/ld+json'

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -94,6 +94,26 @@ describe('Resources query', function () {
       expect(body.bool.should[0].query_string).to.be.a('object')
       expect(body.bool.should[0].query_string.query).to.equal('potatoes')
     })
+
+    it('accepts advanced search parameters', function () {
+      const params = resourcesPrivMethods.parseSearchParams({ contributor: 'Poe', title: 'Raven', subject: 'ravens' })
+      const body = resourcesPrivMethods.buildElasticQuery(params)
+      expect(body).to.be.a('object')
+      expect(body.bool).to.be.a('object')
+      expect(body.bool.should).to.be.a('array')
+      expect(body.bool.should[0].query_string).to.be.a('object')
+      expect(body.bool.should[0].query_string.fields).to.be.a('array')
+      expect(body.bool.should[0].query_string.fields[0]).to.equal('title^5')
+      expect(body.bool.should[0].query_string.query).to.equal('Raven')
+      expect(body.bool.should[1].query_string).to.be.a('object')
+      expect(body.bool.should[1].query_string.fields).to.be.a('array')
+      expect(body.bool.should[1].query_string.fields[0]).to.equal('subjectLiteral^2')
+      expect(body.bool.should[1].query_string.query).to.equal('ravens')
+      expect(body.bool.should[2].query_string).to.be.a('object')
+      expect(body.bool.should[2].query_string.fields).to.be.a('array')
+      expect(body.bool.should[2].query_string.fields[0]).to.equal('creatorLiteral^4')
+      expect(body.bool.should[2].query_string.query).to.equal('Poe')
+    })
   })
 
   describe('buildElasticBody', function () {


### PR DESCRIPTION
- Adds optional advanced search params, including `contributor`, `subject`, and `title`.
- Builds query for these params, if present, by passing them to existing query builder and aggregating the query bodies together.