### PR TITLE
Hotfix: Fix bug with annotated-marc endpoint

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -85,7 +85,7 @@ module.exports = function (app) {
       .catch((error) => handleError(res, error, params))
   })
 
-  app.get(`/api/v${VER}/discovery/resources/:uri\-:itemUri`, function (req, res) {
+  app.get(`/api/v${VER}/discovery/resources/:uri\-:itemUri(i[0-9]+)`, function (req, res) {
     var params = { uri: req.params.uri, itemUri: req.params.itemUri }
 
     return app.resources.findByUri(params, { baseUrl: app.baseUrl }, req)


### PR DESCRIPTION
We have a `resources/:uri\.:ext?` route for handling both of the following requests:

 * `resources/b1234` (parsed as `:uri => "b1234"`)
 * `resources/b1234.annotated-marc` (parsed as `:uri => "b1234", :ext => "annotated-marc"`)

We recently added a new route `resources/:uri-:itemUri` to handle requests like:

 * `resources/b1234-i6789` (parsed as `:uri => "b1234", :itemUri => "i6789"`)

With that added route, requests for `resources/b1234.annotated-marc` are now handled by the new route (parsed as `:uri => "b1234.annotated", :itemUri => "marc"`). Because "b1234.annotated" is not a valid bnumber, all annotated-marc requests are 404ing.

This fix adds inline path param validation (available from express 4.12+) to ensure the new `resources/:uri-:itemUri` only matches `itemUri` params that look like item uris.