### PR TITLE
SCC 2719: Add support for HL records

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -3,6 +3,8 @@
 var R = require('ramda')
 var lexicon = require('nypl-registry-utils-lexicon')
 
+const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
+
 var util = require('./util.js')
 const logger = require('./logger')
 const PACK_DELIM = '||'
@@ -308,21 +310,21 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
   // e.g.
   //   urn:SierraNypl:1234
   //   urn:RecapCul:4567
-  //   urn:Recappul:6789
+  //   urn:RecapPul:6789
+  //   urn:RecapHl:87654321
   static addSourceIdentifier (item) {
     // Ensure identifiers array exists:
-    if (!item.identifier) item.identifier = []
+    item.identifier = item.identifier || []
 
-    // Partner items will have prefix 'c' or 'p'
-    var m = item.uri.match(/^(\w?)i(.*)$/)
-    if (m.length === 3) {
-      var sourceIdentifier = m[2]
-      var sourceIdentifierPrefix = 'SierraNypl'
-      if (m[1] === 'c') sourceIdentifierPrefix = 'RecapCul'
-      else if (m[1] === 'p') sourceIdentifierPrefix = 'RecapPul'
-
-      item.identifier.push(`urn:${sourceIdentifierPrefix}:${sourceIdentifier}`)
+    const { id, nyplSource, type } = NyplSourceMapper.instance().splitIdentifier(item.uri)
+    if (type === 'item') {
+      // Build prefix nyplSource as camel case
+      const sourceIdentifierPrefix = nyplSource.split('-')
+        .map((term) => term.replace(/^\w/, (c) => c.toUpperCase()))
+        .join('')
+      item.identifier.push(`urn:${sourceIdentifierPrefix}:${id}`)
     }
+
     return item
   }
 }
@@ -517,4 +519,4 @@ class AgentSerializer extends JsonLdItemSerializer {
   }
 }
 
