### PR TITLE
Noref fix test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,25 +96,25 @@ Run all tests:
 npm test
 ```
 
-Almost all HTTP dependencies are rerouted to fixtures (except for requesting nypl-core mapping files). All fixtures can be updated dynamically (using whatever elastic, scsb, & platform api config is present in `process.env` or `./.env`) via the following:
+### Adding fixtures
 
-```
-UPDATE_FIXTURES=all npm test
-```
+Almost all HTTP dependencies are rerouted to fixtures (except for requesting nypl-core mapping files). All fixtures can be updated dynamically (using creds in `./.env`) via the following:
 
-Rebuilding fixtures tends to introduce trivial git diff noise, so one may use the following to *only* generate fixtures that don't already exist:
+Run tests and automatically build any missing Elasticsearch or SCSB fixtures:
 
 ```
 UPDATE_FIXTURES=if-missing npm test
 ```
 
-Remove fixtures that are no longer used in any test with this flag:
+The above command can be used to fill in missing fixtures as new tests are written or ES queries change.
+
+As ES queries change, some auto generated fixtures may no longer be used by any tests. Remove them with this flag:
 
 ```
 REMOVE_UNUSED_FIXTURES=true npm test
 ```
 
-The above command can be used to fill in missing fixtures as new tests are written.
+Note that other Platform API fixtures (e.g. requests on the Bib service like `bibs/sierra-nypl/1234`) must be fetched and saved manually and then enabled in a `before` via `fixtures.enableDataApiFixtures({ %requestpath% : %fixturepath%`, ... })`. (There's not a great reason for the extra work required to create and use other Platform API fixtures except that there are fewer of them and they tend not to need to change as ES queries change.)
 
 ## API Documentation
 

--- a/config/test.env
+++ b/config/test.env
@@ -4,3 +4,11 @@ SEARCH_ITEMS_SIZE=100
 # This can be any port, but let's choose something reasonably high to
 # avoid conflict:
 PORT=5678
+
+ELASTICSEARCH_HOST=https://es.example.com
+RESOURCES_INDEX=index-name
+
+NYPL_API_BASE_URL=http://api.example.com/api/v0.1/
+NYPL_OAUTH_URL=http://oauth.example.com
+NYPL_OAUTH_ID=user
+NYPL_OAUTH_SECRET=secret

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -2,7 +2,10 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 // Set some env variables:
-require('dotenv').config({ path: './config/test.env' })
+require('dotenv').config({
+  // If we're updating fixtures, load some real creds
+  path: process.env.UPDATE_FIXTURES ? '.env' : './config/test.env'
+})
 
 // Establish base url for local queries:
 global.TEST_BASE_URL = `http://localhost:${process.env.PORT}`


### PR DESCRIPTION
Adds missing env vars to `config/test.env` so that the test suite can pass without a `.env`.

Also:
 - Ensures the existing mechanism for updating fixtures loads the correct, non-test creds
 - Updates README to clarify how to update different kinds of fixtures