### PR TITLE
move eddRequestable check to mirror other request types

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -9,14 +9,14 @@ const Feature = require('./feature')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 
 class AvailabilityResolver {
-  constructor (responseReceived) {
+  constructor(responseReceived) {
     this.elasticSearchResponse = responseReceived
     this.barcodes = this._parseBarCodesFromESResponse()
-    this.restClient = new SCSBRestClient({url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY})
+    this.restClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
   }
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
-  responseWithUpdatedAvailability (request) {
+  responseWithUpdatedAvailability(request) {
     return this._createSCSBBarcodeAvailbilityMapping(this.barcodes)
       .then((barcodesAndAvailability) => {
         this._fixItemAvailabilityInResponse(barcodesAndAvailability, request)
@@ -31,7 +31,7 @@ class AvailabilityResolver {
   /**
    *  Given an array of barcodes, returns a hash mapping barcode to SCSB availability
    */
-  _createSCSBBarcodeAvailbilityMapping (barcodes) {
+  _createSCSBBarcodeAvailbilityMapping(barcodes) {
     if (barcodes.length === 0) {
       logger.debug('no barcodes found')
       return Promise.resolve({})
@@ -46,7 +46,7 @@ class AvailabilityResolver {
       })
   }
 
-  _parseBarCodesFromESResponse () {
+  _parseBarCodesFromESResponse() {
     var barcodes = []
     for (let hit of this.elasticSearchResponse.hits.hits) {
       for (let item of (hit._source.items || [])) {
@@ -68,7 +68,7 @@ class AvailabilityResolver {
     return barcodes
   }
 
-  _fixItemAvailabilityInResponse (barcodesAndAvailability, request) {
+  _fixItemAvailabilityInResponse(barcodesAndAvailability, request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
         // If it's an electronic item, skip it
@@ -104,10 +104,8 @@ class AvailabilityResolver {
             item.physRequestable = [false]
             item.eddRequestable = false
 
-          // Otherwise it is in ReCAP:
+            // Otherwise it is in ReCAP:
           } else {
-            // check eddRequestable by recap customer code:
-            if (recapCustomerCodes[item.recapCustomerCode]) item.eddRequestable = recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
 
             // Make sure properties exist:
             if (!item.status || item.status.length === 0) item.status = [{}]
@@ -123,6 +121,8 @@ class AvailabilityResolver {
                 // Now that true availability is set, establish requestability based on it (and holdingLocation)
                 item.requestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
                 item.physRequestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
+                // check eddRequestable by recap customer code:
+                if (recapCustomerCodes[item.recapCustomerCode]) item.eddRequestable = recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
               } else {
                 // If recap status is Not Available, we need check nothing else
                 item.requestable[0] = false
@@ -132,23 +132,25 @@ class AvailabilityResolver {
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }
 
-            // It's a partner item in ReCAP:
+              // It's a partner item in ReCAP:
             } else {
               if (recapAvailabilityStatus === 'Available') {
                 item.requestable[0] = true
                 item.physRequestable[0] = true
+                item.eddRequestable = true
                 item.status[0].id = config.get('itemAvailability.available.id')
                 item.status[0].label = config.get('itemAvailability.available.label')
               } else {
                 item.requestable[0] = false
                 item.physRequestable[0] = false
+                item.eddRequestable = false
                 item.status[0].id = config.get('itemAvailability.notAvailable.id')
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }
             }
           }
 
-        // Item has a non-ReCAP holdingLocation, so compute requestability against on-site criteria:
+          // Item has a non-ReCAP holdingLocation, so compute requestability against on-site criteria:
         } else {
           // By default, make non-ReCAP materials not requestable
           item.requestable = [false]

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -146,7 +146,9 @@ class AvailabilityResolver {
             item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
           }
         }
-        if (!item.requestable) {
+        // If requestable has not been already set during this serialization,
+        // set it based on separate requestable truthiness
+        if (!Feature.enabled('on-site-edd', request)) {
           item.requestable = []
           item.requestable[0] = item.eddRequestable || item.physRequestable || item.specRequestable
         }

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -136,7 +136,7 @@ class AvailabilityResolver {
               if (recapAvailabilityStatus === 'Available') {
                 item.requestable[0] = true
                 item.physRequestable[0] = true
-                item.eddRequestable = true
+                if (recapCustomerCodes[item.recapCustomerCode]) item.eddRequestable = recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
                 item.status[0].id = config.get('itemAvailability.available.id')
                 item.status[0].label = config.get('itemAvailability.available.label')
               } else {

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -93,24 +93,16 @@ class AvailabilityResolver {
         //  2. it's an NYPL item with a ReCAP holding location or
         //  3. it's not an NYPL owned item (i.e. it's a partner item)
         const isInRecap = item.recapCustomerCode || isRecapHoldingLocation || !isItemNyplOwned(item)
+        item.physRequestable = false
+        item.eddRequestable = false
+        item.specRequestable = false
 
         // If it's in ReCAP
         if (isInRecap) {
           let recapAvailabilityStatus = barcodesAndAvailability[barcode]
 
           // If it's not in ReCAP (but it has a rc location), it's def not requestable
-          if (recapAvailabilityStatus === "Item Barcode doesn't exist in SCSB database.") {
-            item.requestable = [false]
-            item.physRequestable = [false]
-            item.eddRequestable = false
-
-            // Otherwise it is in ReCAP:
-          } else {
-            // Make sure properties exist:
-            if (!item.status || item.status.length === 0) item.status = [{}]
-            if (!item.reqestable || item.requestable.length === 0) item.requestable = []
-            if (!item.physRequestable || item.physRequestable.length === 0) item.physRequestable = []
-
+          if (recapAvailabilityStatus !== "Item Barcode doesn't exist in SCSB database.") {
             // NYPL items require checking 1) recap status, location requestability, and sierra status requestability
             if (isItemNyplOwned(item)) {
               // First check recap status:
@@ -118,15 +110,11 @@ class AvailabilityResolver {
                 item.status[0].id = config.get('itemAvailability.available.id')
                 item.status[0].label = config.get('itemAvailability.available.label')
                 // Now that true availability is set, establish requestability based on it (and holdingLocation)
-                item.requestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
-                item.physRequestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
+                item.physRequestable = requestableBasedOnStatusAndHoldingLocation(item)
                 // check eddRequestable by recap customer code:
                 if (recapCustomerCodes[item.recapCustomerCode]) item.eddRequestable = recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
               } else {
                 // If recap status is Not Available, we need check nothing else
-                item.requestable[0] = false
-                item.physRequestable[0] = false
-                item.eddRequestable = false
                 item.status[0].id = config.get('itemAvailability.notAvailable.id')
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }
@@ -134,15 +122,11 @@ class AvailabilityResolver {
               // It's a partner item in ReCAP:
             } else {
               if (recapAvailabilityStatus === 'Available') {
-                item.requestable[0] = true
-                item.physRequestable[0] = true
+                item.physRequestable = true
                 if (recapCustomerCodes[item.recapCustomerCode]) item.eddRequestable = recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
                 item.status[0].id = config.get('itemAvailability.available.id')
                 item.status[0].label = config.get('itemAvailability.available.label')
               } else {
-                item.requestable[0] = false
-                item.physRequestable[0] = false
-                item.eddRequestable = false
                 item.status[0].id = config.get('itemAvailability.notAvailable.id')
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }
@@ -151,10 +135,9 @@ class AvailabilityResolver {
 
           // Item has a non-ReCAP holdingLocation, so compute requestability against on-site criteria:
         } else {
-          // By default, make non-ReCAP materials not requestable
-          item.requestable = [false]
-          item.physRequestable = [false]
-          item.specRequestable = item.aeonUrl ? [true] : [false]
+          // By default, leave non-ReCAP materials as not requestable
+          // Check for existence of aeonUrl for special collections:
+          item.specRequestable = !!item.aeonUrl
 
           if (Feature.enabled('on-site-edd', request)) {
             // In principle, we should tie requestability to the presence of *any*
@@ -162,6 +145,10 @@ class AvailabilityResolver {
             // on-site is EDD
             item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
           }
+        }
+        if (!item.requestable) {
+          item.requestable = []
+          item.requestable[0] = item.eddRequestable || item.physRequestable || item.specRequestable
         }
         return item
       })

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -9,14 +9,14 @@ const Feature = require('./feature')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 
 class AvailabilityResolver {
-  constructor(responseReceived) {
+  constructor (responseReceived) {
     this.elasticSearchResponse = responseReceived
     this.barcodes = this._parseBarCodesFromESResponse()
     this.restClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
   }
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
-  responseWithUpdatedAvailability(request) {
+  responseWithUpdatedAvailability (request) {
     return this._createSCSBBarcodeAvailbilityMapping(this.barcodes)
       .then((barcodesAndAvailability) => {
         this._fixItemAvailabilityInResponse(barcodesAndAvailability, request)
@@ -31,7 +31,7 @@ class AvailabilityResolver {
   /**
    *  Given an array of barcodes, returns a hash mapping barcode to SCSB availability
    */
-  _createSCSBBarcodeAvailbilityMapping(barcodes) {
+  _createSCSBBarcodeAvailbilityMapping (barcodes) {
     if (barcodes.length === 0) {
       logger.debug('no barcodes found')
       return Promise.resolve({})
@@ -46,7 +46,7 @@ class AvailabilityResolver {
       })
   }
 
-  _parseBarCodesFromESResponse() {
+  _parseBarCodesFromESResponse () {
     var barcodes = []
     for (let hit of this.elasticSearchResponse.hits.hits) {
       for (let item of (hit._source.items || [])) {
@@ -68,7 +68,7 @@ class AvailabilityResolver {
     return barcodes
   }
 
-  _fixItemAvailabilityInResponse(barcodesAndAvailability, request) {
+  _fixItemAvailabilityInResponse (barcodesAndAvailability, request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
         // If it's an electronic item, skip it
@@ -106,7 +106,6 @@ class AvailabilityResolver {
 
             // Otherwise it is in ReCAP:
           } else {
-
             // Make sure properties exist:
             if (!item.status || item.status.length === 0) item.status = [{}]
             if (!item.reqestable || item.requestable.length === 0) item.requestable = []

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -143,15 +143,12 @@ class AvailabilityResolver {
             // In principle, we should tie requestability to the presence of *any*
             // delivery option. For now, the only delivery option we trust for
             // on-site is EDD
-            item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
+            item.eddRequestable = DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)
           }
         }
-        // If requestable has not been already set during this serialization,
-        // set it based on separate requestable truthiness
-        if (!Feature.enabled('on-site-edd', request)) {
-          item.requestable = []
-          item.requestable[0] = item.eddRequestable || item.physRequestable || item.specRequestable
-        }
+        // Set generic requestable based on separate requestable truthiness
+        if (!item.requestable) item.requestable = []
+        item.requestable[0] = item.eddRequestable || item.physRequestable || item.specRequestable
         return item
       })
     }

--- a/swagger.v1.1.x.json
+++ b/swagger.v1.1.x.json
@@ -809,11 +809,8 @@
           }
         },
         "physRequestable": {
-          "type": "array",
-          "description": "Boolean indicating whether an item is available for a physical hold request",
-          "items":{
-            "type": "boolean"
-          }
+          "type": "boolean",
+          "description": "Indiates whether an item is available for a physical hold request"
         },
         "requestable": {
           "type": "array",
@@ -830,11 +827,8 @@
           }
         },
         "specRequestable": {
-          "type": "array",
-          "description": "Boolean indicating if an item is requestable through the Aeon interface",
-          "items":{
-            "type": "boolean"
-          }
+          "type": "boolean",
+          "description": "Indicates if an item is requestable through the Aeon interface"
         },
         "status": {
           "type": "array",

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -140,7 +140,7 @@ describe('Response with updated availability', function () {
       .then((modifiedResponse) => {
         // Find the modified item in the response:
         let theItem = modifiedResponse.hits.hits[0]._source.items.find((item) => item.uri === indexedButNotAvailableInSCSBURI)
-
+        console.log(theItem)
         // Our fakeRESTClient said its barcode doesn't exist, so it should appear with `requestable` false
         expect(theItem.requestable[0]).to.equal(false)
       })
@@ -191,7 +191,7 @@ describe('Response with updated availability', function () {
         var availableItem = items.find((item) => {
           return item.uri === 'i10283664'
         })
-        expect(availableItem.physRequestable[0]).to.equal(true)
+        expect(availableItem.physRequestable).to.equal(true)
       })
   })
 
@@ -326,7 +326,7 @@ describe('Response with updated availability', function () {
         .then((response) => {
           const items = response.hits.hits[0]._source.items
           const specRequestableItem = items.find((item) => item.uri === 'i22566485')
-          expect(specRequestableItem.specRequestable[0]).to.equal(true)
+          expect(specRequestableItem.specRequestable).to.equal(true)
         })
     })
     it('marks items as not specRequestable when there is no aeonURL present', function () {
@@ -334,7 +334,7 @@ describe('Response with updated availability', function () {
         .then((response) => {
           const items = response.hits.hits[0]._source.items
           const specRequestableItem = items.find((item) => item.uri === 'i10283665')
-          expect(specRequestableItem.specRequestable[0]).to.equal(false)
+          expect(specRequestableItem.specRequestable).to.equal(false)
         })
     })
   })

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -140,7 +140,6 @@ describe('Response with updated availability', function () {
       .then((modifiedResponse) => {
         // Find the modified item in the response:
         let theItem = modifiedResponse.hits.hits[0]._source.items.find((item) => item.uri === indexedButNotAvailableInSCSBURI)
-        console.log(theItem)
         // Our fakeRESTClient said its barcode doesn't exist, so it should appear with `requestable` false
         expect(theItem.requestable[0]).to.equal(false)
       })

--- a/test/fixtures/edd_elastic_search_response.js
+++ b/test/fixtures/edd_elastic_search_response.js
@@ -191,7 +191,7 @@ module.exports = () => {
                   }
                 ],
                 'status_packed': [
-                  'status:na||Not Available'
+                  'status:a||Available'
                 ],
                 'owner': [
                   {
@@ -219,8 +219,8 @@ module.exports = () => {
                 ],
                 'status': [
                   {
-                    'id': 'status:na',
-                    'label': 'Not available'
+                    'id': 'status:a',
+                    'label': 'Available'
                   }
                 ],
                 'owner_packed': [
@@ -283,6 +283,68 @@ module.exports = () => {
                   {
                     'id': 'status:a',
                     'label': 'Available'
+                  }
+                ],
+                'owner_packed': [
+                  'orgs:1000||Stephen A. Schwarzman Building'
+                ],
+                'requestable': [
+                  false
+                ],
+                'identifier': [
+                  'urn:barcode:1000020117'
+                ],
+                'holdingLocation_packed': [
+                  'loc:rc2ma||OFFSITE - Request in Advance'
+                ],
+                'shelfMark': [
+                  '*OFC 90-2649 2'
+                ],
+                'suppressed': [
+                  false
+                ]
+              },
+              // eddRequestable but unavailable (partner item)
+              {
+                'uri': 'i10283667',
+                'recapCustomerCode': ['HL'],
+                'holdingLocation': [
+                  {
+                    'label': 'OFFSITE - Request in Advance',
+                    'id': 'loc:rc2ma'
+                  }
+                ],
+                'status_packed': [
+                  'status:na||Not Available'
+                ],
+                'owner': [
+                  {
+                    'id': 'orgs:1000',
+                    'label': 'Stephen A. Schwarzman Building'
+                  }
+                ],
+                'deliveryLocation': [
+                  {
+                    'id': 'loc:mala',
+                    'label': 'SASB - Allen Scholar Room'
+                  }
+                ],
+                'deliveryLocation_packed': [
+                  'loc:mala||SASB - Allen Scholar Room'
+                ],
+                'accessMessage_packed': [
+                  'accessMessage:2||ADV REQUEST'
+                ],
+                'accessMessage': [
+                  {
+                    'id': 'accessMessage:2',
+                    'label': 'ADV REQUEST'
+                  }
+                ],
+                'status': [
+                  {
+                    'id': 'status:na',
+                    'label': 'Not Available'
                   }
                 ],
                 'owner_packed': [


### PR DESCRIPTION
First run in QA items were coming with requestable and physrequestable false, but with no eddrequestable field. I moved the check to mirror where the other request checks are happening, and i think I squashed le bug.