### PR TITLE
Add isbn_clean to isbn search

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -644,7 +644,16 @@ const queryForIdentifierNumber = function (params) {
   } else if (params.issn) {
     return { query: { bool: { must: { term: { idIssn: params.issn } } } } }
   } else if (params.isbn) {
-    return { query: { bool: { must: { term: { idIsbn: params.isbn } } } } }
+    return {
+      query: {
+        bool: {
+          should: [
+            { term: { idIsbn: params.isbn } },
+            { term: { idIsbn_clean: params.isbn } }
+          ]
+        }
+      }
+    }
   } else if (params.oclc) {
     // body.query.function_score.query.bool
     return { query: { bool: { must: { term: { idOclc: params.oclc } } } } }

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -214,7 +214,16 @@ describe('Resources query', function () {
     it('processes isbn correctly', () => {
       const params = resourcesPrivMethods.parseSearchParams({ isbn: '0689844921' })
       const body = resourcesPrivMethods.buildElasticBody(params)
-      expect(body).to.deep.equal({ query: { bool: { must: { term: { idIsbn: '0689844921' } } } } })
+      expect(body).to.deep.equal({
+        query: {
+          bool: {
+            should: [
+              { term: { idIsbn: '0689844921' } },
+              { term: { idIsbn_clean: '0689844921' } }
+            ]
+          }
+        }
+      })
     })
 
     it('processes issn correctly', () => {


### PR DESCRIPTION
- Adds `idIsbn_clean` as a search field when searching by isbn
- Changes tests to match new expectations.