### PR TITLE
Default to onsite edd

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,6 @@ Note that `page=` is not supported for aggregations (ES doesn't seem to offer a 
 
 > /resources/b15704876-i25375512
 
+### Features
+
+There is currently one feature flag in this app, which is 'no-on-site-edd'. When it is set, all onsite items have an eddRequestable property of false. 

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -155,7 +155,7 @@ class AvailabilityResolver {
           // Check for existence of aeonUrl for special collections:
           item.specRequestable = !!item.aeonUrl
 
-          if (Feature.enabled('on-site-edd', request)) {
+          if (!Feature.enabled('no-on-site-edd', request)) {
             // In principle, we should tie requestability to the presence of *any*
             // delivery option. For now, the only delivery option we trust for
             // on-site is EDD

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -240,11 +240,10 @@ describe('Response with updated availability', function () {
       })
   })
 
-  it('marks on-site (loc:scff2) Available items as requestable', function () {
+  it.only('marks on-site (loc:scff2) Available items as requestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 
-    process.env.FEATURES = 'on-site-edd'
     return availabilityResolver.responseWithUpdatedAvailability()
       .then((modifedResponse) => {
         return modifedResponse
@@ -257,11 +256,10 @@ describe('Response with updated availability', function () {
       })
   })
 
-  it('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
+  it.only('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 
-    process.env.FEATURES = 'on-site-edd'
     return availabilityResolver.responseWithUpdatedAvailability()
       .then((modifedResponse) => {
         return modifedResponse

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -240,7 +240,7 @@ describe('Response with updated availability', function () {
       })
   })
 
-  it.only('marks on-site (loc:scff2) Available items as requestable', function () {
+  it('marks on-site (loc:scff2) Available items as requestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 
@@ -272,11 +272,11 @@ describe('Response with updated availability', function () {
       })
   })
 
-  it('marks on-site (loc:scff2) Available items as not requestable if "on-site-edd" feature flag missing', function () {
+  it('marks on-site (loc:scff2) Available items as not requestable if "no-on-site-edd" feature flag is set', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 
-    process.env.FEATURES = ''
+    process.env.FEATURES = 'no-on-site-edd'
     return availabilityResolver.responseWithUpdatedAvailability()
       .then((modifedResponse) => {
         return modifedResponse

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -256,7 +256,7 @@ describe('Response with updated availability', function () {
       })
   })
 
-  it.only('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
+  it('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 


### PR DESCRIPTION
Defaults to checking onsite edd requestability. Flipped the prior logic, which checked for a on-site-edd flag and now checks for a no-on-site-edd feature flag. 