### PR TITLE
Update holdings location labels to match nypl-core

### DIFF
--- a/lib/location_label_updater.js
+++ b/lib/location_label_updater.js
@@ -9,13 +9,23 @@ class LocationLabelUpdater {
   responseWithUpdatedLabels () {
     let resp = this.elasticSearchResponse
     let updatedHits = resp.hits.hits.map((bib) => {
-      (bib._source.items || []).map((item) => {
+      // Update locations for items:
+      ; (bib._source.items || []).map((item) => {
         if (item.holdingLocation && item.holdingLocation.length > 0) {
           let holdingLocation = item.holdingLocation[0]
           holdingLocation.label = sierraLocations[holdingLocation.id.replace(/^loc:/, '')].label
           item.holdingLocation = [holdingLocation]
         }
         return item
+      })
+      // Update locations for holdings:
+      ; (bib._source.holdings || []).map((holding) => {
+        if (holding.location && holding.location.length > 0) {
+          let location = holding.location[0]
+          location.label = sierraLocations[location.code.replace(/^loc:/, '')].label
+          holding.location = [location]
+        }
+        return holding
       })
       return bib
     })

--- a/test/location_label_updater.test.js
+++ b/test/location_label_updater.test.js
@@ -1,7 +1,7 @@
 let LocationLabelUpdater = require('../lib/location_label_updater.js')
 
 describe('Location LabelUpdater', function () {
-  it('will overwrite an ElasticSearch Response\'s holding location label', function () {
+  it('will overwrite an ElasticSearch Response\'s item holding location label', function () {
     // This is just enough information for LocationLabelUpdater to make use of
     let fakeESResponse = {'hits':
     {'hits': [{
@@ -16,5 +16,22 @@ describe('Location LabelUpdater', function () {
 
     let updatedResponse = new LocationLabelUpdater(fakeESResponse).responseWithUpdatedLabels()
     expect(updatedResponse.hits.hits[0]._source.items[0].holdingLocation[0].label).to.equal('Schwarzman Building - Periodicals and Microforms Room 119')
+  })
+
+  it('will overwrite an ElasticSearch Response\'s holdings record location label', function () {
+    // This is just enough information for LocationLabelUpdater to make use of
+    let fakeESResponse = {'hits':
+    {'hits': [{
+      '_id': 'b10980129',
+      '_source': {
+        'holdings': [{
+          'location': [{'code': 'mai', 'label': 'Some other room name'}]
+        }]
+      }
+    }]}
+    }
+
+    let updatedResponse = new LocationLabelUpdater(fakeESResponse).responseWithUpdatedLabels()
+    expect(updatedResponse.hits.hits[0]._source.holdings[0].location[0].label).to.equal('Schwarzman Building - Microforms Room 315')
   })
 })

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -170,6 +170,7 @@ describe('Resources query', function () {
 
     describe('nyplSource filtering', function () {
       it('does not filter by nyplSource when HIDE_NYPL_SOURCE is not set', function () {
+        delete process.env.HIDE_NYPL_SOURCE
         expect(process.env.HIDE_NYPL_SOURCE).to.be.a('undefined')
 
         const params = resourcesPrivMethods.parseSearchParams({ q: '' })


### PR DESCRIPTION
Uses the existing "location label updater" library that corrects item
location labels to also correct holdings record location labels.