-module.exports = { JsonLdSerializer, ResourceSerializer, ItemResultsSerializer, ResourceResultsSerializer, AggregationsSerializer, AgentResultsSerializer, AgentSerializer, AggregationSerializer }
+module.exports = { JsonLdSerializer, ResourceSerializer, ItemResourceSerializer, ItemResultsSerializer, ResourceResultsSerializer, AggregationsSerializer, AgentResultsSerializer, AgentSerializer, AggregationSerializer }

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -284,7 +284,7 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
     if (stmts.identifier) {
       // Add idNyplSourceId convenience property by parsing identifiers that match urn:[source]:[id]
       this.body.identifier
-        .filter((urn) => /^urn:(SierraNypl|RecapCul|RecapPul):.+/.test(urn))
+        .filter((urn) => /^urn:(SierraNypl|Recap.+):.+/.test(urn))
         .forEach((urn) => {
           var type = urn.split(':')[1]
           var value = urn.split(':')[2]
@@ -319,13 +319,18 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
     const { id, nyplSource, type } = NyplSourceMapper.instance().splitIdentifier(item.uri)
     if (type === 'item') {
       // Build prefix nyplSource as camel case
-      const sourceIdentifierPrefix = nyplSource.split('-')
-        .map((term) => term.replace(/^\w/, (c) => c.toUpperCase()))
-        .join('')
+      const sourceIdentifierPrefix = ItemResourceSerializer.sourceIdentifierPrefixByNyplSource(nyplSource)
       item.identifier.push(`urn:${sourceIdentifierPrefix}:${id}`)
     }
 
     return item
+  }
+
+  static sourceIdentifierPrefixByNyplSource (nyplSource) {
+    return nyplSource
+      .split('-')
+      .map((term) => term.replace(/^\w/, (c) => c.toUpperCase()))
+      .join('')
   }
 }
 

--- a/lib/ownership_determination.js
+++ b/lib/ownership_determination.js
@@ -1,13 +1,10 @@
+const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
+
 // This is based on uri now but should be changed to use the 'item.owner' field once it's more reliably serialized.
 // This just talks about ownership, not recap vs non-recap
 let isItemNyplOwned = (item) => {
-  let match = item.uri.match(/^(\w?)i(.*)$/)
-  if (match && match.length === 3) {
-    let parnerPrefixes = ['c', 'p']
-    return !(parnerPrefixes.indexOf(match[1]) >= 0)
-  } else {
-    return false
-  }
+  const { nyplSource } = NyplSourceMapper.instance().splitIdentifier(item.uri)
+  return nyplSource === 'sierra-nypl'
 }
 
 module.exports = {isItemNyplOwned}

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -1,3 +1,5 @@
+const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
+
 var ResourceResultsSerializer = require('./jsonld_serializers.js').ResourceResultsSerializer
 var ResourceSerializer = require('./jsonld_serializers.js').ResourceSerializer
 var AggregationsSerializer = require('./jsonld_serializers.js').AggregationsSerializer
@@ -192,13 +194,7 @@ module.exports = function (app, _private = null) {
   // Get a single raw annotated-marc resource:
   app.resources.annotatedMarc = function (params, opts) {
     // Convert discovery id to nyplSource and un-prefixed id:
-    const prefix = params.uri.match(/^[pc]?b/)[0]
-    const id = params.uri.replace(prefix, '')
-    let nyplSource = ({
-      b: 'sierra-nypl',
-      pb: 'recap-pul',
-      cb: 'recap-cul'
-    })[prefix]
+    const { id, nyplSource } = NyplSourceMapper.instance().splitIdentifier(params.uri)
 
     app.logger.debug('Resources#annotatedMarc', { id, nyplSource })
     return makeNyplDataApiClient().get(`bibs/${nyplSource}/${id}`)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@nypl/nypl-data-api-client": "^1.0.1",
     "@nypl/scsb-rest-client": "1.0.6",
     "config": "1.12.0",
-    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.2a",
+    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.2",
     "dotenv": "^4.0.0",
     "elasticsearch": "^15.0.0",
     "express": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@nypl/nypl-data-api-client": "^1.0.1",
     "@nypl/scsb-rest-client": "1.0.6",
     "config": "1.12.0",
+    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.2a",
     "dotenv": "^4.0.0",
     "elasticsearch": "^15.0.0",
     "express": "^4.14.0",

--- a/test/item-resource-serializer.test.js
+++ b/test/item-resource-serializer.test.js
@@ -1,16 +1,6 @@
 const { ItemResourceSerializer } = require('../lib/jsonld_serializers')
 
 describe('ItemResourceSerializer', () => {
-  const originalCoreVersion = process.env.NYPL_CORE_VERSION
-
-  before(() => {
-    process.env.NYPL_CORE_VERSION = 'v1.37a'
-  })
-
-  after(() => {
-    process.env.NYPL_CORE_VERSION = originalCoreVersion
-  })
-
   describe('sourceIdentifierPrefixByNyplSource', () => {
     it('produces camel case form of nypl source', () => {
       expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('sierra-nypl')).to.eq('SierraNypl')

--- a/test/item-resource-serializer.test.js
+++ b/test/item-resource-serializer.test.js
@@ -1,0 +1,111 @@
+const { ItemResourceSerializer } = require('../lib/jsonld_serializers')
+
+describe('ItemResourceSerializer', () => {
+  const originalCoreVersion = process.env.NYPL_CORE_VERSION
+
+  before(() => {
+    process.env.NYPL_CORE_VERSION = 'v1.37a'
+  })
+
+  after(() => {
+    process.env.NYPL_CORE_VERSION = originalCoreVersion
+  })
+
+  describe('sourceIdentifierPrefixByNyplSource', () => {
+    it('produces camel case form of nypl source', () => {
+      expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('sierra-nypl')).to.eq('SierraNypl')
+      expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('recap-cul')).to.eq('RecapCul')
+      expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('recap-pul')).to.eq('RecapPul')
+      expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('recap-hl')).to.eq('RecapHl')
+      expect(ItemResourceSerializer.sourceIdentifierPrefixByNyplSource('recap-someotherlibraryacronym')).to.eq('RecapSomeotherlibraryacronym')
+    })
+  })
+
+  describe('serialize', () => {
+    it('adds entity form of NYPL source identifier', () => {
+      const item = ItemResourceSerializer.addSourceIdentifier({
+        uri: 'i22566485',
+        identifier: [
+          'urn:barcode:33433058338470'
+        ]
+      })
+      const doc = ItemResourceSerializer.serialize(item)
+      expect(doc).to.be.a('object')
+      expect(doc['@id']).to.eq('res:i22566485')
+      expect(doc['identifier']).to.be.a('array')
+      expect(doc['identifier'][0]).to.eq('urn:barcode:33433058338470')
+      expect(doc['identifier'][1]).to.eq('urn:SierraNypl:22566485')
+      expect(doc['idNyplSourceId']).to.be.a('object')
+      expect(doc['idNyplSourceId']['@type']).to.eq('SierraNypl')
+      expect(doc['idNyplSourceId']['@value']).to.eq('22566485')
+    })
+
+    it('adds entity form of CUL source identifier', () => {
+      const item = ItemResourceSerializer.addSourceIdentifier({
+        uri: 'ci98765'
+      })
+      const doc = ItemResourceSerializer.serialize(item)
+
+      expect(doc).to.be.a('object')
+      expect(doc['@id']).to.eq('res:ci98765')
+      expect(doc['identifier']).to.be.a('array')
+      expect(doc['identifier'][0]).to.eq('urn:RecapCul:98765')
+      expect(doc['idNyplSourceId']).to.be.a('object')
+      expect(doc['idNyplSourceId']['@type']).to.eq('RecapCul')
+      expect(doc['idNyplSourceId']['@value']).to.eq('98765')
+    })
+
+    it('adds entity form of HL source identifier', () => {
+      const item = ItemResourceSerializer.addSourceIdentifier({
+        uri: 'hi9876543210'
+      })
+      const doc = ItemResourceSerializer.serialize(item)
+
+      expect(doc).to.be.a('object')
+      expect(doc['@id']).to.eq('res:hi9876543210')
+      expect(doc['identifier']).to.be.a('array')
+      expect(doc['identifier'][0]).to.eq('urn:RecapHl:9876543210')
+      expect(doc['idNyplSourceId']).to.be.a('object')
+      expect(doc['idNyplSourceId']['@type']).to.eq('RecapHl')
+      expect(doc['idNyplSourceId']['@value']).to.eq('9876543210')
+    })
+  })
+
+  describe('addSourceIdentifier', () => {
+    it('adds source identifier for NYPL', () => {
+      const item = { uri: 'i1234' }
+
+      const itemWithSourceIds = ItemResourceSerializer.addSourceIdentifier(item)
+      expect(itemWithSourceIds).to.be.a('object')
+      expect(itemWithSourceIds.identifier).to.be.a('array')
+      expect(itemWithSourceIds.identifier[0]).to.eq('urn:SierraNypl:1234')
+    })
+
+    it('adds source identifier for CUL', () => {
+      const item = { uri: 'ci1234' }
+
+      const itemWithSourceIds = ItemResourceSerializer.addSourceIdentifier(item)
+      expect(itemWithSourceIds).to.be.a('object')
+      expect(itemWithSourceIds.identifier).to.be.a('array')
+      expect(itemWithSourceIds.identifier[0]).to.eq('urn:RecapCul:1234')
+    })
+
+    it('adds source identifier for PUL', () => {
+      const item = { uri: 'pi1234' }
+
+      const itemWithSourceIds = ItemResourceSerializer.addSourceIdentifier(item)
+      expect(itemWithSourceIds).to.be.a('object')
+      expect(itemWithSourceIds.identifier).to.be.a('array')
+      expect(itemWithSourceIds.identifier[0]).to.eq('urn:RecapPul:1234')
+    })
+
+    it('adds source identifier for HL', () => {
+      const item = { uri: 'hi1234' }
+
+      const itemWithSourceIds = ItemResourceSerializer.addSourceIdentifier(item)
+      expect(itemWithSourceIds).to.be.a('object')
+      expect(itemWithSourceIds.identifier).to.be.a('array')
+      expect(itemWithSourceIds.identifier[0]).to.eq('urn:RecapHl:1234')
+    })
+  })
+})

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -713,4 +713,50 @@ describe('Test Resources responses', function () {
       })
     })
   })
