### PR TITLE
Scc 3077

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -650,7 +650,8 @@ const queryForIdentifierNumber = function (params) {
           should: [
             { term: { idIsbn: params.isbn } },
             { term: { idIsbn_clean: params.isbn } }
-          ]
+          ],
+          minimum_should_match: 1
         }
       }
     }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -109,7 +109,7 @@ const SEARCH_SCOPES = {
     fields: ['shelfMark', 'items.shelfMark']
   },
   standard_number: {
-    fields: ['shelfMark', 'identifierV2.value', 'uri', 'identifier', 'items.shelfMark', { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }]
+    fields: ['shelfMark', 'identifierV2.value', 'uri', 'identifier', 'items.shelfMark', { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }, 'idIsbn_clean']
   }
 }
 

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -220,7 +220,8 @@ describe('Resources query', function () {
             should: [
               { term: { idIsbn: '0689844921' } },
               { term: { idIsbn_clean: '0689844921' } }
-            ]
+            ],
+            minimum_should_match: 1
           }
         }
       })


### PR DESCRIPTION
- Adds `minimum_should_match: 1` to the isbn query
- Adds `idIsbn_clean` to the standard number search scope