### PR TITLE
Remove status 'o' from criteria for on-site EDD

### DIFF
--- a/data/onsite-edd-criteria.json
+++ b/data/onsite-edd-criteria.json
@@ -1,7 +1,6 @@
 {
   "status": [
-    "a",
-    "o"
+    "a"
   ],
   "accessMessage": [
     "-",


### PR DESCRIPTION
To match the criteria set forth in
https://docs.google.com/spreadsheets/d/1fTZlmvT39Yk3ZAeYR2qNNwIUIhWhBY1XpOUPaYTeOL8/edit#gid=0
this PR removes 'o' as an acceptable status for on-site EDD as those
items are not pagable by staff.