+
+  describe('annotatedMarc endpoint', () => {
+    let app = { logger: { debug: () => null } }
+
+    before(() => {
+      require('../lib/resources')(app)
+
+      // Configure the stubbing to serve up the same fixture for all calls:
+      fixtures.enableDataApiFixtures({
+        'bibs/sierra-nypl/11055155': 'bib-11055155.json',
+        'bibs/recap-cul/11055155': 'bib-11055155.json',
+        'bibs/recap-hl/11055155': 'bib-11055155.json'
+      })
+    })
+
+    after(() => {
+      fixtures.disableDataApiFixtures()
+    })
+
+    it('traslates nypl record id into necessary BibService call', () => {
+      return app.resources.annotatedMarc({ uri: 'b11055155' })
+        .then((data) => {
+          expect(data).to.be.a('object')
+          expect(data.bib).to.be.a('object')
+          expect(data.bib.id).to.eq('11055155')
+        })
+    })
+
+    it('traslates CUL record id into necessary BibService call', () => {
+      return app.resources.annotatedMarc({ uri: 'cb11055155' })
+        .then((data) => {
+          expect(data).to.be.a('object')
+          expect(data.bib).to.be.a('object')
+          expect(data.bib.id).to.eq('11055155')
+        })
+    })
+
+    it('traslates HL record id into necessary BibService call', () => {
+      return app.resources.annotatedMarc({ uri: 'hb11055155' })
+        .then((data) => {
+          expect(data).to.be.a('object')
+          expect(data.bib).to.be.a('object')
+          expect(data.bib.id).to.eq('11055155')
+        })
+    })
+  })
 })

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -18,5 +18,11 @@ if (!process.env.UPDATE_FIXTURES) {
   process.env.SCSB_API_KEY = 'fake-scsb-api-key'
 }
 
+// TODO: Setting a hard NYPL-Core version is temporary (although largely
+// future safe) and may be removed once the following is merged to
+// `master`:
+// https://github.com/NYPL/nypl-core/commit/e7548eaedd93c7dcbe17c82f61e299dfca1a9e13
+process.env.NYPL_CORE_VERSION = 'v1.37a'
+
 require('../lib/globals')
 global.expect = require('chai').expect

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -18,11 +18,5 @@ if (!process.env.UPDATE_FIXTURES) {
   process.env.SCSB_API_KEY = 'fake-scsb-api-key'
 }
 
-// TODO: Setting a hard NYPL-Core version is temporary (although largely
-// future safe) and may be removed once the following is merged to
-// `master`:
-// https://github.com/NYPL/nypl-core/commit/e7548eaedd93c7dcbe17c82f61e299dfca1a9e13
-process.env.NYPL_CORE_VERSION = 'v1.37a'
-
 require('../lib/globals')
 global.expect = require('chai').expect


### PR DESCRIPTION
This makes several small edits to add support for Harvard records. It generally updates instances where PUL/CUL identifiers are handled explicitly and replaces them with use of a shared NyplSourceMapper module, which centralizes institution identifiers.