### PR TITLE
Add support for hiding records by nyplSource

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -498,10 +498,7 @@ const buildElasticBody = function (params) {
 
   // If HIDE_NYPL_SOURCE env config set, filter records w/matching nyplSource
   if (process.env.HIDE_NYPL_SOURCE) {
-    body.query = body.query || {}
-    body.query.bool = body.query.bool || {}
-    body.query.bool.filter = body.query.bool.filter || []
-    body.query.bool.filter.push({
+    const hideByNyplSourceClause = {
       bool: {
         must_not: {
           terms: {
@@ -509,7 +506,15 @@ const buildElasticBody = function (params) {
           }
         }
       }
-    })
+    }
+
+    // If body already has a function_score query, add this filter to it;
+    // Otherwise, add it to the top level
+    const placeToPutQuery = body.query && body.query.function_score ? body.query.function_score : body
+    placeToPutQuery.query = placeToPutQuery.query || {}
+    placeToPutQuery.query.bool = placeToPutQuery.query.bool || {}
+    placeToPutQuery.query.bool.filter = placeToPutQuery.query.bool.filter || []
+    placeToPutQuery.query.bool.filter.push(hideByNyplSourceClause)
   }
 
   // Default is relevance. Handle case where it's set to something else:

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -496,6 +496,22 @@ const buildElasticBody = function (params) {
     }
   }
 
+  // If HIDE_NYPL_SOURCE env config set, filter records w/matching nyplSource
+  if (process.env.HIDE_NYPL_SOURCE) {
+    body.query = body.query || {}
+    body.query.bool = body.query.bool || {}
+    body.query.bool.filter = body.query.bool.filter || []
+    body.query.bool.filter.push({
+      bool: {
+        must_not: {
+          terms: {
+            nyplSource: process.env.HIDE_NYPL_SOURCE.split(',')
+          }
+        }
+      }
+    })
+  }
+
   // Default is relevance. Handle case where it's set to something else:
   if (params.sort && params.sort !== 'relevance') {
     var direction = params.sort_direction || SORT_FIELDS[params.sort].initialDirection

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -128,6 +128,45 @@ describe('Resources query', function () {
       expect(body.query.bool.filter[0].term).to.be.a('object')
       expect(body.query.bool.filter[0].term.subjectLiteral_exploded).to.equal('United States -- History')
     })
+
+    describe('nyplSource filtering', function () {
+      it('does not filter by nyplSource when HIDE_NYPL_SOURCE is not set', function () {
+        expect(process.env.HIDE_NYPL_SOURCE).to.be.a('undefined')
+
+        const params = resourcesPrivMethods.parseSearchParams({ q: '' })
+        const body = resourcesPrivMethods.buildElasticBody(params)
+
+        expect(body).to.be.a('object')
+        expect(body.query).to.be.a('undefined')
+      })
+
+      it('filters by nyplSource when HIDE_NYPL_SOURCE is set', function () {
+        process.env.HIDE_NYPL_SOURCE = 'recap-hl'
+
+        const params = resourcesPrivMethods.parseSearchParams({ q: '' })
+        const body = resourcesPrivMethods.buildElasticBody(params)
+
+        // Expect query to resemble: {"from":0,"size":50,"query":{"bool":{"filter":[{"bool":{"must_not":{"terms":{"nyplSource":["recap-hl"]}}}}]}},"sort":["uri"]}
+        expect(body).to.be.a('object')
+        expect(body).to.have.deep.property('query', {
+          bool: {
+            filter: [
+              {
+                bool: {
+                  must_not: {
+                    terms: {
+                      nyplSource: ['recap-hl']
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        })
+
+        delete process.env.HIDE_NYPL_SOURCE
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Adds check for process.env.HIDE_NYPL_SOURCE. When set, adds a filter to
all searches, which filters out records matching any of the indicated
nyplSource values.

https://jira.nypl.org/browse/SCC-2753