### PR TITLE
Scc 3077

### DIFF
--- a/config/test.env
+++ b/config/test.env
@@ -1,5 +1,5 @@
 # Number of items returned for each bib by default:
-SEARCH_ITEMS_SIZE=100
+SEARCH_ITEMS_SIZE=200
 
 # This can be any port, but let's choose something reasonably high to
 # avoid conflict:

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -650,7 +650,8 @@ const queryForIdentifierNumber = function (params) {
           should: [
             { term: { idIsbn: params.isbn } },
             { term: { idIsbn_clean: params.isbn } }
-          ]
+          ],
+          minimum_should_match: 1
         }
       }
     }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -109,7 +109,7 @@ const SEARCH_SCOPES = {
     fields: ['shelfMark', 'items.shelfMark']
   },
   standard_number: {
-    fields: ['shelfMark', 'identifierV2.value', 'uri', 'identifier', 'items.shelfMark', { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }]
+    fields: ['shelfMark', 'identifierV2.value', 'uri', 'identifier', 'items.shelfMark', { field: 'items.idBarcode', on: (q) => /\d{6,}/.test(q) }, 'idIsbn_clean']
   }
 }
 

--- a/test/fixtures/query-05c57b738005af3b527fb5bc6a4c4161.json
+++ b/test/fixtures/query-05c57b738005af3b527fb5bc6a4c4161.json
@@ -1,0 +1,240 @@
+{
+  "took": 90,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 88.34372,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13627363",
+        "_score": 88.34372,
+        "_source": {
+          "extent": [
+            "128 p. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Creative age press, inc."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1947
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cats, cats, & cats,"
+          ],
+          "shelfMark": [
+            "VPS (Rice, E. Cats, cats, & cats)"
+          ],
+          "creatorLiteral": [
+            "Rice, Edward, 1917-"
+          ],
+          "createdString": [
+            "1947"
+          ],
+          "idLccn": [
+            "agr47000211"
+          ],
+          "contributorLiteral": [
+            "Gleason, Jean, 1917-"
+          ],
+          "dateStartYear": [
+            1947
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VPS (Rice, E. Cats, cats, & cats)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13627363"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "agr47000211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3600714"
+            }
+          ],
+          "updatedAt": 1636428476541,
+          "publicationStatement": [
+            "New York, Creative age press, inc. [c1947]"
+          ],
+          "identifier": [
+            "urn:bnum:13627363",
+            "urn:lccn:agr47000211",
+            "urn:undefined:(WaOLN)nyp3600714"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1947"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats -- Pictorial works.",
+            "Cats."
+          ],
+          "titleDisplay": [
+            "Cats, cats, & cats, by Edward Rice and Jean Gleason."
+          ],
+          "uri": "b13627363",
+          "lccClassification": [
+            "SF447 .R5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10754478",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VPS (Rice, E. Cats, cats, & cats)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006598316"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006598316"
+                    ],
+                    "idBarcode": [
+                      "33433006598316"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aVPS (Rice, E. Cats, cats, & cats)"
+                  },
+                  "sort": [
+                    "aVPS (Rice, E. Cats, cats, & cats)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-09419184ff287b4d77fb5a83670de435.json
+++ b/test/fixtures/query-09419184ff287b4d77fb5a83670de435.json
@@ -1,0 +1,11954 @@
+{
+  "took": 765,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 13422933,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "publisherLiteral": [
+            "Stauffenburg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "contributorLiteral": [
+            "Baum, Richard.",
+            "Gmelin, Hermann, 1900-1958.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    "aJFE 86-003252"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Constable,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    "aJFF 89-000526"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    "a*OLB 84-001934"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "publisherLiteral": [
+            "Muzyka,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22,"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    "aJMF 83-000336"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām,"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    "a*OGC 84-001984"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar",
+            "Guitar -- Studies and exercises",
+            "Guitar music"
+          ],
+          "publisherLiteral": [
+            "Editio Musica,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar -- Studies and exercises.",
+            "Guitar music."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    "aJMG 83-000276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    "a*OLB 84-001986"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    "aJMG 83-000278"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    "a*OLB 84-001938"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Easter music (Organ)",
+            "Passion music",
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Boeijenga,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Easter music (Organ)",
+            "Passion music.",
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    "aJMG 83-000279"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    "a*OFS 84-001997"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    "aJMF 83-000366"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century",
+            "Panislamism"
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century.",
+            "Panislamism."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    "a*OGC 84-001996"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    "a*OLB 84-001937"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    "aJMG 83-000395"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    "a*OFX 84-001995"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    "aJMG 83-000111"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLB 84-1936 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    "aJMG 83-000113"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "contributorLiteral": [
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952.",
+            "Peruntēvaṉār, active 11th century."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    "a*OLB 84-001935"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Shawnee Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    "aJMF 83-000038"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    "a*OFK 84-001944"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    "aJMF 83-000107"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    "a*OFX 84-001953"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    "aJMF 83-000095"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama),"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    "a*OKTM 84-001945"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    "aJMF 83-000093"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "contributorLiteral": [
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Pāṇini.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-",
+            "Āpiśali.",
+            "Śākatāyana."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    "a*OKA 84-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "W. Müller,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    "aJMG 83-000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    "a*OMP 84-002007"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ"
+          ],
+          "publisherLiteral": [
+            "Agápe,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ."
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "contributorLiteral": [
+            "Agrawala, Prithvi Kumar.",
+            "Agrawala, Vasudeva Sharana.",
+            "Guṇāḍhya."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    "a*OKR 84-002006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade,"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    "a*OKB 84-001928"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    "aJMG 83-000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    "a*OKP 84-001932"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas,"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    "aJMG 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    "a*OLB 84-001947"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "publisherLiteral": [
+            "Primavera,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    "aJMF 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    "a*OKN 84-001926"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    "aJMC 83-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884"
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Lamas -- Tibet -- Biography.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002361"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    "aJMG 82-000688"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries"
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Sa-skya-pa lamas -- Tibet -- Biography.",
+            "Tripiṭaka. -- Commentaries."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po.",
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002362"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    "aJMG 83-000079"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002382"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    "aJMG 83-000080"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism.",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002381"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "uniformTitle": [
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Den forsvundne.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    "aJMG 83-000075"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-157f38298ef720d20ff835717e63e834.json
+++ b/test/fixtures/query-157f38298ef720d20ff835717e63e834.json
@@ -1,0 +1,905 @@
+{
+  "took": 129,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 50.9789,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 50.9789,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-1d9c3be7903a160a5eda9246e174b4e4.json
+++ b/test/fixtures/query-1d9c3be7903a160a5eda9246e174b4e4.json
@@ -1,0 +1,11954 @@
+{
+  "took": 825,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 16477240,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "publisherLiteral": [
+            "Stauffenburg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "contributorLiteral": [
+            "Baum, Richard.",
+            "Gmelin, Hermann, 1900-1958.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    "aJFE 86-003252"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Constable,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    "aJFF 89-000526"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    "a*OLB 84-001934"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "publisherLiteral": [
+            "Muzyka,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22,"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    "aJMF 83-000336"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām,"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    "a*OGC 84-001984"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar",
+            "Guitar -- Studies and exercises",
+            "Guitar music"
+          ],
+          "publisherLiteral": [
+            "Editio Musica,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar -- Studies and exercises.",
+            "Guitar music."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    "aJMG 83-000276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    "a*OLB 84-001986"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    "aJMG 83-000278"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    "a*OLB 84-001938"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Easter music (Organ)",
+            "Passion music",
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Boeijenga,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Easter music (Organ)",
+            "Passion music.",
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    "aJMG 83-000279"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    "a*OFS 84-001997"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    "aJMF 83-000366"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century",
+            "Panislamism"
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century.",
+            "Panislamism."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    "a*OGC 84-001996"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    "a*OLB 84-001937"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    "aJMG 83-000395"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    "a*OFX 84-001995"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    "aJMG 83-000111"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLB 84-1936 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    "aJMG 83-000113"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "contributorLiteral": [
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952.",
+            "Peruntēvaṉār, active 11th century."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    "a*OLB 84-001935"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Shawnee Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    "aJMF 83-000038"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    "a*OFK 84-001944"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    "aJMF 83-000107"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    "a*OFX 84-001953"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    "aJMF 83-000095"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama),"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    "a*OKTM 84-001945"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    "aJMF 83-000093"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "contributorLiteral": [
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Pāṇini.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-",
+            "Āpiśali.",
+            "Śākatāyana."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    "a*OKA 84-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "W. Müller,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    "aJMG 83-000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    "a*OMP 84-002007"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ"
+          ],
+          "publisherLiteral": [
+            "Agápe,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ."
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "contributorLiteral": [
+            "Agrawala, Prithvi Kumar.",
+            "Agrawala, Vasudeva Sharana.",
+            "Guṇāḍhya."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    "a*OKR 84-002006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade,"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    "a*OKB 84-001928"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    "aJMG 83-000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    "a*OKP 84-001932"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas,"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    "aJMG 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    "a*OLB 84-001947"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "publisherLiteral": [
+            "Primavera,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    "aJMF 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    "a*OKN 84-001926"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    "aJMC 83-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884"
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Lamas -- Tibet -- Biography.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002361"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    "aJMG 82-000688"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries"
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Sa-skya-pa lamas -- Tibet -- Biography.",
+            "Tripiṭaka. -- Commentaries."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po.",
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002362"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    "aJMG 83-000079"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002382"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    "aJMG 83-000080"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism.",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002381"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "uniformTitle": [
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Den forsvundne.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    "aJMG 83-000075"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-24ad421fdaa24acb20a3d1f90ddff095.json
+++ b/test/fixtures/query-24ad421fdaa24acb20a3d1f90ddff095.json
@@ -1,0 +1,11903 @@
+{
+  "took": 324,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 2152211,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000061",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score (10 p.) + 1 ms. part (3 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holographs (?) signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For violin and piano; part incomplete.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title varies: Hungarian song and dance.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "On t.p.: Given to H H Huss by Maud Powell.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Huss, Henry Holden, 1862-1953",
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts",
+            "Violin and piano music",
+            "Violin and piano music -- Scores and parts"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1888
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hungarian melody and dance"
+          ],
+          "shelfMark": [
+            "JPB 83-155 no. 189"
+          ],
+          "creatorLiteral": [
+            "Matus."
+          ],
+          "createdString": [
+            "1888"
+          ],
+          "contributorLiteral": [
+            "American Music Collection.",
+            "Huss, Henry Holden, 1862-1953.",
+            "Powell, Maud, 1867-1920."
+          ],
+          "dateStartYear": [
+            1888
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-155 no. 189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000061"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100579"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200060"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "1888."
+          ],
+          "identifier": [
+            "urn:bnum:10000061",
+            "urn:undefined:NNSZ00100579",
+            "urn:undefined:(WaOLN)nyp0200060"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1888"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts.",
+            "Violin and piano music -- Scores and parts."
+          ],
+          "titleDisplay": [
+            "Hungarian melody and dance / Matus ; arranged by H.H.H. Mazurka caprice / Henry Holden Huss."
+          ],
+          "uri": "b10000061",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Hungarian song and dance.",
+            "Mazurka caprice."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000061"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746396",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:8",
+                        "label": "manuscript music"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:8||manuscript music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-155 no. 189"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-155 no. 189",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116929518"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-155 no. 189"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116929518"
+                    ],
+                    "idBarcode": [
+                      "33433116929518"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-155 no. 000189"
+                  },
+                  "sort": [
+                    "aJPB 83-155 no. 000189"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000063",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score (2 leaves) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ms. (in ink) in the hand of Henry Holden Huss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For one or more voices and piano.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Choruses, Secular (Mixed voices, 2 parts) with piano",
+            "Huss, Henry Holden, 1862-1953",
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts",
+            "Songs (Medium voice) with piano"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1953"
+          ],
+          "createdYear": [
+            1862
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "For it's free : our native land"
+          ],
+          "shelfMark": [
+            "JPB 83-155 no. 190  "
+          ],
+          "creatorLiteral": [
+            "Proctor, David."
+          ],
+          "createdString": [
+            "1862"
+          ],
+          "contributorLiteral": [
+            "American Music Collection.",
+            "Huss, Henry Holden, 1862-1953."
+          ],
+          "dateStartYear": [
+            1862
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-155 no. 190  "
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000063"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100580"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200062"
+            }
+          ],
+          "dateEndYear": [
+            1953
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "[19--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000063",
+            "urn:undefined:NNSZ00100580",
+            "urn:undefined:(WaOLN)nyp0200062"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1862"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Choruses, Secular (Mixed voices, 2 parts) with piano.",
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "For it's free : our native land / music by David Proctor ; author anon."
+          ],
+          "uri": "b10000063",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000063"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746397",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:8",
+                        "label": "manuscript music"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:8||manuscript music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-155 no. 190"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-155 no. 190",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116929526"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-155 no. 190"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116929526"
+                    ],
+                    "idBarcode": [
+                      "33433116929526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-155 no. 000190"
+                  },
+                  "sort": [
+                    "aJPB 83-155 no. 000190"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000071",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gilbert, Henry F. B. 1868-1928",
+            "Gilbert, Henry F. B. 1868-1928 -- Manuscripts",
+            "Riley, James Whitcomb, 1849-1916",
+            "Riley, James Whitcomb, 1849-1916 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1928"
+          ],
+          "createdYear": [
+            1868
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The treasure of the wise man"
+          ],
+          "shelfMark": [
+            "JPB 83-480"
+          ],
+          "creatorLiteral": [
+            "Gilbert, Henry F. B. (Henry Franklin Belknap), 1868-1928."
+          ],
+          "createdString": [
+            "1868"
+          ],
+          "contributorLiteral": [
+            "American Music Collection.",
+            "Riley, James Whitcomb, 1849-1916."
+          ],
+          "dateStartYear": [
+            1868
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-480"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000071"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100584"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200070"
+            }
+          ],
+          "dateEndYear": [
+            1928
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "[19--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000071",
+            "urn:undefined:NNSZ00100584",
+            "urn:undefined:(WaOLN)nyp0200070"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1868"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gilbert, Henry F. B. 1868-1928 -- Manuscripts.",
+            "Riley, James Whitcomb, 1849-1916 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "The treasure of the wise man / [words by] James Whitcomb Riley ; [music by] Henry F. Gilbert."
+          ],
+          "uri": "b10000071",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000071"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746401",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-480"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-480",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-480"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000480"
+                  },
+                  "sort": [
+                    "aJPB 83-000480"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000077",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: Komponirt im September 1892 ; revidirt & ballindet [?] im Mai 1894.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Published in: Sechs Lieder für tiefe Stimme mit Pianofortebegleitung, op. 2, no. 1. Leipzig, New York : Breitkopf & Härtel, c1900.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Paper extremely brittle and badly torn.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Goldmark, Rubin, 1872-1936",
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts",
+            "Songs (Low voice) with piano"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1894
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Blaublümlein : rheinisches Volkslied"
+          ],
+          "shelfMark": [
+            "JPB 83-483"
+          ],
+          "creatorLiteral": [
+            "Goldmark, Rubin, 1872-1936."
+          ],
+          "createdString": [
+            "1894"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1894
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-483"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000077"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100587"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200076"
+            }
+          ],
+          "uniformTitle": [
+            "Lieder, op. 2. Blaublümlein"
+          ],
+          "updatedAt": 1643425445362,
+          "publicationStatement": [
+            "1894 May."
+          ],
+          "identifier": [
+            "urn:bnum:10000077",
+            "urn:undefined:NNSZ00100587",
+            "urn:undefined:(WaOLN)nyp0200076"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1894"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts.",
+            "Songs (Low voice) with piano."
+          ],
+          "titleDisplay": [
+            "Blaublümlein : rheinisches Volkslied / Rubin Goldmark."
+          ],
+          "uri": "b10000077",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Lieder, op. 2. Blaublümlein"
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000077"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746404",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-483"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-483",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-483"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000483"
+                  },
+                  "sort": [
+                    "aJPB 83-000483"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000079",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Goldmark, Rubin, 1872-1936",
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts",
+            "Songs (Medium voice) with piano"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1936"
+          ],
+          "createdYear": [
+            1872
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The forest has its birds of song"
+          ],
+          "shelfMark": [
+            "JPB 83-484"
+          ],
+          "creatorLiteral": [
+            "Goldmark, Rubin, 1872-1936."
+          ],
+          "createdString": [
+            "1872"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1872
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-484"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000079"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100588"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200078"
+            }
+          ],
+          "dateEndYear": [
+            1936
+          ],
+          "updatedAt": 1643425447071,
+          "publicationStatement": [
+            "[18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000079",
+            "urn:undefined:NNSZ00100588",
+            "urn:undefined:(WaOLN)nyp0200078"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1872"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "The forest has its birds of song / [Rubin Goldmark]."
+          ],
+          "uri": "b10000079",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000079"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746405",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-484"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-484",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-484"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000484"
+                  },
+                  "sort": [
+                    "aJPB 83-000484"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000084",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([2] leaves) ; 1 ms. part ([1] leaf) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Published in: A group of songs, op. 1-2. Boston: Boston Music Co., c1896.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Accompanied by text (holograph, 2 leaves, 26 cm.) dated June 27th, 1889.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gow, George Coleman, 1860-1938",
+            "Gow, George Coleman, 1860-1938 -- Manuscripts",
+            "Songs (Medium voice) with instrumental ensemble",
+            "Songs (Medium voice) with instrumental ensemble -- Scores and parts"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1890
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Slumber song : violin, voice, and pianoforte"
+          ],
+          "shelfMark": [
+            "JPB 83-488"
+          ],
+          "creatorLiteral": [
+            "Gow, George Coleman, 1860-1938."
+          ],
+          "createdString": [
+            "1890"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1890
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200083"
+            }
+          ],
+          "updatedAt": 1643425445362,
+          "publicationStatement": [
+            "1890 Mar. 10."
+          ],
+          "identifier": [
+            "urn:bnum:10000084",
+            "urn:undefined:NNSZ00100591",
+            "urn:undefined:(WaOLN)nyp0200083"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1890"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gow, George Coleman, 1860-1938 -- Manuscripts.",
+            "Songs (Medium voice) with instrumental ensemble -- Scores and parts."
+          ],
+          "titleDisplay": [
+            "Slumber song : violin, voice, and pianoforte / by G. C. Gow."
+          ],
+          "uri": "b10000084",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm. + 27 cm."
+          ]
+        },
+        "sort": [
+          "b10000084"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746408",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-488",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-488"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000488"
+                  },
+                  "sort": [
+                    "aJPB 83-000488"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000284",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20, 429 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1826 ed., published by Dar al-Inṭibāʻ-i Dār al-Salṭanah, Tabrīz.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Foreign relations",
+            "Iran -- Foreign relations -- Russia",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Russia",
+            "Russia -- Foreign relations",
+            "Russia -- Foreign relations -- Iran"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Ibn Sīnā,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1826"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maʼā̲sir-i sulṭānīyah, tārīkh-i janǵhā-yi Īrān va Rūs."
+          ],
+          "shelfMark": [
+            "*OMZ 82-4274"
+          ],
+          "creatorLiteral": [
+            "Maftūn Dunbulī, ʻAbd al-Razzāq, 1762 or 3-1827 or 8."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "74216823"
+          ],
+          "contributorLiteral": [
+            "Ṣadrī Afshār, Ghulām Ḥusayn."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 82-4274"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000284"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74216823"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100237"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200283"
+            }
+          ],
+          "dateEndYear": [
+            1826
+          ],
+          "updatedAt": 1636115466510,
+          "publicationStatement": [
+            "[Tihrān] Intishārāt-i Ibn Sīnā, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000284",
+            "urn:lccn:74216823",
+            "urn:undefined:NNSZ00100237",
+            "urn:undefined:(WaOLN)nyp0200283"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Foreign relations -- Russia.",
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Russia -- Foreign relations -- Iran."
+          ],
+          "titleDisplay": [
+            "Maʼā̲sir-i sulṭānīyah, tārīkh-i janǵhā-yi Īrān va Rūs. A̲sar-i ʻAbd al-Razzāq Maftūn Dunbulī. Bā muqaddamah va fihristhā bi-ihtimām-i Ghulām Ḥusayn Ṣadrī Afshār."
+          ],
+          "uri": "b10000284",
+          "lccClassification": [
+            "DS302 .M33 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000284"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942064",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 82-4274"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 82-4274",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539161"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 82-4274"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539161"
+                    ],
+                    "idBarcode": [
+                      "33433014539161"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 82-004274"
+                  },
+                  "sort": [
+                    "a*OMZ 82-004274"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000348",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[28], 573 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [7-10] (1st group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Description and travel"
+          ],
+          "publisherLiteral": [
+            "Mīrzā Ḥabīb Allāh"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1880"
+          ],
+          "createdYear": [
+            1879
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish"
+          ],
+          "shelfMark": [
+            "*ONA+ 82-2677"
+          ],
+          "creatorLiteral": [
+            "Muʻtamid al-Sulṭān, Muḥammad Taqī khān Ḥakīm, mutakhalliṣ bih Ḥakīm."
+          ],
+          "createdString": [
+            "1879"
+          ],
+          "dateStartYear": [
+            1879
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONA+ 82-2677"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200347"
+            }
+          ],
+          "dateEndYear": [
+            1880
+          ],
+          "updatedAt": 1650981383311,
+          "publicationStatement": [
+            "Ṭihrān : Mīrzā Ḥabīb Allāh, 1305 [1879 or 1880]"
+          ],
+          "identifier": [
+            "urn:bnum:10000348",
+            "urn:undefined:NNSZ00100301",
+            "urn:undefined:(WaOLN)nyp0200347"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1879"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish / az taʼlīfāt-i Muʻtamid al-Sulṭān Muḥammad Taqī Khān mutikhalliṣ bih Ḥakīm ; bi-saʻī va ihtimām-i Mullā Maḥmūd va Mullā Rizā Kitābfurūsh."
+          ],
+          "uri": "b10000348",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṭihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Ganj-i dānish."
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000348"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONA+ 82-2677  ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059840763"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059840763"
+                    ],
+                    "idBarcode": [
+                      "33433059840763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ONA+ 82-2677 "
+                  },
+                  "sort": [
+                    "a*ONA+ 82-2677 "
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000546",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Trük. K. Mattiesen,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Üks öö tissa jöe peal [microform]."
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 9"
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000546"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100503"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200545"
+            }
+          ],
+          "updatedAt": 1636145121521,
+          "publicationStatement": [
+            "Tartus : Trük. K. Mattiesen, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000546",
+            "urn:undefined:NNSZ00100503",
+            "urn:undefined:(WaOLN)nyp0200545"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Üks öö tissa jöe peal [microform]."
+          ],
+          "uri": "b10000546",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000546"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "a*Z-3414 no. 000001-16"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000547",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "31 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Trük. L. Weyde,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1874
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kirjakandja tuike [microform] : üks rutuline rööwlide käest päästaw sönum."
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 6"
+          ],
+          "createdString": [
+            "1874"
+          ],
+          "dateStartYear": [
+            1874
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000547"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100504"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200546"
+            }
+          ],
+          "updatedAt": 1636109470901,
+          "publicationStatement": [
+            "Riigas : Trük. L. Weyde, 1874."
+          ],
+          "identifier": [
+            "urn:bnum:10000547",
+            "urn:undefined:NNSZ00100504",
+            "urn:undefined:(WaOLN)nyp0200546"
+          ],
+          "genreForm": [
+            "Estonian fiction."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1874"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kirjakandja tuike [microform] : üks rutuline rööwlide käest päästaw sönum."
+          ],
+          "uri": "b10000547",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riigas :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000547"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "a*Z-3414 no. 000001-16"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000548",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "89 p. : ill., port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tennis",
+            "Tennis -- Rules",
+            "United States Lawn Tennis Association"
+          ],
+          "publisherLiteral": [
+            "Wright & Ditson,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1889
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Official lawn tennis rules [microform] : as adopted by the United States National Lawn Tennis Association, containing also the constitution and by-laws, list of officers and clubs in the association, cases and decisions, rules for umpires, and the Bagnal wild system of drawing, by James Dwight ..."
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 4"
+          ],
+          "createdString": [
+            "1889"
+          ],
+          "contributorLiteral": [
+            "United States Lawn Tennis Association."
+          ],
+          "dateStartYear": [
+            1889
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000548"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100505"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200547"
+            }
+          ],
+          "updatedAt": 1636119590968,
+          "publicationStatement": [
+            "Boston, Mass. : Wright & Ditson, 1889."
+          ],
+          "identifier": [
+            "urn:bnum:10000548",
+            "urn:undefined:NNSZ00100505",
+            "urn:undefined:(WaOLN)nyp0200547"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1889"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tennis -- Rules.",
+            "United States Lawn Tennis Association."
+          ],
+          "titleDisplay": [
+            "Official lawn tennis rules [microform] : as adopted by the United States National Lawn Tennis Association, containing also the constitution and by-laws, list of officers and clubs in the association, cases and decisions, rules for umpires, and the Bagnal wild system of drawing, by James Dwight ..."
+          ],
+          "uri": "b10000548",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Boston, Mass. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000548"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "a*Z-3414 no. 000001-16"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000574",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xii, 56 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "J. Maisonneuve,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Les hymnes rohitas [microform] Livre XIII de l'Atharva-Véda,"
+          ],
+          "shelfMark": [
+            "*ZO-180 no. 10"
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "contributorLiteral": [
+            "Henry, Victor, 1850-1907."
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-180 no. 10"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200573"
+            }
+          ],
+          "uniformTitle": [
+            "Vedas. Atharvaveda. French. Selections."
+          ],
+          "updatedAt": 1636112835928,
+          "publicationStatement": [
+            "Paris, J. Maisonneuve, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000574",
+            "urn:undefined:NNSZ00100531",
+            "urn:undefined:(WaOLN)nyp0200573"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Les hymnes rohitas [microform] Livre XIII de l'Atharva-Véda, traduit et commenté par Victor Henry."
+          ],
+          "uri": "b10000574",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10000574"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-180 11 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-180 11 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673077"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-180"
+                    ],
+                    "enumerationChronology": [
+                      "11 misc oriental titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673077"
+                    ],
+                    "idBarcode": [
+                      "33433105673077"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-180 11 misc oriental titles"
+                  },
+                  "sort": [
+                    "a*ZO-180 11 misc oriental titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000575",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Pianists",
+            "Pianists -- England",
+            "Pianists -- England -- Biography",
+            "Sloman, Jane, 1824-"
+          ],
+          "publisherLiteral": [
+            "Dutton and Wentworth,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1841
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A Biographical sketch of Jane Sloman, the celebrated pianiste [microform]."
+          ],
+          "shelfMark": [
+            "*ZB-1040"
+          ],
+          "createdString": [
+            "1841"
+          ],
+          "dateStartYear": [
+            1841
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZB-1040"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000575"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100532"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200574"
+            }
+          ],
+          "updatedAt": 1636068781403,
+          "publicationStatement": [
+            "Boston : Dutton and Wentworth, 1841."
+          ],
+          "identifier": [
+            "urn:bnum:10000575",
+            "urn:undefined:NNSZ00100532",
+            "urn:undefined:(WaOLN)nyp0200574"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1841"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Pianists -- England -- Biography.",
+            "Sloman, Jane, 1824-"
+          ],
+          "titleDisplay": [
+            "A Biographical sketch of Jane Sloman, the celebrated pianiste [microform]."
+          ],
+          "uri": "b10000575",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Boston :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          "b10000575"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17446753",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "*ZB-1040"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZB-1040",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZB-1040"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZB-001040"
+                  },
+                  "sort": [
+                    "a*ZB-001040"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000576",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxviii, 469 p. illus., maps (part fold.)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published under title: A history of Egypt under the Pharaohs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- History",
+            "Egypt -- History -- To 332 B.C"
+          ],
+          "publisherLiteral": [
+            "J. Murray,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Egypt under the Pharaohs [microform] a history derived entirely from the monuments."
+          ],
+          "shelfMark": [
+            "*ZO-185 no. 5"
+          ],
+          "creatorLiteral": [
+            "Brugsch, Heinrich, 1827-1894."
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "idLccn": [
+            "49042562"
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-185 no. 5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000576"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "49042562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100533"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200575"
+            }
+          ],
+          "updatedAt": 1636092634707,
+          "publicationStatement": [
+            "London, J. Murray, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000576",
+            "urn:lccn:49042562",
+            "urn:undefined:NNSZ00100533",
+            "urn:undefined:(WaOLN)nyp0200575"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- History -- To 332 B.C."
+          ],
+          "titleDisplay": [
+            "Egypt under the Pharaohs [microform] a history derived entirely from the monuments."
+          ],
+          "uri": "b10000576",
+          "lccClassification": [
+            "DT83 .89 1891"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000576"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-185 5 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-185 5 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673168"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-185"
+                    ],
+                    "enumerationChronology": [
+                      "5 misc oriental titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673168"
+                    ],
+                    "idBarcode": [
+                      "33433105673168"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-185 5 misc oriental titles"
+                  },
+                  "sort": [
+                    "a*ZO-185 5 misc oriental titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000577",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "137 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Chinese language",
+            "Chinese language -- Writing"
+          ],
+          "publisherLiteral": [
+            "C. B. Norton,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1854
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Discoveries in Chinese, or, The symbolism of the primitive characters of the Chinese system of writing [microform] As a contribution to philology and ethnology and a practical aid in the acquisition of the Chinese language,"
+          ],
+          "shelfMark": [
+            "*ZO-185 no. 1"
+          ],
+          "creatorLiteral": [
+            "Andrews, Stephen Pearl, 1812-1886."
+          ],
+          "createdString": [
+            "1854"
+          ],
+          "idLccn": [
+            "12008608"
+          ],
+          "dateStartYear": [
+            1854
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-185 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "12008608"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100534"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200576"
+            }
+          ],
+          "updatedAt": 1636089811738,
+          "publicationStatement": [
+            "New York, C. B. Norton, 1854."
+          ],
+          "identifier": [
+            "urn:bnum:10000577",
+            "urn:lccn:12008608",
+            "urn:undefined:NNSZ00100534",
+            "urn:undefined:(WaOLN)nyp0200576"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1854"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Chinese language -- Writing."
+          ],
+          "titleDisplay": [
+            "Discoveries in Chinese, or, The symbolism of the primitive characters of the Chinese system of writing [microform] As a contribution to philology and ethnology and a practical aid in the acquisition of the Chinese language, by Stephen Pearl Andrews."
+          ],
+          "uri": "b10000577",
+          "lccClassification": [
+            "PL1171 .A6"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Discoveries in Chinese",
+            "Symbolism of the primitive characters of the Chinese system of writing"
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000577"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-185 5 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-185 5 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673168"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-185"
+                    ],
+                    "enumerationChronology": [
+                      "5 misc oriental titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673168"
+                    ],
+                    "idBarcode": [
+                      "33433105673168"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-185 5 misc oriental titles"
+                  },
+                  "sort": [
+                    "a*ZO-185 5 misc oriental titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000578",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "vi, 285 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Agriculture",
+            "Agriculture -- Terminology",
+            "Hindustani language",
+            "Hindustani language -- Glossaries, vocabularies, etc"
+          ],
+          "publisherLiteral": [
+            "Supt. of Govt. Printing,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1888
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A rural and agricultural glossary for the N.-W. provinces and Oudh [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-187 no. 6"
+          ],
+          "creatorLiteral": [
+            "Crooke, William, 1848-1923."
+          ],
+          "createdString": [
+            "1888"
+          ],
+          "dateStartYear": [
+            1888
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-187 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000578"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100535"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200577"
+            }
+          ],
+          "updatedAt": 1636069811077,
+          "publicationStatement": [
+            "Calcutta, Supt. of Govt. Printing, 1888."
+          ],
+          "identifier": [
+            "urn:bnum:10000578",
+            "urn:undefined:NNSZ00100535",
+            "urn:undefined:(WaOLN)nyp0200577"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1888"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Agriculture -- Terminology.",
+            "Hindustani language -- Glossaries, vocabularies, etc."
+          ],
+          "titleDisplay": [
+            "A rural and agricultural glossary for the N.-W. provinces and Oudh [microform] [By] William Crooke."
+          ],
+          "uri": "b10000578",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Calcutta,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4̕."
+          ]
+        },
+        "sort": [
+          "b10000578"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081049",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-187 9 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-187 9 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673309"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-187"
+                    ],
+                    "enumerationChronology": [
+                      "9 misc oriental titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673309"
+                    ],
+                    "idBarcode": [
+                      "33433105673309"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-187 9 misc oriental titles"
+                  },
+                  "sort": [
+                    "a*ZO-187 9 misc oriental titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000985",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22, 460 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1884 ed. published in Lahore.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lahore (Pakistan)",
+            "Lahore (Pakistan) -- History"
+          ],
+          "publisherLiteral": [
+            "Majlis-i Taraqqī-i Adab,"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "dateEndString": [
+            "1884"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tārīkh-i Lāhaur"
+          ],
+          "shelfMark": [
+            "*OKTY 82-4463"
+          ],
+          "creatorLiteral": [
+            "KanhaiyyĀ Lāl Hindī, 1830-1888."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "contributorLiteral": [
+            "Fāiq, Kalb ʻAlī Khān."
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTY 82-4463"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000985"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200995"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200984"
+            }
+          ],
+          "dateEndYear": [
+            1884
+          ],
+          "updatedAt": 1636140614194,
+          "publicationStatement": [
+            "Lāhau : Majlis-i Taraqqī-i Adab, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000985",
+            "urn:undefined:NNSZ00200995",
+            "urn:undefined:(WaOLN)nyp0200984"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lahore (Pakistan) -- History."
+          ],
+          "titleDisplay": [
+            "Tārīkh-i Lāhaur / muṣannifah-yi Kanhaiyyā Lāl Hindī ;murattabah-yi Kalb ʻalī Khān Fāʼiq."
+          ],
+          "uri": "b10000985",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāhau :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000985"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000619",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTY 82-4463"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTY 82-4463",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011242603"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTY 82-4463"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011242603"
+                    ],
+                    "idBarcode": [
+                      "33433011242603"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKTY 82-004463"
+                  },
+                  "sort": [
+                    "a*OKTY 82-004463"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001056",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "67 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.l.,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buḥūr al-ḥikmah [microform]."
+          ],
+          "shelfMark": [
+            "*ZO-243 no. 1"
+          ],
+          "creatorLiteral": [
+            "Baháʼuʼlláh, 1817-1892."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-243 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001056"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201067"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201055"
+            }
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1636079365906,
+          "publicationStatement": [
+            "[New Delhi? : s.l., 19-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001056",
+            "urn:undefined:NNSZ00201067",
+            "urn:undefined:(WaOLN)nyp0201055"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Buḥūr al-ḥikmah [microform]."
+          ],
+          "uri": "b10001056",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[New Delhi? :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "14 cm."
+          ]
+        },
+        "sort": [
+          "b10001056"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081267",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-243 11 Arabic titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-243 11 Arabic titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673531"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-243"
+                    ],
+                    "enumerationChronology": [
+                      "11 Arabic titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673531"
+                    ],
+                    "idBarcode": [
+                      "33433105673531"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-243 11 Arabic titles"
+                  },
+                  "sort": [
+                    "a*ZO-243 11 Arabic titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "577 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"The first printed book in Malayalam\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Facsimile reproduction of old Malayalam and transcription, paraphrase, and notes in modern Malayalam, on opposite pages.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Original t.p. reads: Nasṟāṇikaḷ okkakkuṃ aṟiyeṇṭunna saṅkṣepavedārtthaṃ=Compendiosa legis explanatio omnibus Christianis scitu necessaria. Malabarico idiomate. Romāyilninn Miśihā pirṟannīṭṭ 1772 śṟȧṣṭa melpaṭṭakkāraruṭe anuvādattāl=Romae An. A nativit. Christi 1772, praisidum facultate\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Catholic Church. Syro-Malabar rite",
+            "Christianity",
+            "Christianity -- Philosophy"
+          ],
+          "publisherLiteral": [
+            "Ḍi. Ṣi. Buks ; Kārmel Pabḷiṣiṅg Senṟar,"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "dateEndString": [
+            "1772"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp"
+          ],
+          "shelfMark": [
+            "*OLD 84-299"
+          ],
+          "creatorLiteral": [
+            "Piyāniyas, Kḷemanṟ, 1731-1782."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82904075"
+          ],
+          "contributorLiteral": [
+            "Choondal, Chummar, 1940-",
+            "Mathew, Ulakamthara."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-299"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82904075"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201079"
+            }
+          ],
+          "dateEndYear": [
+            1772
+          ],
+          "updatedAt": 1636128328325,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Ḍi. Ṣi. Buks ; Tiruvanantapuraṃ : Kārmel Pabḷiṣiṅg Senṟar, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10001080",
+            "urn:lccn:82904075",
+            "urn:undefined:NNSZ00201091",
+            "urn:undefined:(WaOLN)nyp0201079"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Catholic Church. Syro-Malabar rite.",
+            "Christianity -- Philosophy."
+          ],
+          "titleDisplay": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp / Kḷemanṟ Piyāniyas = Samkshepa vedartham / by Clement Pianius ; introduction by Chummar Choondel ; commentary by Mathew Ulakamthara."
+          ],
+          "uri": "b10001080",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ : Tiruvanantapuraṃ :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001080"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000682",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-299"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-299",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011099029"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-299"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011099029"
+                    ],
+                    "idBarcode": [
+                      "33433011099029"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000299"
+                  },
+                  "sort": [
+                    "a*OLD 84-000299"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001550",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. (no paging) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Shīʻah",
+            "Shīʻah -- Doctrines"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Ḥajī ʻAbd al-Ḥamīd,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1851"
+          ],
+          "createdYear": [
+            1850
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "[Zubdat al-maʻārif"
+          ],
+          "shelfMark": [
+            "*OGI+ 82-3286"
+          ],
+          "creatorLiteral": [
+            "Iṣfahānī, Mullā ʻAlī Akbar."
+          ],
+          "createdString": [
+            "1850"
+          ],
+          "dateStartYear": [
+            1850
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI+ 82-3286"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001550"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201585"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201548"
+            }
+          ],
+          "dateEndYear": [
+            1851
+          ],
+          "updatedAt": 1636145031562,
+          "publicationStatement": [
+            "[Tihrān?] : Chāpkhānah-ʼi Ḥajī ʻAbd al-Ḥamīd, 1267 [1850 or 1851]"
+          ],
+          "identifier": [
+            "urn:bnum:10001550",
+            "urn:undefined:NNSZ00201585",
+            "urn:undefined:(WaOLN)nyp0201548"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1850"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Shīʻah -- Doctrines."
+          ],
+          "titleDisplay": [
+            "[Zubdat al-maʻārif / Ākhund Mullā ʻAlī Akbar Iṣfahānī]."
+          ],
+          "uri": "b10001550",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān?] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10001550"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058659826"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058659826"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058659826"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OGI+ 82-3286"
+                    ],
+                    "shelfMark_sort": "a*OGI+ 82-003286"
+                  },
+                  "sort": [
+                    "a*OGI+ 82-003286"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001735",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Handbooks, vade-mecums, etc",
+            "Middle East",
+            "Middle East -- Biography"
+          ],
+          "publisherLiteral": [
+            "s.n,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1873
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuzhat al-jalīs wa-munyat al-adīb al-anīs [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-158 no. 9"
+          ],
+          "creatorLiteral": [
+            "Mūsawī, al-ʻAbbās ibn ʻAlī, active 1735."
+          ],
+          "createdString": [
+            "1873"
+          ],
+          "dateStartYear": [
+            1873
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-158 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001735"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201770"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201733"
+            }
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "[al-Qāhirah : s.n, 1873?]"
+          ],
+          "identifier": [
+            "urn:bnum:10001735",
+            "urn:undefined:NNSZ00201770",
+            "urn:undefined:(WaOLN)nyp0201733"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1873"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Handbooks, vade-mecums, etc.",
+            "Middle East -- Biography."
+          ],
+          "titleDisplay": [
+            "Nuzhat al-jalīs wa-munyat al-adīb al-anīs [microform] / taʼlīf al-ʻAbbās ibn ʻAlī ibn Nūr al-Dīn al-Makkī al-Ḥusaynī al-Mūsawī."
+          ],
+          "uri": "b10001735",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10001735"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30154976",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-158 no. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-158 no. 1-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433098135548"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-158"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433098135548"
+                    ],
+                    "idBarcode": [
+                      "33433098135548"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-158 no. 000001-10"
+                  },
+                  "sort": [
+                    "a*ZO-158 no. 000001-10"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001741",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʻIyāḍ ibn Mūsá, 1083-1149"
+          ],
+          "publisherLiteral": [
+            "Matbaa-yi Osmaniye,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1897"
+          ],
+          "createdYear": [
+            1894
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nasīm al-riyāḍ fī sharḥ Shifāʼ al-Qāḍī ʻIyāḍ [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-162"
+          ],
+          "creatorLiteral": [
+            "Khafājī, Aḥmad ibn Muḥammad, -1659."
+          ],
+          "createdString": [
+            "1894"
+          ],
+          "contributorLiteral": [
+            "Schiff Collection."
+          ],
+          "dateStartYear": [
+            1894
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-162"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001741"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201776"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201739"
+            }
+          ],
+          "dateEndYear": [
+            1897
+          ],
+          "updatedAt": 1641230723038,
+          "publicationStatement": [
+            "Der-i Saadet : Matbaa-yi Osmaniye, 1312-17 [1894-97]"
+          ],
+          "identifier": [
+            "urn:bnum:10001741",
+            "urn:undefined:NNSZ00201776",
+            "urn:undefined:(WaOLN)nyp0201739"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1894"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʻIyāḍ ibn Mūsá, 1083-1149."
+          ],
+          "titleDisplay": [
+            "Nasīm al-riyāḍ fī sharḥ Shifāʼ al-Qāḍī ʻIyāḍ [microform] / li-Aḥmad Shihāb al-Dīn al-Khafājī al-Miṣrī."
+          ],
+          "uri": "b10001741",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Der-i Saadet :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4̕."
+          ]
+        },
+        "sort": [
+          "b10001741"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30079670",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-162 1894-1897"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-162 1894-1897",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105672749"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-162"
+                    ],
+                    "enumerationChronology": [
+                      "1894-1897"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105672749"
+                    ],
+                    "idBarcode": [
+                      "33433105672749"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-162 1894-001897"
+                  },
+                  "sort": [
+                    "a*ZO-162 1894-001897"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001747",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 148 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "On margin: Aṭbāq al-dhahab / ʻAbd al-Muʼmin al-Maghribī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Middle East",
+            "Middle East -- Biography"
+          ],
+          "publisherLiteral": [
+            "al-Maṭbaʻah al-ʻĀmirah al-Sharafīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1890
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tuḥfat ahl al-fukāhah [microform] : fī al-munādamah wa-al-nazāhah"
+          ],
+          "shelfMark": [
+            "*ZO-158 no. 10"
+          ],
+          "creatorLiteral": [
+            "Muḥammad Saʻd ibn Muḥammad Saʻd al-Miṣrī."
+          ],
+          "createdString": [
+            "1890"
+          ],
+          "contributorLiteral": [
+            "Maghribī, ʻAbd al-Muʼmin.",
+            "Schiff Collection."
+          ],
+          "dateStartYear": [
+            1890
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-158 no. 10"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001747"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201782"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201745"
+            }
+          ],
+          "updatedAt": 1637345508286,
+          "publicationStatement": [
+            "al-Qāhirah : al-Maṭbaʻah al-ʻĀmirah al-Sharafīyah, 1307 [1890]"
+          ],
+          "identifier": [
+            "urn:bnum:10001747",
+            "urn:undefined:NNSZ00201782",
+            "urn:undefined:(WaOLN)nyp0201745"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1890"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Middle East -- Biography."
+          ],
+          "titleDisplay": [
+            "Tuḥfat ahl al-fukāhah [microform] : fī al-munādamah wa-al-nazāhah / li-Muḥammad Afandī Saʻd."
+          ],
+          "uri": "b10001747",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8 degrees."
+          ]
+        },
+        "sort": [
+          "b10001747"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30154976",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-158 no. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-158 no. 1-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433098135548"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-158"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433098135548"
+                    ],
+                    "idBarcode": [
+                      "33433098135548"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-158 no. 000001-10"
+                  },
+                  "sort": [
+                    "a*ZO-158 no. 000001-10"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001936",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "400 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Publication date from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Also available on microform;",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Armenian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Microfilmed;",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Armenians",
+            "Armenians -- Iran",
+            "Armenians -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Tparan Hovhannu Tēr-Abrahamian,"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan"
+          ],
+          "shelfMark": [
+            "*ONR 84-743"
+          ],
+          "creatorLiteral": [
+            "Shermazanian, Galust."
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONR 84-743"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001936"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201976"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201934"
+            }
+          ],
+          "updatedAt": 1636118919632,
+          "publicationStatement": [
+            "Ṛostov (Doni Vra) : Tparan Hovhannu Tēr-Abrahamian, 1890 [i.e. 1891]"
+          ],
+          "identifier": [
+            "urn:bnum:10001936",
+            "urn:undefined:NNSZ00201976",
+            "urn:undefined:(WaOLN)nyp0201934"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenians -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan / Ashkhatasirutʻiamb Galust Shermazaniani."
+          ],
+          "uri": "b10001936",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṛostov (Doni Vra) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10001936"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001320",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ONR 84-743"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONR 84-743",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001892276"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONR 84-743"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001892276"
+                    ],
+                    "idBarcode": [
+                      "33433001892276"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ONR 84-000743"
+                  },
+                  "sort": [
+                    "a*ONR 84-000743"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001936-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/nyp.33433001892276",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10001936-e"
+                  },
+                  "sort": [
+                    "bi10001936-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002107",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Laakmann,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Wenemaa ajaloost."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 4"
+          ],
+          "createdString": [
+            "1881"
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002107"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202103"
+            }
+          ],
+          "updatedAt": 1636143254095,
+          "publicationStatement": [
+            "Tartus: H. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002107",
+            "urn:undefined:NNSZ00202149",
+            "urn:undefined:(WaOLN)nyp0202103"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Wenemaa ajaloost."
+          ],
+          "uri": "b10002107",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "13 cm"
+          ]
+        },
+        "sort": [
+          "b10002107"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001452",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFB 82-48 no. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001"
+                  },
+                  "sort": [
+                    "aJFB 82-48 no. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002108",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ; 13 cm."
+          ],
+          "publicationStatement": [
+            "Tartus : M. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002108",
+            "urn:undefined:NNSZ00202150",
+            "urn:undefined:(WaOLN)nyp0202104"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "M. Laakmann,"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rätsepp Kergepüks."
+          ],
+          "titleDisplay": [
+            "Rätsepp Kergepüks."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 3"
+          ],
+          "uri": "b10002108",
+          "createdString": [
+            "1881"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002108"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202150"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202104"
+            }
+          ],
+          "placeOfPublication": [
+            "Tartus :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "updatedAt": 1636127692677
+        },
+        "sort": [
+          "b10002108"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001452",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFB 82-48 no. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001"
+                  },
+                  "sort": [
+                    "aJFB 82-48 no. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Laakmann,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Masajalg."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 1"
+          ],
+          "createdString": [
+            "1881"
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002109"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202105"
+            }
+          ],
+          "updatedAt": 1636115332522,
+          "publicationStatement": [
+            "Tartus : H. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002109",
+            "urn:undefined:NNSZ00202151",
+            "urn:undefined:(WaOLN)nyp0202105"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Masajalg."
+          ],
+          "uri": "b10002109",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "13 cm."
+          ]
+        },
+        "sort": [
+          "b10002109"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001452",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFB 82-48 no. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001"
+                  },
+                  "sort": [
+                    "aJFB 82-48 no. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001459",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFD 82-4488",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488"
+                  },
+                  "sort": [
+                    "a*OFD 82-004488"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002588",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "24 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At head of title: Not published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jews",
+            "Jews -- Conversion to Christianity",
+            "Missions to Jews"
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1840
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Report of the late agency of the Rev. J.S.C.F. Frey presented to the Board of Managers of the American Society for Meliorating the Condition of the Jews."
+          ],
+          "shelfMark": [
+            "*XMH-2174"
+          ],
+          "creatorLiteral": [
+            "Frey, Joseph Samuel C. F. (Joseph Samuel Christian Frederick), 1771-1850."
+          ],
+          "createdString": [
+            "1840"
+          ],
+          "contributorLiteral": [
+            "American Society for Meliorating the Condition of the Jews."
+          ],
+          "dateStartYear": [
+            1840
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XMH-2174"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002588"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302930"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202584"
+            }
+          ],
+          "updatedAt": 1651837077662,
+          "publicationStatement": [
+            "[New York : s.n., 1840?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002588",
+            "urn:undefined:NNSZ00302930",
+            "urn:undefined:(WaOLN)nyp0202584"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1840"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jews -- Conversion to Christianity.",
+            "Missions to Jews."
+          ],
+          "titleDisplay": [
+            "Report of the late agency of the Rev. J.S.C.F. Frey [microform] : presented to the Board of Managers of the American Society for Meliorating the Condition of the Jews."
+          ],
+          "uri": "b10002588",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "[New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10002588"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002627",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "48 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Horses"
+          ],
+          "publisherLiteral": [
+            "Bokförlaget Rediviva"
+          ],
+          "language": [
+            {
+              "id": "lang:swe",
+              "label": "Swedish"
+            }
+          ],
+          "dateEndString": [
+            "1837"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Undervisning i hästkännedom för korporals-skolorna vid kavalleriet inom fjerde militär-districtet"
+          ],
+          "shelfMark": [
+            "*XM-15430"
+          ],
+          "creatorLiteral": [
+            "Billing, J. S."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XM-15430"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002627"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9171201017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302971"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202622"
+            }
+          ],
+          "dateEndYear": [
+            1837
+          ],
+          "updatedAt": 1651837112373,
+          "publicationStatement": [
+            "Stockholm : Bokförlaget Rediviva, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10002627",
+            "urn:isbn:9171201017",
+            "urn:undefined:NNSZ00302971",
+            "urn:undefined:(WaOLN)nyp0202622"
+          ],
+          "idIsbn": [
+            "9171201017"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Horses."
+          ],
+          "titleDisplay": [
+            "Undervisning i hästkännedom för korporals-skolorna [microform] : vid kavalleriet inom fjerde militär-districtet / uppraättad af J. S. Billing."
+          ],
+          "uri": "b10002627",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Stockholm"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9171201017"
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10002627"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002631",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "44 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Socialism"
+          ],
+          "publisherLiteral": [
+            "Trübsche Buchh."
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1882
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Wetterleuchten, der Staatssozialismus und seine Consequenzen. Erster Theil"
+          ],
+          "shelfMark": [
+            "*XME-10755"
+          ],
+          "creatorLiteral": [
+            "Locher, Friedrich, 1820-1911."
+          ],
+          "createdString": [
+            "1882"
+          ],
+          "dateStartYear": [
+            1882
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XME-10755"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002631"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302975"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202626"
+            }
+          ],
+          "updatedAt": 1651837112373,
+          "publicationStatement": [
+            "Zürich : Trübsche Buchh., 1882."
+          ],
+          "identifier": [
+            "urn:bnum:10002631",
+            "urn:undefined:NNSZ00302975",
+            "urn:undefined:(WaOLN)nyp0202626"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1882"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Socialism."
+          ],
+          "titleDisplay": [
+            "Wetterleuchten, der Staatssozialismus und seine Consequenzen. Erster Theil [microform] / von Friedrich Locher."
+          ],
+          "uri": "b10002631",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Zürich"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10002631"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003085",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 172, 10 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A revision of the authoress' thesis, Varanaseya Sanskrit Vishwavidyalaya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [1]-5 (3rd group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism",
+            "Hinduism -- Rites and ceremonies",
+            "Vedas"
+          ],
+          "publisherLiteral": [
+            "[Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ."
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1889"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Atharvavede śāntipuṣṭikarmāṇi."
+          ],
+          "shelfMark": [
+            "*OLY 83-704"
+          ],
+          "creatorLiteral": [
+            "Malaviya, Maya, 1939-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68016943"
+          ],
+          "seriesStatement": [
+            "Sarasvatībhavana - Adhyayanamālā, 17"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-704"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003085"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68016943"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303436"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203078"
+            }
+          ],
+          "dateEndYear": [
+            1889
+          ],
+          "updatedAt": 1636075653207,
+          "publicationStatement": [
+            "Vārāṇasyām [Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ. 1889 tame Śakābde [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10003085",
+            "urn:lccn:sa 68016943",
+            "urn:undefined:NNSZ00303436",
+            "urn:undefined:(WaOLN)nyp0203078"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism -- Rites and ceremonies.",
+            "Vedas."
+          ],
+          "titleDisplay": [
+            "Atharvavede śāntipuṣṭikarmāṇi. Lekhikā sampādikā ca Māyā Mālavīyā."
+          ],
+          "uri": "b10003085",
+          "lccClassification": [
+            "BL1226.2 .M32 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003085"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784336",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-704"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-704",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417965"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-704"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417965"
+                    ],
+                    "idBarcode": [
+                      "33433060417965"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000704"
+                  },
+                  "sort": [
+                    "a*OLY 83-000704"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003088",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 16, 200 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- Varanaseya Sanskrit Vishwavidyalaya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [198]-200.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Solar eclipses"
+          ],
+          "publisherLiteral": [
+            "Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ["
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1889"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sūryagrahaṇam."
+          ],
+          "shelfMark": [
+            "*OKQ 83-703"
+          ],
+          "creatorLiteral": [
+            "Dvivedī, Kṛṣṇacandra."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68014918"
+          ],
+          "seriesStatement": [
+            "Sarasvatībhavana - Adhyayanamālā, .15"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKQ 83-703"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003088"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68014918"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303439"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203081"
+            }
+          ],
+          "dateEndYear": [
+            1889
+          ],
+          "updatedAt": 1636132203514,
+          "publicationStatement": [
+            "Vārāṇasyām, Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ[ 1889 tame śakāb de [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10003088",
+            "urn:lccn:sa 68014918",
+            "urn:undefined:NNSZ00303439",
+            "urn:undefined:(WaOLN)nyp0203081"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Solar eclipses."
+          ],
+          "titleDisplay": [
+            "Sūryagrahaṇam. Lekhakaḥ sampādakaśca Kṛṣnacandra-dvivedī."
+          ],
+          "uri": "b10003088",
+          "lccClassification": [
+            "QB541 .D83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003088"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002163",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKQ 83-703"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKQ 83-703",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002896748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKQ 83-703"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002896748"
+                    ],
+                    "idBarcode": [
+                      "33433002896748"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKQ 83-000703"
+                  },
+                  "sort": [
+                    "a*OKQ 83-000703"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003117",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10, 192, 52 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1313 H. (1895 or 1896) ed. published by al-Sharikah al-Ṣiḥāfīyah al-ʻUthmānīyah, Istanbul.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870.",
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870. -- Indexes",
+            "Hadith",
+            "Hadith -- Indexes",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875. -- Indexes"
+          ],
+          "publisherLiteral": [
+            "Dār al-Kutub al-ʻIlmīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1895"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miftāḥ al-Ṣaḥīḥayn Bukhārī wa-Muslim"
+          ],
+          "shelfMark": [
+            "*OGF 84-1307"
+          ],
+          "creatorLiteral": [
+            "Tawqādī, Muḥammad al-Sharīf ibn Muṣṭafá."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "77960426"
+          ],
+          "contributorLiteral": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGF 84-1307"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003117"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77960426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303468"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203110"
+            }
+          ],
+          "dateEndYear": [
+            1895
+          ],
+          "updatedAt": 1636116228553,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Kutub al-ʻIlmīyah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10003117",
+            "urn:lccn:77960426",
+            "urn:undefined:NNSZ00303468",
+            "urn:undefined:(WaOLN)nyp0203110"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870. -- Indexes.",
+            "Hadith -- Indexes.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875. -- Indexes."
+          ],
+          "titleDisplay": [
+            "Miftāḥ al-Ṣaḥīḥayn Bukhārī wa-Muslim / Muḥammad al-Sharīf ibn Muṣṭafá al-Tūqādī."
+          ],
+          "uri": "b10003117",
+          "lccClassification": [
+            "BP135.2. T86 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Miftāḥ Ṣaḥīḥ al-Bukhārī: Irshād al-sārī lil-Qasṭallānī. Fatḥ al-Bārī li-ibn Ḥajar al-ʻAsqulānī. ʻUmdat al-qārī lil-ʻAynī. Matn Ṣaḥīḥ al-Bukhārī. -- Miftāḥ Ṣaḥīḥ Muslim: al-Nawawī ʻalá Ṣaḥīḥ Muslim. Matn Ṣaḥīḥ Muslim."
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10003117"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002177",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGF 84-1307"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGF 84-1307",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013217298"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGF 84-1307"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013217298"
+                    ],
+                    "idBarcode": [
+                      "33433013217298"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGF 84-001307"
+                  },
+                  "sort": [
+                    "a*OGF 84-001307"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003143",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20, 784 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reproduced from Ms. copy.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Reprint of the ed. published in Teheran, 1272 A. H.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Shīʻah",
+            "Shīʻah -- Doctrines"
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1855"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ghāyat al-marām fī ḥujjat al-khiṣ̣ām ʻan ṭarīq al-khāṣṣ wa-al-ʻāmm,"
+          ],
+          "shelfMark": [
+            "*OGI+ 84-1305"
+          ],
+          "creatorLiteral": [
+            "Baḥrānī, Hāshim ibn Sulaymān, -1695 or 6."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75961367"
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI+ 84-1305"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75961367"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303494"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203136"
+            }
+          ],
+          "dateEndYear": [
+            1855
+          ],
+          "updatedAt": 1641231073322,
+          "publicationStatement": [
+            "[Bayrūt, Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10003143",
+            "urn:lccn:75961367",
+            "urn:undefined:NNSZ00303494",
+            "urn:undefined:(WaOLN)nyp0203136"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Shīʻah -- Doctrines."
+          ],
+          "titleDisplay": [
+            "Ghāyat al-marām fī ḥujjat al-khiṣ̣ām ʻan ṭarīq al-khāṣṣ wa-al-ʻāmm, lil-Baḥrānī."
+          ],
+          "uri": "b10003143",
+          "lccClassification": [
+            "BP194 .B3 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10003143"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784359",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058659842"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058659842"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058659842"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OGI+ 84-1305"
+                    ],
+                    "shelfMark_sort": "a*OGI+ 84-001305"
+                  },
+                  "sort": [
+                    "a*OGI+ 84-001305"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003146",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[i], 4, 120, 796 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English: ... ed. by Ananda Chandra Vedantavagisa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Originally published:",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lāṭyāyanaśrautasūtra",
+            "Vedas"
+          ],
+          "publisherLiteral": [
+            "Munshiram Manoharlal Publishers,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1872"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srautasūtram"
+          ],
+          "shelfMark": [
+            "*OKH 84-1426"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "contributorLiteral": [
+            "Agnisvāmi.",
+            "Kashikar, C. G.",
+            "Lāṭyāyanaśrautasūtra.",
+            "Vedāntavāgīśa, Ānandacandra."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKH 84-1426"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003146"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303497"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203139"
+            }
+          ],
+          "uniformTitle": [
+            "Vedas. Sāmaveda Srautasutra."
+          ],
+          "dateEndYear": [
+            1872
+          ],
+          "updatedAt": 1636130442624,
+          "publicationStatement": [
+            "New Delhi : Munshiram Manoharlal Publishers, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10003146",
+            "urn:undefined:NNSZ00303497",
+            "urn:undefined:(WaOLN)nyp0203139"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lāṭyāyanaśrautasūtra.",
+            "Vedas."
+          ],
+          "titleDisplay": [
+            "Srautasūtram / Lāṭyāyanācārya praṇītam ; Agnisvāmiviracitabhāṣyasahitam ; Śrīānandacandravēdāntavāgīśena pariśodhitam ; [with new appendix containing corrections and emendations to the text by Dr. C. G. Kashikar]."
+          ],
+          "uri": "b10003146",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003146"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058568993"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058568993"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058568993"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKH 84-1426"
+                    ],
+                    "shelfMark_sort": "a*OKH 84-001426"
+                  },
+                  "sort": [
+                    "a*OKH 84-001426"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003158",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "608 p. in various pagings ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Chinese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Chinese"
+          ],
+          "publisherLiteral": [
+            "Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si,"
+          ],
+          "language": [
+            {
+              "id": "lang:chi",
+              "label": "Chinese"
+            }
+          ],
+          "dateEndString": [
+            "1670"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zheng yin mo zhi : [4 juan]"
+          ],
+          "shelfMark": [
+            "*OVL 84-1330"
+          ],
+          "creatorLiteral": [
+            "Qin, Changyu, active 17th century."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "77839836"
+          ],
+          "seriesStatement": [
+            "zhongguo yi yao zong shu."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OVL 84-1330"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003158"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77839836"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303509"
+            }
+          ],
+          "dateEndYear": [
+            1670
+          ],
+          "updatedAt": 1641391919318,
+          "publicationStatement": [
+            "Taipei xian yonghe zhen : Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si, Min'Guo 61[1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10003158",
+            "urn:lccn:77839836",
+            "urn:undefined:NNSZ00303509"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Chinese."
+          ],
+          "titleDisplay": [
+            "Zheng yin mo zhi : [4 juan] / Qin Jingming [Changyu] zhu ; Qin Zhizheng ji ; [Cao Binzhang quan dian]."
+          ],
+          "uri": "b10003158",
+          "lccClassification": [
+            "R128.7 .C545"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Taipei xian yonghe zhen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003158"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002193",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OVL 84-1330",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001746852"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001746852"
+                    ],
+                    "idBarcode": [
+                      "33433001746852"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OVL 84-001330"
+                  },
+                  "sort": [
+                    "a*OVL 84-001330"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "606 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Basavapurāṇavu.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Kannaḍa sāhitya caritre.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Poetry",
+            "Lingayats",
+            "Lingayats -- Poetry"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavapurāṇavu"
+          ],
+          "shelfMark": [
+            "*OLA+ 82-1360"
+          ],
+          "creatorLiteral": [
+            "Palakuriki Somanatha, active 13th century."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Bhīmakavi, active 1369."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 82-1360"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003190"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303541"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203183"
+            }
+          ],
+          "uniformTitle": [
+            "Basavapurāṇamu. Kannada"
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636076831370,
+          "publicationStatement": [
+            "[S.1. : s.n., 18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003190",
+            "urn:undefined:NNSZ00303541",
+            "urn:undefined:(WaOLN)nyp0203183"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Poetry.",
+            "Lingayats -- Poetry."
+          ],
+          "titleDisplay": [
+            "Basavapurāṇavu / [Bhīmakavi viracita ; Sōmanātha kaviya Telugu Basavapurāṇamuvina Kannaḍa anuvāda]."
+          ],
+          "uri": "b10003190",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Basavapurāṇamu."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10003190"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784381",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069579674"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069579674"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433069579674"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 82-1360"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 82-001360"
+                  },
+                  "sort": [
+                    "a*OLA+ 82-001360"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003301",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map, facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kurds",
+            "Kurds -- Iran",
+            "Kurds -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Kūshish,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān"
+          ],
+          "shelfMark": [
+            "*OMR 84-1145"
+          ],
+          "creatorLiteral": [
+            "Tavaḥḥudī Awghāzī, Kalīm Allāh."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMR 84-1145"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303655"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000007"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636103985760,
+          "publicationStatement": [
+            "Mashhad : Chāpkhānah-ʼi Kūshish, 1359-  [1981-  ]"
+          ],
+          "identifier": [
+            "urn:bnum:10003301",
+            "urn:undefined:NNSZ00303655",
+            "urn:undefined:(WaOLN)nyp0000007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kurds -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān / taʼlīf-i Kalīm Allāh Tavaḥḥudī (Awghāzi)"
+          ],
+          "uri": "b10003301",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Mashhad :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003301"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013136530"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013136530"
+                    ],
+                    "idBarcode": [
+                      "33433013136530"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000001"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002282",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135847"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135847"
+                    ],
+                    "idBarcode": [
+                      "33433013135847"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000003"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002283",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135854"
+                    ],
+                    "idBarcode": [
+                      "33433013135854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000004"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003564",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13, 496 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Abū Ṭālib Shīrāzī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "createdYear": [
+            1859
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥadīqat al-ḥaqīqah va sharīʻat al-ṭarīqah"
+          ],
+          "shelfMark": [
+            "*OMQ 82-3324"
+          ],
+          "creatorLiteral": [
+            "Sanāʼī al-Ghaznavī, Abū al-Majd Majdūd ibn Ādam, -approximately 1150."
+          ],
+          "createdString": [
+            "1859"
+          ],
+          "dateStartYear": [
+            1859
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 82-3324"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203556"
+            }
+          ],
+          "updatedAt": 1636103985797,
+          "publicationStatement": [
+            "Bumbaʼī : Abū Ṭālib Shīrāzī, 1859."
+          ],
+          "identifier": [
+            "urn:bnum:10003564",
+            "urn:undefined:NNSZ00303920",
+            "urn:undefined:(WaOLN)nyp0203556"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1859"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ḥadīqat al-ḥaqīqah va sharīʻat al-ṭarīqah / Abū al-Majd Majdūd ibn Ādam al-Sanāʼī al-Ghaznavī."
+          ],
+          "uri": "b10003564",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bumbaʼī :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10003564"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002468",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMQ 82-3324"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMQ 82-3324",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013144385"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 82-3324"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013144385"
+                    ],
+                    "idBarcode": [
+                      "33433013144385"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMQ 82-003324"
+                  },
+                  "sort": [
+                    "a*OMQ 82-003324"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003703",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "253 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "J.R. Vilímek,"
+          ],
+          "language": [
+            {
+              "id": "lang:cze",
+              "label": "Czech"
+            }
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Listí po krajích rozváté : básně"
+          ],
+          "shelfMark": [
+            "*QVH 83-187"
+          ],
+          "creatorLiteral": [
+            "Svoboda, František Xaver, 1860-"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "seriesStatement": [
+            "Spisy / F.X. Svobody ; 23"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QVH 83-187"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003703"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304061"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203695"
+            }
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1636113429964,
+          "publicationStatement": [
+            "V Praze : J.R. Vilímek, [19--]."
+          ],
+          "identifier": [
+            "urn:bnum:10003703",
+            "urn:undefined:NNSZ00304061",
+            "urn:undefined:(WaOLN)nyp0203695"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Listí po krajích rozváté : básně / F. X. Svoboda."
+          ],
+          "uri": "b10003703",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "V Praze :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10003703"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002586",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*QVH 83-187"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QVH 83-187",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011955378"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*QVH 83-187"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011955378"
+                    ],
+                    "idBarcode": [
+                      "33433011955378"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*QVH 83-000187"
+                  },
+                  "sort": [
+                    "a*QVH 83-000187"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003857",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "319 p. : ill., plates, maps ;"
+          ],
+          "parallelDisplayField": [
+            {
+              "fieldName": "publicationStatement",
+              "index": 0,
+              "value": "‏بيروت : دار مكتبة الحياة, [196-؟]"
+            },
+            {
+              "fieldName": "placeOfPublication",
+              "index": 0,
+              "value": "‏بيروت :"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yemen (Republic)"
+          ],
+          "publisherLiteral": [
+            "Dār Maktabat al-Ḥayāh,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            196
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah /"
+          ],
+          "parallelTitle": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة /"
+          ],
+          "shelfMark": [
+            "*OFI 82-4419"
+          ],
+          "creatorLiteral": [
+            "Tarsīsī, ʻAdnān."
+          ],
+          "createdString": [
+            "196"
+          ],
+          "parallelPublisher": [
+            "‏دار مكتبة الحياة,"
+          ],
+          "idLccn": [
+            "ne 64003290"
+          ],
+          "dateStartYear": [
+            196
+          ],
+          "parallelCreatorLiteral": [
+            "‏ترسيسي, عدنان."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFI 82-4419"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003857"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 64003290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)221366702"
+            }
+          ],
+          "idOclc": [
+            "11272192"
+          ],
+          "updatedAt": 1649121307527,
+          "publicationStatement": [
+            "Bayrūt : Dār Maktabat al-Ḥayāh, [196-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003857",
+            "urn:lccn:ne 64003290",
+            "urn:oclc:11272192",
+            "urn:undefined:(OCoLC)11272192",
+            "urn:undefined:(OCoLC)221366702"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "196"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yemen (Republic)"
+          ],
+          "titleDisplay": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah / [taʼlīf] ʻAdnān Tarsīsī."
+          ],
+          "uri": "b10003857",
+          "lccClassification": [
+            "DS247.Y4 T3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة / [تاليف] عدنان ترسيسي."
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Includes musical score of national anthem of Yemen Arab Republic."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003857"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002714",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFI 82-4419",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002023293"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002023293"
+                    ],
+                    "idBarcode": [
+                      "33433002023293"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFI 82-004419"
+                  },
+                  "sort": [
+                    "a*OFI 82-004419"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29202258",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101143836"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101143836"
+                    ],
+                    "idBarcode": [
+                      "33433101143836"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                  },
+                  "sort": [
+                    "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[15], 409 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Based on conversation with Sayyāḥ yamanī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sufism"
+          ],
+          "publisherLiteral": [
+            "s.n.,]"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1890"
+          ],
+          "createdYear": [
+            1889
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Haẕā Kitāb-i hadīqat al-inṣāf"
+          ],
+          "shelfMark": [
+            "*OMQ 82-3319"
+          ],
+          "creatorLiteral": [
+            "Sarmast Rūmī, ʻAbd al-Karīm Maḥmūd."
+          ],
+          "createdString": [
+            "1889"
+          ],
+          "contributorLiteral": [
+            "Sayyāḥ yamanī."
+          ],
+          "dateStartYear": [
+            1889
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 82-3319"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304387"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204018"
+            }
+          ],
+          "dateEndYear": [
+            1890
+          ],
+          "updatedAt": 1636101588849,
+          "publicationStatement": [
+            "[S.l. : s.n.,] 1307 [1889 or 1890]"
+          ],
+          "identifier": [
+            "urn:bnum:10004026",
+            "urn:undefined:NNSZ00304387",
+            "urn:undefined:(WaOLN)nyp0204018"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1889"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sufism."
+          ],
+          "titleDisplay": [
+            "Haẕā Kitāb-i hadīqat al-inṣāf / [ʻAbd al-Karīm Sarmast Rūmī]."
+          ],
+          "uri": "b10004026",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Ḥadīqat al-inṣāf."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10004026"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002864",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMQ 82-3319"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMQ 82-3319",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013144377"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 82-3319"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013144377"
+                    ],
+                    "idBarcode": [
+                      "33433013144377"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMQ 82-003319"
+                  },
+                  "sort": [
+                    "a*OMQ 82-003319"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Esosiẏeṭeḍa Pābaliśārsa"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "dateEndString": [
+            "62"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Junāpura Sṭīla."
+          ],
+          "shelfMark": [
+            "*OKV 82-3891"
+          ],
+          "creatorLiteral": [
+            "Mānnā, Guṇamaẏa, 1925-2010."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "sa 63003864"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-3891"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63003864"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204072"
+            }
+          ],
+          "dateEndYear": [
+            62
+          ],
+          "updatedAt": 1636108800927,
+          "publicationStatement": [
+            "[Kalakātā] Esosiẏeṭeḍa Pābaliśārsa [1960-1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10004080",
+            "urn:lccn:sa 63003864",
+            "urn:undefined:NNSZ00304442",
+            "urn:undefined:(WaOLN)nyp0204072"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Junāpura Sṭīla. [Lekhaka] Guṇamaẏa Mānnā."
+          ],
+          "uri": "b10004080",
+          "lccClassification": [
+            "PK1718.M253 53"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Kalakātā]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004080"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-3891 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168394"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168394"
+                    ],
+                    "idBarcode": [
+                      "33433011168394"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000001"
+                  },
+                  "sort": [
+                    "a*OKV 82-3891 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002917",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-3891 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168402"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168402"
+                    ],
+                    "idBarcode": [
+                      "33433011168402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000002"
+                  },
+                  "sort": [
+                    "a*OKV 82-3891 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004340",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 552, 28 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Arab"
+          ],
+          "publisherLiteral": [
+            "Maṭbaʻat Muḥammad Rashīd ibn Dāvūd al-Saʻdī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1895
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hādhā kitāb Daqaʼiq al-ʻilāj fī al-ṭibb al-badanī"
+          ],
+          "shelfMark": [
+            "*OGB 83-1915"
+          ],
+          "creatorLiteral": [
+            "Kirmānī, Muḥammad Karīm Khān, 1809-1870."
+          ],
+          "createdString": [
+            "1895"
+          ],
+          "dateStartYear": [
+            1895
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGB 83-1915"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004340"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304705"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204332"
+            }
+          ],
+          "updatedAt": 1636103964357,
+          "publicationStatement": [
+            "Bumbaʼī : Maṭbaʻat Muḥammad Rashīd ibn Dāvūd al-Saʻdī, 1315 [1895]"
+          ],
+          "identifier": [
+            "urn:bnum:10004340",
+            "urn:undefined:NNSZ00304705",
+            "urn:undefined:(WaOLN)nyp0204332"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1895"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Arab."
+          ],
+          "titleDisplay": [
+            "Hādhā kitāb Daqaʼiq al-ʻilāj fī al-ṭibb al-badanī / min muṣannafāt Muḥammad Karīm Khān al-Kirmānī."
+          ],
+          "uri": "b10004340",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bumbaʼī :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Daqāʼiq al-ʻilāj."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10004340"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540130",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGB 83-1915"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGB 83-1915",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019817224"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGB 83-1915"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019817224"
+                    ],
+                    "idBarcode": [
+                      "33433019817224"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OGB 83-001915"
+                  },
+                  "sort": [
+                    "a*OGB 83-001915"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004340-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/nyp.33433019817224",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10004340-e"
+                  },
+                  "sort": [
+                    "bi10004340-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "34 p.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Pronunciation"
+          ],
+          "publisherLiteral": [
+            "Naṭarācaṉ,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            197
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum"
+          ],
+          "shelfMark": [
+            "*OLB 83-2757"
+          ],
+          "creatorLiteral": [
+            "Natarajan, Subbiah, 1911-"
+          ],
+          "createdString": [
+            "197"
+          ],
+          "idLccn": [
+            "75906338"
+          ],
+          "dateStartYear": [
+            197
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2757"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004504"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906338"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304869"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204496"
+            }
+          ],
+          "updatedAt": 1636132308475,
+          "publicationStatement": [
+            "[Tūttukkuṭi]: Naṭarācaṉ, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10004504",
+            "urn:lccn:75906338",
+            "urn:undefined:NNSZ00304869",
+            "urn:undefined:(WaOLN)nyp0204496"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "197"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Pronunciation."
+          ],
+          "titleDisplay": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum/ Cu. Naṭarājaṉ."
+          ],
+          "uri": "b10004504",
+          "lccClassification": [
+            "PL4754 .N33 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tūttukkuṭi]:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10004504"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784546",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-2757",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296681"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296681"
+                    ],
+                    "idBarcode": [
+                      "33433061296681"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002757"
+                  },
+                  "sort": [
+                    "a*OLB 83-002757"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 p. l., iii, 404, vi p. 1 plate."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Niscaladasa, supposed author.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Dhole,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1885
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The metaphysics of the Upanishads, Vicharsagar [microform]."
+          ],
+          "shelfMark": [
+            "*ZO-179 no. 8"
+          ],
+          "createdString": [
+            "1885"
+          ],
+          "seriesStatement": [
+            "Dhole's Vedanta series, \\3"
+          ],
+          "contributorLiteral": [
+            "Niscaladasa."
+          ],
+          "dateStartYear": [
+            1885
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-179 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004657"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405768"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204649"
+            }
+          ],
+          "uniformTitle": [
+            "Upanishads. English."
+          ],
+          "updatedAt": 1636136428813,
+          "publicationStatement": [
+            "Calcutta, H. Dhole, 1885."
+          ],
+          "identifier": [
+            "urn:bnum:10004657",
+            "urn:undefined:NNSZ00405768",
+            "urn:undefined:(WaOLN)nyp0204649"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1885"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The metaphysics of the Upanishads, Vicharsagar [microform]. Translated with copious notes by Lala Sreeram."
+          ],
+          "uri": "b10004657",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Calcutta,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vicharsagar."
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10004657"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-179 9 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-179 9 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673085"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-179"
+                    ],
+                    "enumerationChronology": [
+                      "9 misc oriental titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673085"
+                    ],
+                    "idBarcode": [
+                      "33433105673085"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-179 9 misc oriental titles"
+                  },
+                  "sort": [
+                    "a*ZO-179 9 misc oriental titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004661",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gregorius de Montelongo",
+            "Italy",
+            "Italy -- History",
+            "Italy -- History -- 476-1492"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1898
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gregorius de Montelongo [microform]. Ein Beitrag zur Geschichte Oberitaliens in den Jahren 1238-1269."
+          ],
+          "shelfMark": [
+            "*Z-3433 no. 3"
+          ],
+          "creatorLiteral": [
+            "Frankfurth, Hermann."
+          ],
+          "createdString": [
+            "1898"
+          ],
+          "dateStartYear": [
+            1898
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3433 no. 3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004661"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405772"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204653"
+            }
+          ],
+          "updatedAt": 1636100134306,
+          "publicationStatement": [
+            "Marburg, N.G. Elwert, 1808."
+          ],
+          "identifier": [
+            "urn:bnum:10004661",
+            "urn:undefined:NNSZ00405772",
+            "urn:undefined:(WaOLN)nyp0204653"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1898"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gregorius de Montelongo.",
+            "Italy -- History -- 476-1492."
+          ],
+          "titleDisplay": [
+            "Gregorius de Montelongo [microform]. Ein Beitrag zur Geschichte Oberitaliens in den Jahren 1238-1269. Von Hermann Frankfurth."
+          ],
+          "uri": "b10004661",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Marburg,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10004661"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30141341",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3433"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3433",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107964664"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3433"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107964664"
+                    ],
+                    "idBarcode": [
+                      "33433107964664"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-003433"
+                  },
+                  "sort": [
+                    "a*Z-003433"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004664",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, [11]-149 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cuban question",
+            "Cuban question -- To 1895"
+          ],
+          "publisherLiteral": [
+            "Impr. de \"El Cronista,\""
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1872
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cuba puede ser independiente [microform]. Folleto político de actualidad,"
+          ],
+          "shelfMark": [
+            "*ZH-695 no. 6"
+          ],
+          "creatorLiteral": [
+            "Ferrer de Couto, José, 1820-1877."
+          ],
+          "createdString": [
+            "1872"
+          ],
+          "idLccn": [
+            "17000612"
+          ],
+          "dateStartYear": [
+            1872
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZH-695 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004664"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "17000612"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405775"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204656"
+            }
+          ],
+          "updatedAt": 1636085605650,
+          "publicationStatement": [
+            "Nueva York, Impr. de \"El Cronista,\" 1872."
+          ],
+          "identifier": [
+            "urn:bnum:10004664",
+            "urn:lccn:17000612",
+            "urn:undefined:NNSZ00405775",
+            "urn:undefined:(WaOLN)nyp0204656"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1872"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cuban question -- To 1895."
+          ],
+          "titleDisplay": [
+            "Cuba puede ser independiente [microform]. Folleto político de actualidad, por José Ferrer de Couto."
+          ],
+          "uri": "b10004664",
+          "lccClassification": [
+            "F1783 .F39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Nueva York,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004664"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30805021",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZH-695 8 misc. American history titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZH-695 8 misc. American history titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110498031"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZH-695"
+                    ],
+                    "enumerationChronology": [
+                      "8 misc. American history titles"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110498031"
+                    ],
+                    "idBarcode": [
+                      "33433110498031"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZH-695 8 misc. American history titles"
+                  },
+                  "sort": [
+                    "a*ZH-695 8 misc. American history titles"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004665",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 p.l., v., 382 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gustav III, King of Sweden, 1746-1792"
+          ],
+          "publisherLiteral": [
+            "Amyot,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1861
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gustave III, roi de Suède, 1746-1792 [microform],"
+          ],
+          "shelfMark": [
+            "*Z-3354 no. 2"
+          ],
+          "creatorLiteral": [
+            "Léouzon Le Duc, L. (Louis), 1815-1889."
+          ],
+          "createdString": [
+            "1861"
+          ],
+          "idLccn": [
+            "05008965"
+          ],
+          "seriesStatement": [
+            "Les Couronnes sanglantes"
+          ],
+          "dateStartYear": [
+            1861
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3354 no. 2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004665"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "05008965"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405776"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204657"
+            }
+          ],
+          "updatedAt": 1636100755031,
+          "publicationStatement": [
+            "Paris, Amyot, 1861."
+          ],
+          "identifier": [
+            "urn:bnum:10004665",
+            "urn:lccn:05008965",
+            "urn:undefined:NNSZ00405776",
+            "urn:undefined:(WaOLN)nyp0204657"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1861"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gustav III, King of Sweden, 1746-1792."
+          ],
+          "titleDisplay": [
+            "Gustave III, roi de Suède, 1746-1792 [microform], par L. Léouzon Le Duc."
+          ],
+          "uri": "b10004665",
+          "lccClassification": [
+            "DL766 .L58"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Gustave trois, roi de Suède, 1746-1792."
+          ],
+          "dimensions": [
+            "19cm."
+          ]
+        },
+        "sort": [
+          "b10004665"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30147719",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3354 no. 1-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3354 no. 1-7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107663993"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3354"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107663993"
+                    ],
+                    "idBarcode": [
+                      "33433107663993"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3354 no. 000001-7"
+                  },
+                  "sort": [
+                    "a*Z-3354 no. 000001-7"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-3c9d7620a684610f5c7f2f4def2be5f6.json
+++ b/test/fixtures/query-3c9d7620a684610f5c7f2f4def2be5f6.json
@@ -1,0 +1,905 @@
+{
+  "took": 34,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.383019,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.383019,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-46c869df83f360721329b851f0e5d852.json
+++ b/test/fixtures/query-46c869df83f360721329b851f0e5d852.json
@@ -1,0 +1,222 @@
+{
+  "took": 28,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 31.642473,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "pb1717",
+        "_score": 31.642473,
+        "_source": {
+          "extent": [
+            "x, 340 p. : ill. ;"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Fiction",
+            "Cats"
+          ],
+          "publisherLiteral": [
+            "Lothrop, Lee & Shepard Books,"
+          ],
+          "description": [
+            "More than 40 stories and essays about cats by famous writers."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cat encounters : a cat-lover's anthology /"
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "   79002437 "
+          ],
+          "contributorLiteral": [
+            "Lewis, Gogo.",
+            "Manley, Seon."
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1717"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0688419143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   79002437 "
+            }
+          ],
+          "updatedAt": 1523549727960,
+          "publicationStatement": [
+            "New York : Lothrop, Lee & Shepard Books, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:1717",
+            "urn:isbn:0688419143",
+            "urn:lccn:   79002437 "
+          ],
+          "idIsbn": [
+            "0688419143"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats -- Fiction.",
+            "Cats."
+          ],
+          "titleDisplay": [
+            "Cat encounters : a cat-lover's anthology / selected by Seon Manley & Gogo Lewis."
+          ],
+          "uri": "pb1717",
+          "lccClassification": [
+            "SF445.5 .C378"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32101087644330"
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "pi2775",
+                    "shelfMark": [
+                      "SF445.5 .C378"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "SF445.5 .C378"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101087644330"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101087644330"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available "
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-46e5f60fb1ecd2303caee7a57cf2f3c7.json
+++ b/test/fixtures/query-46e5f60fb1ecd2303caee7a57cf2f3c7.json
@@ -1,0 +1,905 @@
+{
+  "took": 49,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.7560005,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.7560005,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-4f07c13df15f1a0e778b1dbb9e951a91.json
+++ b/test/fixtures/query-4f07c13df15f1a0e778b1dbb9e951a91.json
@@ -1,0 +1,215 @@
+{
+  "took": 72,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 67.557014,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12423567",
+        "_score": 67.557014,
+        "_source": {
+          "extent": [
+            "202 p."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Campanella, Tommaso, 1568-1639"
+          ],
+          "publisherLiteral": [
+            "S. Neaulme,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1741
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vita Th. Campanellae."
+          ],
+          "shelfMark": [
+            "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+          ],
+          "creatorLiteral": [
+            "Cyprian, Ernst Salomon, 1673-1745."
+          ],
+          "createdString": [
+            "1741"
+          ],
+          "dateStartYear": [
+            1741
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12423567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2408048"
+            }
+          ],
+          "updatedAt": 1636321232714,
+          "publicationStatement": [
+            "Trajecti ad Rhenum, S. Neaulme, 1741."
+          ],
+          "identifier": [
+            "urn:bnum:12423567",
+            "urn:undefined:(WaOLN)nyp2408048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1741"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Campanella, Tommaso, 1568-1639."
+          ],
+          "titleDisplay": [
+            "Vita Th. Campanellae. Autore Ern. Sal. Cypriano. Accedunt hac secunda editione appendices IV. doctorum virorum de Campanellae vita, philosophia & libris schediasmata complectentes."
+          ],
+          "uri": "b12423567",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Trajecti ad Rhenum,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16020288",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104031624"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104031624"
+                    ],
+                    "idBarcode": [
+                      "33433104031624"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aAN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                  },
+                  "sort": [
+                    "aAN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-4fe9f7cebbfa731e8d63ffc886fb91e9.json
+++ b/test/fixtures/query-4fe9f7cebbfa731e8d63ffc886fb91e9.json
@@ -1,0 +1,905 @@
+{
+  "took": 134,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015295,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015295,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-62e1997dde4a81a94a39717646ecba87.json
+++ b/test/fixtures/query-62e1997dde4a81a94a39717646ecba87.json
@@ -1,0 +1,905 @@
+{
+  "took": 16,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.383019,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.383019,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-714e754f72d390a74789a3b229317312.json
+++ b/test/fixtures/query-714e754f72d390a74789a3b229317312.json
@@ -1,0 +1,905 @@
+{
+  "took": 67,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.0990095,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.0990095,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-71558c8b7738cf89f5222d2fce653282.json
+++ b/test/fixtures/query-71558c8b7738cf89f5222d2fce653282.json
@@ -1,0 +1,905 @@
+{
+  "took": 89,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.7560005,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.7560005,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-760c0ed0cfdfb1224efb9394e7d056af.json
+++ b/test/fixtures/query-760c0ed0cfdfb1224efb9394e7d056af.json
@@ -1,0 +1,14 @@
+{
+  "took": 42,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 0,
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-77769135ab6c2d7e52705a4102720121.json
+++ b/test/fixtures/query-77769135ab6c2d7e52705a4102720121.json
@@ -1,0 +1,276 @@
+{
+  "took": 117,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 49.10901,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13565153",
+        "_score": 49.10901,
+        "_source": {
+          "extent": [
+            "430 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: Ladies companion to the flower garden.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Ladies' companion to the flower-garden (p. [97]-340), has half- title page.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Monthly calendar of work to be done in the flower-garden: p. [425]-430.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Flower gardening",
+            "Gardening"
+          ],
+          "publisherLiteral": [
+            "John Wiley,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1853"
+          ],
+          "createdYear": [
+            1854
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gardening for ladies : and, Companion to the flower-garden"
+          ],
+          "shelfMark": [
+            "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+          ],
+          "creatorLiteral": [
+            "Loudon, Mrs. (Jane), 1807-1858."
+          ],
+          "createdString": [
+            "1854"
+          ],
+          "contributorLiteral": [
+            "Downing, A. J. (Andrew Jackson), 1815-1852."
+          ],
+          "dateStartYear": [
+            1854
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13565153"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3539974"
+            }
+          ],
+          "dateEndYear": [
+            1853
+          ],
+          "updatedAt": 1636445026964,
+          "publicationStatement": [
+            "New York : John Wiley, 1854, c1853."
+          ],
+          "identifier": [
+            "urn:bnum:13565153",
+            "urn:undefined:(WaOLN)nyp3539974"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1854"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Flower gardening.",
+            "Gardening."
+          ],
+          "titleDisplay": [
+            "Gardening for ladies : and, Companion to the flower-garden / by Mrs. Loudon."
+          ],
+          "uri": "b13565153",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Companion to the flower-garden.",
+            "Ladies' companion to the flower garden."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10708577",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006564110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006564110"
+                    ],
+                    "idBarcode": [
+                      "33433006564110"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aVQG (Loudon, J. W. Gardening for ladies. 1854)"
+                  },
+                  "sort": [
+                    "aVQG (Loudon, J. W. Gardening for ladies. 1854)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13565153-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433006564110",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "shelfMark_sort": "bi13565153-e"
+                  },
+                  "sort": [
+                    "bi13565153-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-78b7cdec4f519cb34c0c738f3e2e7fa6.json
+++ b/test/fixtures/query-78b7cdec4f519cb34c0c738f3e2e7fa6.json
@@ -1,0 +1,24026 @@
+{
+  "took": 821,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5632922,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxii, 321 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [305]-321).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Americans",
+            "Americans -- History",
+            "Americans -- History -- China",
+            "Americans -- History -- China -- 19th century",
+            "China",
+            "China -- Description and travel",
+            "China -- History",
+            "China -- History -- 19th century",
+            "China -- In popular culture",
+            "China -- Relations",
+            "China -- Relations -- United States",
+            "Public opinion",
+            "Public opinion -- United States",
+            "Public opinion -- United States -- History",
+            "Public opinion -- United States -- History -- 19th century",
+            "United States",
+            "United States -- Chinese influences",
+            "United States -- Intellectual life",
+            "United States -- Intellectual life -- 19th century",
+            "United States -- Relations",
+            "United States -- Relations -- China"
+          ],
+          "publisherLiteral": [
+            "Columbia University Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            2008
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876"
+          ],
+          "shelfMark": [
+            "JFE 09-1362"
+          ],
+          "creatorLiteral": [
+            "Haddad, John Rogers."
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "idLccn": [
+            "2008037637"
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000109"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780231130943 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0231130945 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008037637"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)184821618"
+            }
+          ],
+          "idOclc": [
+            "184821618"
+          ],
+          "updatedAt": 1643425447071,
+          "publicationStatement": [
+            "New York : Columbia University Press, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:10000109",
+            "urn:isbn:9780231130943 (cloth : alk. paper)",
+            "urn:isbn:0231130945 (cloth : alk. paper)",
+            "urn:lccn:2008037637",
+            "urn:oclc:184821618",
+            "urn:undefined:(OCoLC)184821618"
+          ],
+          "idIsbn": [
+            "9780231130943 (cloth : alk. paper)",
+            "0231130945 (cloth : alk. paper)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Americans -- History -- China -- 19th century.",
+            "China -- Description and travel.",
+            "China -- History -- 19th century.",
+            "China -- In popular culture.",
+            "China -- Relations -- United States.",
+            "Public opinion -- United States -- History -- 19th century.",
+            "United States -- Chinese influences.",
+            "United States -- Intellectual life -- 19th century.",
+            "United States -- Relations -- China."
+          ],
+          "titleDisplay": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876 / John Rogers Haddad."
+          ],
+          "uri": "b10000109",
+          "lccClassification": [
+            "E183.8.C5 H175 2008"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Xanadu : an envoy at the throne of a monarch -- Romantic domesticity : a Chinese world invented at home -- Pursuing the China effect : a country described through marketing -- China in miniature : Nathan Dunn's Chinese museum -- A floating ethnology : the strange voyage of the Chinese junk Keying -- God's China : the Middle Kingdom of Samuel Wells Williams -- The cultural fruits of diplomacy : Chinese museum and panorama -- The ugly face of China : Bayard Taylor's travels in Asia -- Traditional China and Chinese Yankees : the Centennial Exposition of 1876."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000109"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLF 82-5145",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061318089"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061318089"
+                    ],
+                    "idBarcode": [
+                      "33433061318089"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLF 82-005145"
+                  },
+                  "sort": [
+                    "a*OLF 82-005145"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23117386",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084847221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084847221"
+                    ],
+                    "idBarcode": [
+                      "33433084847221"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001362"
+                  },
+                  "sort": [
+                    "aJFE 09-001362"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000871",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001377",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill., music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 69).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Improvisation (Music)",
+            "Improvisation (Music) -- Instruction and study",
+            "Organ (Musical instrument)",
+            "Organ (Musical instrument) -- Instruction and study",
+            "Organ builders",
+            "Organ builders -- Germany",
+            "Organ music",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Silbermann, Gottfried, 1683-1753"
+          ],
+          "publisherLiteral": [
+            "Verlag Klaus-Jürgen Kamprad,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns"
+          ],
+          "shelfMark": [
+            "JMG 09-710"
+          ],
+          "creatorLiteral": [
+            "Wagler, Dietrich, 1940-"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "seriesStatement": [
+            "Freiberger Studien zur Orgel ; 10"
+          ],
+          "contributorLiteral": [
+            "Gottfried-Silbermann-Gesellschaft."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 09-710"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001377"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783930550494 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3930550490 (pbk.)"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)439765611"
+            }
+          ],
+          "updatedAt": 1636081466070,
+          "publicationStatement": [
+            "[Altenburg] : Verlag Klaus-Jürgen Kamprad, c2007."
+          ],
+          "identifier": [
+            "urn:bnum:10001377",
+            "urn:isbn:9783930550494 (pbk.)",
+            "urn:isbn:3930550490 (pbk.)",
+            "urn:undefined:(OCoLC)439765611"
+          ],
+          "idIsbn": [
+            "9783930550494 (pbk.)",
+            "3930550490 (pbk.)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Improvisation (Music) -- Instruction and study.",
+            "Organ (Musical instrument) -- Instruction and study.",
+            "Organ builders -- Germany.",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Silbermann, Gottfried, 1683-1753."
+          ],
+          "titleDisplay": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns / Dietrich Wagler ; [Hrsg.: Gottfried-Silbermann-Gesellschaft]."
+          ],
+          "uri": "b10001377",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Altenburg] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10001377"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24299761",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 09-710"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 09-710",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089337251"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 09-710"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089337251"
+                    ],
+                    "idBarcode": [
+                      "33433089337251"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 09-000710"
+                  },
+                  "sort": [
+                    "aJMG 09-000710"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784137",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784138",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784139",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784140",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784141",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784142",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784143",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784144",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784146",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 15",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784147",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784177",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 82-2276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276"
+                  },
+                  "sort": [
+                    "a*OKN 82-002276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002358",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGM 84-702",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702"
+                  },
+                  "sort": [
+                    "a*OGM 84-000702"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002360",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002361",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002363",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 1"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002421",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QYN 82-2046 Dala 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1."
+                  },
+                  "sort": [
+                    "a*QYN 82-2046 Dala 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002566",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931"
+                  },
+                  "sort": [
+                    "a*OFP 82-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002601",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002602",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002603",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002604",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002605",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858227",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-341 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 83-341 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003188",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  },
+                  "sort": [
+                    "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-291 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001"
+                  },
+                  "sort": [
+                    "aJFK 84-291 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-221 11 Azerbaijani monographs",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs"
+                  },
+                  "sort": [
+                    "a*ZO-221 11 Azerbaijani monographs"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30087469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-220 collection of 10 titles (monographs)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)"
+                  },
+                  "sort": [
+                    "a*ZO-220 collection of 10 titles (monographs)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .T000425"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    "aSc F 84-000135"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    "aSc Micro R-004202"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-184 v. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2"
+                  },
+                  "sort": [
+                    "aJFK 84-184 v. 000001-2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636102841759,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "aHDK 84-1693 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003945",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003946",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003947",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006705",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Architecture, Domestic",
+            "Architecture, Domestic -- Greece",
+            "Vernacular architecture",
+            "Vernacular architecture -- Greece"
+          ],
+          "publisherLiteral": [
+            "Ekdot. Oikos \"Melissa,\""
+          ],
+          "language": [
+            {
+              "id": "lang:gre",
+              "label": "Greek, Modern (1453- )"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hellēnikē paradosiakē architektonikē"
+          ],
+          "shelfMark": [
+            "3-MQW+ 84-2551"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83177376"
+          ],
+          "contributorLiteral": [
+            "Philippidēs, Dēmētrēs."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "3-MQW+ 84-2551"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83177376"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206694"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636102156834,
+          "publicationStatement": [
+            "Athēna : Ekdot. Oikos \"Melissa,\" c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006705",
+            "urn:lccn:83177376",
+            "urn:undefined:(WaOLN)nyp0206694"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Architecture, Domestic -- Greece.",
+            "Vernacular architecture -- Greece."
+          ],
+          "titleDisplay": [
+            "Hellēnikē paradosiakē architektonikē / symvoulos kai syntonistēs tēs ekdosēs, Dēmētrēs Philippidēs ; [phōtographies, V. Voutsas]."
+          ],
+          "uri": "b10006705",
+          "lccClassification": [
+            "NA1091 .H44 1982"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Athēna :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "t. 1. Anatoliko Aigaio. Sporades. Heptanēsa -- t. 2. Kyklades -- t. 3. Dōdekanēsa-Krētē -- t. 4. Peloponnēsos I -- t. 5 Peloponnesos II, Sterea Hellada -- t. 6. Thessalia-Ēpeiros -- t. 7. Makedonia I."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10006705"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746669",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160612"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160612"
+                    ],
+                    "idBarcode": [
+                      "33433105160612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000001"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746670",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160620"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160620"
+                    ],
+                    "idBarcode": [
+                      "33433105160620"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000002"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746671",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160638"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160638"
+                    ],
+                    "idBarcode": [
+                      "33433105160638"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000003"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160646"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160646"
+                    ],
+                    "idBarcode": [
+                      "33433105160646"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000004"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746673",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160653"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160653"
+                    ],
+                    "idBarcode": [
+                      "33433105160653"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000005"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160661"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160661"
+                    ],
+                    "idBarcode": [
+                      "33433105160661"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000006"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160679"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160679"
+                    ],
+                    "idBarcode": [
+                      "33433105160679"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000007"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000007"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006715",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some ed.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: 2222.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Austria",
+            "Austria -- Relations",
+            "Austria -- Relations -- United States",
+            "United States",
+            "United States -- Relations",
+            "United States -- Relations -- Austria"
+          ],
+          "publisherLiteral": [
+            "The author,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadruple 2"
+          ],
+          "shelfMark": [
+            "ICM (Austria) 85-584"
+          ],
+          "creatorLiteral": [
+            "Humes, John P."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ICM (Austria) 85-584"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006715"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507948"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206704"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124417162,
+          "publicationStatement": [
+            "[S.l. : The author, 197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10006715",
+            "urn:undefined:NNSZ00507948",
+            "urn:undefined:(WaOLN)nyp0206704"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Austria -- Relations -- United States.",
+            "United States -- Relations -- Austria."
+          ],
+          "titleDisplay": [
+            "Quadruple 2 / by John P. Humes."
+          ],
+          "uri": "b10006715",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "2222.",
+            "Quadruple two."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006715"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "ICM (Austria) 85-584 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ICM (Austria) 85-584 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090390752"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "ICM (Austria) 85-584"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090390752"
+                    ],
+                    "idBarcode": [
+                      "33433090390752"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aICM (Austria) 85-584 v. 000002"
+                  },
+                  "sort": [
+                    "aICM (Austria) 85-584 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007240",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Imprint on cover: Tañcāvūr Mahārājā Carapōjiyiṉ Caracuvati Makāl Nūl Nilaiyam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Glossaries, vocabularies, etc"
+          ],
+          "publisherLiteral": [
+            "Tañcai Caracuvati Makāl Nūl Nilaiya Nirvākak Kuḻu,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āciriya nikaṇṭu : cēntaṉ tivākaram, piṅkala nikaṇṭu, cūṭāmaṇi, kayātaram ākiya nikaṇṭukaḷiṉ oppumaip pakutikaḷuṭaṉ"
+          ],
+          "shelfMark": [
+            "*OLB 84-3259"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "77902870"
+          ],
+          "seriesStatement": [
+            "Tañcai Caracuvati Makāl veḷiyīṭu; 156"
+          ],
+          "contributorLiteral": [
+            "Chokkalingam."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-3259"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007240"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77902870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508482"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207225"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636145121608,
+          "publicationStatement": [
+            "[Tañcāvūr] : Tañcai Caracuvati Makāl Nūl Nilaiya Nirvākak Kuḻu, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10007240",
+            "urn:lccn:77902870",
+            "urn:undefined:NNSZ00508482",
+            "urn:undefined:(WaOLN)nyp0207225"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Glossaries, vocabularies, etc."
+          ],
+          "titleDisplay": [
+            "Āciriya nikaṇṭu : cēntaṉ tivākaram, piṅkala nikaṇṭu, cūṭāmaṇi, kayātaram ākiya nikaṇṭukaḷiṉ oppumaip pakutikaḷuṭaṉ / patippāciriyar Vī. Cokkaliṅkam."
+          ],
+          "uri": "b10007240",
+          "lccClassification": [
+            "PL4757 .A5"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Tañcāvūr] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10007240"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-3259"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-3259",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061303693"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-3259"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061303693"
+                    ],
+                    "idBarcode": [
+                      "33433061303693"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-003259"
+                  },
+                  "sort": [
+                    "a*OLB 84-003259"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061354662"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061354662"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433061354662"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-3259"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-003259"
+                  },
+                  "sort": [
+                    "a*OLB 84-003259"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007516",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- History",
+            "Egypt -- History -- 20th century"
+          ],
+          "publisherLiteral": [
+            "al-Mu'assasah al-Àrabīyah lil-Dirāsāt wa-al-Nashr,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qiṣṣat thawrat 23 Yūliyū"
+          ],
+          "shelfMark": [
+            "*OFP 84-3195"
+          ],
+          "creatorLiteral": [
+            "Ḥamrūsh, Aḥmad."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "76960179"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 84-3195"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007516"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960179"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508761"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207500"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124397029,
+          "publicationStatement": [
+            "Bayrūt : al-Mu'assasah al-Àrabīyah lil-Dirāsāt wa-al-Nashr, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10007516",
+            "urn:lccn:76960179",
+            "urn:undefined:NNSZ00508761",
+            "urn:undefined:(WaOLN)nyp0207500"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- History -- 20th century."
+          ],
+          "titleDisplay": [
+            "Qiṣṣat thawrat 23 Yūliyū / Aḥmad Ḥamrūsh."
+          ],
+          "uri": "b10007516",
+          "lccClassification": [
+            "DT107.825 .H35"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Juz' 1. Miṣr wa-al-Àskarīyūn. -- Juz' 2. Mujtamà Jamāl Àbd al-Nāṣir. -- Juz' 3. Àbd al-Nāṣir wa-al-Àrab. -- Juz' 4. Shuhūd thawrat Yūliyū.--Juz' 5. Kharīf Àbd al-Nāṣir."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10007516"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004357",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566207"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566207"
+                    ],
+                    "idBarcode": [
+                      "33433005566207"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000001"
+                  },
+                  "sort": [
+                    "a*OFP 84-3195 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004358",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566215"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566215"
+                    ],
+                    "idBarcode": [
+                      "33433005566215"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000002"
+                  },
+                  "sort": [
+                    "a*OFP 84-3195 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004359",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566223"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566223"
+                    ],
+                    "idBarcode": [
+                      "33433005566223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000003"
+                  },
+                  "sort": [
+                    "a*OFP 84-3195 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004360",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566231"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566231"
+                    ],
+                    "idBarcode": [
+                      "33433005566231"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000004"
+                  },
+                  "sort": [
+                    "a*OFP 84-3195 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004361",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566249"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566249"
+                    ],
+                    "idBarcode": [
+                      "33433005566249"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000005"
+                  },
+                  "sort": [
+                    "a*OFP 84-3195 v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007874",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of: Towards one Nigeria.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nigeria",
+            "Nigeria -- History",
+            "Nigeria -- History -- Civil War, 1967-1970",
+            "Nigeria -- History -- Civil War, 1967-1970 -- Sources"
+          ],
+          "publisherLiteral": [
+            "Federal Ministry of Information,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vers l'unité du Nigèria."
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V377"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "contributorLiteral": [
+            "Nigeria. Federal Ministry of Information."
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V377"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007874"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207856"
+            }
+          ],
+          "uniformTitle": [
+            "Towards one Nigeria. French"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636140076962,
+          "publicationStatement": [
+            "[Lagos : Federal Ministry of Information, [1967?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10007874",
+            "urn:undefined:(WaOLN)nyp0207856"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nigeria -- History -- Civil War, 1967-1970 -- Sources."
+          ],
+          "titleDisplay": [
+            "Vers l'unité du Nigèria."
+          ],
+          "uri": "b10007874",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Lagos :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Towards one Nigeria."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10007874"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V377 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V377 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433034815294"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V377"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433034815294"
+                    ],
+                    "idBarcode": [
+                      "33433034815294"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V377 v. 000003"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V377 v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008327",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editors vary.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk literature, Kannada",
+            "Folk literature, Kannada -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jānapada sāhityadarśana"
+          ],
+          "shelfMark": [
+            "*OLA 83-2636"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75904046"
+          ],
+          "seriesStatement": [
+            "Jānapada sammēḷana smaraṇe ; 1-2, 4"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2636"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008327"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75904046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609733"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208308"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108824394,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10008327",
+            "urn:lccn:75904046",
+            "urn:undefined:NNSZ00609733",
+            "urn:undefined:(WaOLN)nyp0208308"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk literature, Kannada -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Jānapada sāhityadarśana / sampādakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10008327",
+          "lccClassification": [
+            "PL4654 .J3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10008327"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004639",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544238"
+                    ],
+                    "idBarcode": [
+                      "33433005544238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004640",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544246"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544246"
+                    ],
+                    "idBarcode": [
+                      "33433005544246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004641",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119130"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119130"
+                    ],
+                    "idBarcode": [
+                      "33433013119130"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008347",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v.2, p. 375.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Qurʼan",
+            "Qurʼan -- Commentaries"
+          ],
+          "publisherLiteral": [
+            "[s. n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aḍwāʼ ʻalá mutashābihāt al-Qurʼān ; yaḥtawī ʻalá 1600 suʼāl wa-jawāb"
+          ],
+          "shelfMark": [
+            "*OGDM 82-3193"
+          ],
+          "creatorLiteral": [
+            "Yāsīn, Khalīl."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGDM 82-3193"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008347"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609754"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208328"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636071205334,
+          "publicationStatement": [
+            "Bayrūt : [s. n.], 1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10008347",
+            "urn:undefined:NNSZ00609754",
+            "urn:undefined:(WaOLN)nyp0208328"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Qurʼan -- Commentaries."
+          ],
+          "titleDisplay": [
+            "Aḍwāʼ ʻalá mutashābihāt al-Qurʼān ; yaḥtawī ʻalá 1600 suʼāl wa-jawāb / bi-qalam  Khalīl Yāsīn."
+          ],
+          "uri": "b10008347",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10008347"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004653",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGDM 82-3193"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGDM 82-3193",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005577105"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGDM 82-3193"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005577105"
+                    ],
+                    "idBarcode": [
+                      "33433005577105"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGDM 82-003193"
+                  },
+                  "sort": [
+                    "a*OGDM 82-003193"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008408",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. 1-5 : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "One folded map inserted in v. 1; 3 folded maps inserted in v. 3; one folded map inserted in v. 4.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "10 folded maps accompany atlas; issued together in a case.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Errata slip inserted in v. 3.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Excavations (Archaeology)",
+            "Excavations (Archaeology) -- Ingal",
+            "Ingal (Niger)",
+            "Ingal (Niger) -- Antiquities",
+            "Ingal (Niger) -- Antiquities -- Maps",
+            "Ingal Region (Niger)",
+            "Ingal Region (Niger) -- Antiquities",
+            "Niger",
+            "Niger -- Antiquities",
+            "Niger -- Antiquities -- Maps",
+            "Teguidda-n-Tessoumt (Niger)",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities -- Maps"
+          ],
+          "publisherLiteral": [
+            "Institut de recherches en sciences humaines,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La Région d'In Gall--Tegidda n Tesemt (Niger) : programme archéologique d'urgence, 1977-1981."
+          ],
+          "shelfMark": [
+            "Sc F 87-35"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84121246"
+          ],
+          "seriesStatement": [
+            "Etudes nigériennes ; no 47-52"
+          ],
+          "contributorLiteral": [
+            "Grébénart, Danilo.",
+            "Paris, François, 1946-",
+            "Poncet, Yveline.",
+            "Université de Niamey. Institut de recherches en sciences humaines."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 87-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008408"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2859210601 (v. 4)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9782859210601 (v. 4)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84121246"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12840091"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920482 (v. 1)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920490 (v. 2)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920504 (v. 3)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285921061X (v. 5)"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111558545,
+          "publicationStatement": [
+            "Niamey : Institut de recherches en sciences humaines, 1983-<1992>"
+          ],
+          "identifier": [
+            "urn:bnum:10008408",
+            "urn:isbn:2859210601 (v. 4)",
+            "urn:isbn:9782859210601 (v. 4)",
+            "urn:lccn:84121246",
+            "urn:undefined:(OCoLC)12840091",
+            "b10008408#1.0004",
+            "b10008408#1.0005",
+            "b10008408#1.0006",
+            "b10008408#1.0007",
+            "urn:isbn:285920482 (v. 1)",
+            "urn:isbn:285920490 (v. 2)",
+            "urn:isbn:285920504 (v. 3)",
+            "urn:isbn:285921061X (v. 5)"
+          ],
+          "idIsbn": [
+            "2859210601 (v. 4)",
+            "9782859210601 (v. 4)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Excavations (Archaeology) -- Ingal.",
+            "Ingal (Niger) -- Antiquities -- Maps.",
+            "Ingal (Niger) -- Antiquities.",
+            "Ingal Region (Niger) -- Antiquities.",
+            "Niger -- Antiquities -- Maps.",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities -- Maps.",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities."
+          ],
+          "titleDisplay": [
+            "La Région d'In Gall--Tegidda n Tesemt (Niger) : programme archéologique d'urgence, 1977-1981."
+          ],
+          "uri": "b10008408",
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Niamey :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 47. Atlas / conçu et réalisé par Yveline Poncet -- 1. (no. 48) Introduction : méthodologie, environnements -- 2. (no. 49) Le Néolithique final et les débuts de la métallurgie / Danilo Grébénart -- 3.  (no. 50) Les sépultures, du Néolithique final à l'islam / François Paris -- 4. (no. 51) Azelik-Takadda et          l'implantation sédentaire Médiévale -- 5. (no. 52) Les populations actuelles."
+          ],
+          "dimensions": [
+            "24 cm. +"
+          ]
+        },
+        "sort": [
+          "b10008408"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447322",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 Atlas"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 Atlas",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872814"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "Atlas"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872814"
+                    ],
+                    "idBarcode": [
+                      "33433036872814"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 Atlas"
+                  },
+                  "sort": [
+                    "aSc F 87-35 Atlas"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875217"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875217"
+                    ],
+                    "idBarcode": [
+                      "33433057875217"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000001"
+                  },
+                  "sort": [
+                    "aSc F 87-35 t. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540451",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875050"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875050"
+                    ],
+                    "idBarcode": [
+                      "33433057875050"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000002"
+                  },
+                  "sort": [
+                    "aSc F 87-35 t. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540452",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875068"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875068"
+                    ],
+                    "idBarcode": [
+                      "33433057875068"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000003"
+                  },
+                  "sort": [
+                    "aSc F 87-35 t. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540453",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 4-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 4-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875258"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 4-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875258"
+                    ],
+                    "idBarcode": [
+                      "33433057875258"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 4-000005"
+                  },
+                  "sort": [
+                    "aSc F 87-35 t. 4-000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008416",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"No 71.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: t. 1, p. 288.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "French language",
+            "French language -- Study and teaching",
+            "French language -- Study and teaching -- Senegal"
+          ],
+          "publisherLiteral": [
+            "Centre de linguistique appliquée de Dakar,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La grammaire en question"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .B575"
+          ],
+          "creatorLiteral": [
+            "Blondé, Jacques."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "seriesStatement": [
+            "L'Enseignement du français au Sénégal"
+          ],
+          "contributorLiteral": [
+            "Centre de linguistique appliquée de Dakar."
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .B575"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008416"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00709824"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208396"
+            }
+          ],
+          "uniformTitle": [
+            "Enseignement du français au Sénégal."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1141798",
+              "shelfMark": [
+                "Sc Ser.-M .B575"
+              ]
+            }
+          ],
+          "updatedAt": 1636111100976,
+          "publicationStatement": [
+            "[Dakar] : Centre de linguistique appliquée de Dakar, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10008416",
+            "urn:undefined:NNSZ00709824",
+            "urn:undefined:(WaOLN)nyp0208396"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "French language -- Study and teaching -- Senegal."
+          ],
+          "titleDisplay": [
+            "La grammaire en question / par Jacques Blondé."
+          ],
+          "uri": "b10008416",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Dakar] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10008416"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785304",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .B575 t. 1 (1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .B575 t. 1 (1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021653690"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .B575"
+                    ],
+                    "enumerationChronology": [
+                      "t. 1 (1978)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021653690"
+                    ],
+                    "idBarcode": [
+                      "33433021653690"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .B575 t. 1 (1978)"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .B575 t. 1 (1978)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008989",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Florentina Studiorum Universitas.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Novellae constitutiones"
+          ],
+          "publisherLiteral": [
+            "Cisalpino-Goliardica,"
+          ],
+          "language": [
+            {
+              "id": "lang:grc",
+              "label": "Greek, Ancient (to 1453)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1986
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Novellae : pars graeca"
+          ],
+          "shelfMark": [
+            "JLN 88-42"
+          ],
+          "creatorLiteral": [
+            "Bartoletti Colombo, Anna Maria."
+          ],
+          "createdString": [
+            "1986"
+          ],
+          "seriesStatement": [
+            "Legum Iustiniani imperatoris vocabularium"
+          ],
+          "contributorLiteral": [
+            "Archi, Gian Gualberto."
+          ],
+          "dateStartYear": [
+            1986
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLN 88-42"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008989"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8820505517 (v. 1)"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208964"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119109535,
+          "publicationStatement": [
+            "Milano : Cisalpino-Goliardica, c1986-"
+          ],
+          "identifier": [
+            "urn:bnum:10008989",
+            "urn:isbn:8820505517 (v. 1)",
+            "urn:undefined:(WaOLN)nyp0208964"
+          ],
+          "idIsbn": [
+            "8820505517 (v. 1)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1986"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Novellae constitutiones."
+          ],
+          "titleDisplay": [
+            "Novellae : pars graeca / Iohanne Gualberto Archi moderante, curavit Anna Maria Bartoletti Colombo."
+          ],
+          "uri": "b10008989",
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Milano :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10008989"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540484",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLN 88-42 Library has: t. 1-6. T. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLN 88-42 Library has: t. 1-6. T. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433033482716"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42 Library has: t. 1-6."
+                    ],
+                    "enumerationChronology": [
+                      "T. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433033482716"
+                    ],
+                    "idBarcode": [
+                      "33433033482716"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 Library has: t. 1-6. T. 000006"
+                  },
+                  "sort": [
+                    "aJLN 88-42 Library has: t. 1-6. T. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447325",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLN 88-42 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLN 88-42 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237792"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237792"
+                    ],
+                    "idBarcode": [
+                      "33433079237792"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000001"
+                  },
+                  "sort": [
+                    "aJLN 88-42 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447328",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLN 88-42 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLN 88-42 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237784"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237784"
+                    ],
+                    "idBarcode": [
+                      "33433079237784"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000002"
+                  },
+                  "sort": [
+                    "aJLN 88-42 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447327",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLN 88-42 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLN 88-42 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237776"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237776"
+                    ],
+                    "idBarcode": [
+                      "33433079237776"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000003"
+                  },
+                  "sort": [
+                    "aJLN 88-42 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447326",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLN 88-42 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLN 88-42 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237768"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237768"
+                    ],
+                    "idBarcode": [
+                      "33433079237768"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000005"
+                  },
+                  "sort": [
+                    "aJLN 88-42 v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3 v. (loose-leaf) : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Loose-leaves for updating.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Computer industry",
+            "Computer industry -- Technological innovations",
+            "Computers",
+            "Computers -- Catalogs"
+          ],
+          "publisherLiteral": [
+            "Datapro Research Corp. ;"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Datapro reports on minicomputers"
+          ],
+          "shelfMark": [
+            "JSF 85-437"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "contributorLiteral": [
+            "Datapro Research Corporation.",
+            "Heminway, Mary C."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 85-437"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009049"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209024"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1644359525726,
+          "publicationStatement": [
+            "Delran, N.J. : Datapro Research Corp. ; c1985-"
+          ],
+          "identifier": [
+            "urn:bnum:10009049",
+            "urn:undefined:NNSZ00810570",
+            "urn:undefined:(WaOLN)nyp0209024"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Computer industry -- Technological innovations.",
+            "Computers -- Catalogs."
+          ],
+          "titleDisplay": [
+            "Datapro reports on minicomputers / group managing editor, Mary C. Heminway."
+          ],
+          "uri": "b10009049",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Delran, N.J. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Reports on minicomputers."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10009049"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540492",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-437 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-437 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693862"
+                    ],
+                    "idBarcode": [
+                      "33433037693862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000001"
+                  },
+                  "sort": [
+                    "aJSF 85-437 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785401",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-437 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-437 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486500"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486500"
+                    ],
+                    "idBarcode": [
+                      "33433059486500"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000002"
+                  },
+                  "sort": [
+                    "aJSF 85-437 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-437 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-437 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486757"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486757"
+                    ],
+                    "idBarcode": [
+                      "33433059486757"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000003"
+                  },
+                  "sort": [
+                    "aJSF 85-437 v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3 v. (loose-leaf) : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Loose-leaves for updating.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Computer programs",
+            "Computer programs -- Directories",
+            "Microcomputers",
+            "Microcomputers -- Programming",
+            "Microcomputers -- Programming -- Directories",
+            "Programming languages (Electronic computers)",
+            "Programming languages (Electronic computers) -- Directories"
+          ],
+          "publisherLiteral": [
+            "Datapro Research Corp.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Datapro directory of microcomputer software"
+          ],
+          "shelfMark": [
+            "JSF 85-438"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "contributorLiteral": [
+            "Datapro Research Corporation.",
+            "Muldowney, William J."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 85-438"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009050"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209025"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636086399858,
+          "publicationStatement": [
+            "Delran, N.J. : Datapro Research Corp., c1985-"
+          ],
+          "identifier": [
+            "urn:bnum:10009050",
+            "urn:undefined:NNSZ00810571",
+            "urn:undefined:(WaOLN)nyp0209025"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Computer programs -- Directories.",
+            "Microcomputers -- Programming -- Directories.",
+            "Programming languages (Electronic computers) -- Directories."
+          ],
+          "titleDisplay": [
+            "Datapro directory of microcomputer software / managing editor, William J. Muldowney."
+          ],
+          "uri": "b10009050",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Delran, N.J. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Directory of microcomputer software.",
+            "Microcomputer software."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10009050"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540493",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-438 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-438 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693870"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693870"
+                    ],
+                    "idBarcode": [
+                      "33433037693870"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000001"
+                  },
+                  "sort": [
+                    "aJSF 85-438 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785403",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-438 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-438 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486450"
+                    ],
+                    "idBarcode": [
+                      "33433059486450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000002"
+                  },
+                  "sort": [
+                    "aJSF 85-438 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785404",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 85-438 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 85-438 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486724"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486724"
+                    ],
+                    "idBarcode": [
+                      "33433059486724"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000003"
+                  },
+                  "sort": [
+                    "aJSF 85-438 v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009141",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "viṟpaṉai urimai: Pāri Nilaiyam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ilakkaṇat tokai."
+          ],
+          "shelfMark": [
+            "*OLB 85-879"
+          ],
+          "creatorLiteral": [
+            "Subramanian, S. V."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75910470"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 85-879"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009141"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75910470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810664"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636105084628,
+          "publicationStatement": [
+            "Ceṉṉai, viṟpaṉai urimai: Pāri Nilaiyam, 1967-"
+          ],
+          "identifier": [
+            "urn:bnum:10009141",
+            "urn:lccn:75910470",
+            "urn:undefined:NNSZ00810664",
+            "urn:undefined:(WaOLN)nyp0209116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Ilakkaṇat tokai. [Tokuppāciriyar] Ca. Vē. Cuppiramaṇiyaṉ."
+          ],
+          "uri": "b10009141",
+          "lccClassification": [
+            "PL4754 .S78"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Eḻuttu. -- 2. Col."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10009141"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785410",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 85-879 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 85-879 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061304857"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 85-879"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061304857"
+                    ],
+                    "idBarcode": [
+                      "33433061304857"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 85-879 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLB 85-879 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785411",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 85-879 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 85-879 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061304865"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 85-879"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061304865"
+                    ],
+                    "idBarcode": [
+                      "33433061304865"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 85-879 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLB 85-879 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009318",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10 v. in 7."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Villiputtūrār iyaṟṟiya Makāpāratam; Vai. Mu. Kōpālakiruṣṇamācāriyar iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLY 87-5294"
+          ],
+          "creatorLiteral": [
+            "Kōpāla Kiruṣṇamācāryar, Vai. Mu., 1882-1956."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "76909632"
+          ],
+          "contributorLiteral": [
+            "Kiruṣṇamācāriyar, C.",
+            "Villiputtūrāḻvār."
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 87-5294"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009318"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76909632"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00910847"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209293"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636142083541,
+          "publicationStatement": [
+            "Ceṉṉai, 1960-1968 [v.1. 1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10009318",
+            "urn:lccn:76909632",
+            "urn:undefined:NNSZ00910847",
+            "urn:undefined:(WaOLN)nyp0209293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Villiputtūrār iyaṟṟiya Makāpāratam; Vai. Mu. Kōpālakiruṣṇamācāriyar iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "uri": "b10009318",
+          "lccClassification": [
+            "PL4758.9.V492 V534 1960"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10009318"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785434",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585319"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585319"
+                    ],
+                    "idBarcode": [
+                      "33433059585319"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785435",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585327"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585327"
+                    ],
+                    "idBarcode": [
+                      "33433059585327"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785436",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585335"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585335"
+                    ],
+                    "idBarcode": [
+                      "33433059585335"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585343"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585343"
+                    ],
+                    "idBarcode": [
+                      "33433059585343"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785438",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585350"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585350"
+                    ],
+                    "idBarcode": [
+                      "33433059585350"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785439",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 6-8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 6-8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6-8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585368"
+                    ],
+                    "idBarcode": [
+                      "33433059585368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000006-8"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000006-8"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785440",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 9-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 9-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585376"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585376"
+                    ],
+                    "idBarcode": [
+                      "33433059585376"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000009-10"
+                  },
+                  "sort": [
+                    "a*OLY 87-5294 v. 000009-10"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009600",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill.,"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Uchebnik Kir. ︠i︡azyka dl︠i︡a trudovykh shkol.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 1685.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kirghiz.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kyrgyz language",
+            "Kyrgyz language -- Textbooks for foreign speakers",
+            "Kyrgyz language -- Textbooks for foreign speakers -- Russian",
+            "Kyrgyz language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Qïrghïzïstan Memleket Basmasï,"
+          ],
+          "language": [
+            {
+              "id": "lang:kir",
+              "label": "Kyrgyz"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1930
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Orus emgek mektebteri ycyn qïrghïz tilinin oquu kitebi [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-258 no. 1"
+          ],
+          "creatorLiteral": [
+            "Çangïbajuluu, M."
+          ],
+          "createdString": [
+            "1930"
+          ],
+          "dateStartYear": [
+            1930
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-258 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009600"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911072"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209576"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636120403509,
+          "publicationStatement": [
+            "Prunza : Qïrghïzïstan Memleket Basmasï, 1930-"
+          ],
+          "identifier": [
+            "urn:bnum:10009600",
+            "urn:undefined:NNSZ00911072",
+            "urn:undefined:(WaOLN)nyp0209576"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1930"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kyrgyz language -- Textbooks for foreign speakers -- Russian.",
+            "Kyrgyz language -- Texts."
+          ],
+          "titleDisplay": [
+            "Orus emgek mektebteri ycyn qïrghïz tilinin oquu kitebi [microform] / M. Çangïbaj uluu."
+          ],
+          "uri": "b10009600",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prunza :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Uchebnik kirgizskogo ︠i︡azyka dl︠i︡a trudovykh shkol."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10009600"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30068355",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-258, no. 1 no. 1-22"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-258, no. 1 no. 1-22",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105667400"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-258, no. 1"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-22"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105667400"
+                    ],
+                    "idBarcode": [
+                      "33433105667400"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-258, no. 000001 no. 1-22"
+                  },
+                  "sort": [
+                    "a*ZO-258, no. 000001 no. 1-22"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009763",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., facsims., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Suppl. 2 has title: Book of Jared; vol. 3 (the second supplement), continuing the record of descedants of John Jared (1837 [sic]-1805) and his wives Hannah Whitacre and Rachel Palmer.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jared family",
+            "Jared, John, 1737-1805",
+            "Jared, John, 1737-1805 -- Family"
+          ],
+          "publisherLiteral": [
+            "E. M. Hall,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The book of Jared supplement[s] : a family record showing descendants of John Jared, 1737-1805, Hannah Whitacre, Rachel Palmer"
+          ],
+          "shelfMark": [
+            "APV (Jared) 85-2860 Suppl."
+          ],
+          "creatorLiteral": [
+            "Hall, Eleanor McAllister, 1910-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APV (Jared) 85-2860 Suppl."
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009763"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911239"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209739"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636133579155,
+          "publicationStatement": [
+            "Salt Lake City, Utah (7234 So. 2825 East, Salt Lake City 84121) : E. M. Hall, c1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10009763",
+            "urn:undefined:NNSZ00911239",
+            "urn:undefined:(WaOLN)nyp0209739"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jared family.",
+            "Jared, John, 1737-1805 -- Family."
+          ],
+          "titleDisplay": [
+            "The book of Jared supplement[s] : a family record showing descendants of John Jared, 1737-1805, Hannah Whitacre, Rachel Palmer / [compiled by Eleanor M. Hall]."
+          ],
+          "uri": "b10009763",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Salt Lake City, Utah (7234 So. 2825 East, Salt Lake City 84121) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10009763"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160137"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2"
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160137"
+                    ],
+                    "idBarcode": [
+                      "33433093160137"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. "
+                  },
+                  "sort": [
+                    "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. "
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27564640",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160145"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160145"
+                    ],
+                    "idBarcode": [
+                      "33433093160145"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000001"
+                  },
+                  "sort": [
+                    "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27564651",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160152"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160152"
+                    ],
+                    "idBarcode": [
+                      "33433093160152"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000002"
+                  },
+                  "sort": [
+                    "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009901",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Paging in reverse.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Ansaru Allah Community],"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The holy Qur'an : the last testament"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .K786"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "seriesStatement": [
+            "Edition; 41-",
+            "Nubian Islamic Hebrews. Edition 41-"
+          ],
+          "contributorLiteral": [
+            "ʻIsá Abd Allāh Muḥammad al-Mahdī, 1945-"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .K786"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009901"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209877"
+            }
+          ],
+          "uniformTitle": [
+            "Qurʼan. English & Arabic."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1143677",
+              "shelfMark": [
+                "Sc Ser.-M .K786"
+              ]
+            }
+          ],
+          "updatedAt": 1636124772949,
+          "publicationStatement": [
+            "[Brooklyn, N.Y.] : Ansaru Allah Community], 1977-"
+          ],
+          "identifier": [
+            "urn:bnum:10009901",
+            "urn:undefined:(WaOLN)nyp0209877"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The holy Qur'an : the last testament / English translation and commentary by Al Hajj Al Imam Isa Abd'Allah Muhammad al Mahdi."
+          ],
+          "uri": "b10009901",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Brooklyn, N.Y.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10009901"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .K786 v. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .K786 v. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433070348341"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .K786"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433070348341"
+                    ],
+                    "idBarcode": [
+                      "33433070348341"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .K786 v. 000001-3"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .K786 v. 000001-3"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010070",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Supplement",
+              "label": "Issues for 1968-69 include supplement: Quality.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by the institute in collaboration with the General Confederation of Italian Industry.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Fall 1958-"
+          ],
+          "subjectLiteral_exploded": [
+            "Industries",
+            "Industries -- Italy",
+            "Industries -- Italy -- Periodicals",
+            "Italy",
+            "Italy -- Commerce",
+            "Italy -- Commerce -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Istituto Nazionale per il Commercio Estero,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1958
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Italy presents."
+          ],
+          "shelfMark": [
+            "JLM 81-304"
+          ],
+          "createdString": [
+            "1958"
+          ],
+          "idLccn": [
+            "63053813"
+          ],
+          "idIssn": [
+            "0021-3160"
+          ],
+          "contributorLiteral": [
+            "Confederazione generale dell'industria italiana.",
+            "Istituto nazionale per il commercio estero (Italy)"
+          ],
+          "dateStartYear": [
+            1958
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-304"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010070"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0021-3160"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "63053813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1754066"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210046"
+            }
+          ],
+          "idOclc": [
+            "1754066"
+          ],
+          "uniformTitle": [
+            "Quality."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1646404667885,
+          "publicationStatement": [
+            "Rome : Istituto Nazionale per il Commercio Estero, 1958-"
+          ],
+          "identifier": [
+            "urn:bnum:10010070",
+            "urn:issn:0021-3160",
+            "urn:lccn:63053813",
+            "urn:oclc:1754066",
+            "urn:undefined:(WaOLN)nyp0210046"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1958"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Industries -- Italy -- Periodicals.",
+            "Italy -- Commerce -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Italy presents."
+          ],
+          "uri": "b10010070",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "Rome :"
+          ],
+          "titleAlt": [
+            "Italian trade magazine."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10010070"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540519",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-304 1967-1969"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-304 1967-1969",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017526942"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-304"
+                    ],
+                    "enumerationChronology": [
+                      "1967-1969"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017526942"
+                    ],
+                    "idBarcode": [
+                      "33433017526942"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-304 1967-001969"
+                  },
+                  "sort": [
+                    "aJLM 81-304 1967-001969"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540520",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-304 1970-1972"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-304 1970-1972",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017526959"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-304"
+                    ],
+                    "enumerationChronology": [
+                      "1970-1972"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017526959"
+                    ],
+                    "idBarcode": [
+                      "33433017526959"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-304 1970-001972"
+                  },
+                  "sort": [
+                    "aJLM 81-304 1970-001972"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010482",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., facsims., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "K.A.R.D.: Karow, Adamson, Rubidoux, Dye--V. 2, Pref.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 12 published in Kent, Washington.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 12: \"John A. & Judy K. Dye.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Adams family"
+          ],
+          "publisherLiteral": [
+            "J. Dye,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The K.A.R.D. files--Adamson ancestry"
+          ],
+          "shelfMark": [
+            "APV (Adamson) 85-544"
+          ],
+          "creatorLiteral": [
+            "Dye, John."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "contributorLiteral": [
+            "Dye, Judy."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APV (Adamson) 85-544"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010482"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210458"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1-12-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 13",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                }
+              ],
+              "physicalLocation": [
+                "APV (Adamson) 85-544 Library has: Vol. 1-13."
+              ],
+              "location": [
+                {
+                  "code": "loc:mag",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "uri": "h1031668",
+              "shelfMark": [
+                "APV (Adamson) 85-544 Library has: Vol. 1-13."
+              ]
+            }
+          ],
+          "updatedAt": 1636135853428,
+          "publicationStatement": [
+            "Spokane, Wash. : J. Dye, [1982]-"
+          ],
+          "identifier": [
+            "urn:bnum:10010482",
+            "urn:undefined:(WaOLN)nyp0210458"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Adams family."
+          ],
+          "titleDisplay": [
+            "The K.A.R.D. files--Adamson ancestry / John and Judy Dye."
+          ],
+          "uri": "b10010482",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Spokane, Wash. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "KARD files--Adamson ancestry."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10010482"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544 v. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544 v. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335046"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335046"
+                    ],
+                    "idBarcode": [
+                      "33433091335046"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000001-3"
+                  },
+                  "sort": [
+                    "aAPV (Adamson) 85-544 v. 000001-3"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26428927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544  v. 4-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544  v. 4-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544 "
+                    ],
+                    "enumerationChronology": [
+                      "v. 4-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335053"
+                    ],
+                    "idBarcode": [
+                      "33433091335053"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000004-9"
+                  },
+                  "sort": [
+                    "aAPV (Adamson) 85-544 v. 000004-9"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26428980",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544 v. 10-13 (Mar. 1989-Sept. 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544 v. 10-13 (Mar. 1989-Sept. 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335061"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10-13 (Mar. 1989-Sept. 1996)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335061"
+                    ],
+                    "idBarcode": [
+                      "33433091335061"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000010-13 (Mar. 1989-Sept. 1996)"
+                  },
+                  "sort": [
+                    "aAPV (Adamson) 85-544 v. 000010-13 (Mar. 1989-Sept. 1996)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010483",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "vol. 1-2: \"July 18, 1941.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Church records and registers",
+            "Church records and registers -- Herkimer",
+            "Church records and registers -- Herkimer -- Indexes",
+            "Herkimer (N.Y.)",
+            "Herkimer (N.Y.) -- Genealogy",
+            "Herkimer (N.Y.) -- Genealogy -- Indexes",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.)"
+          ],
+          "publisherLiteral": [
+            "The Dept.],"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1941
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Index of records Reformed Protestant Dutch Church of Herkimer"
+          ],
+          "shelfMark": [
+            "APR (Herkimer, N.Y.) 85-424 Index"
+          ],
+          "createdString": [
+            "1941"
+          ],
+          "contributorLiteral": [
+            "Montgomery County (N.Y.). Dept. of History and Archives.",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.). Records of the Reformed Protestant Dutch Church of Herkimer in the Town of Herkimer, Herkimer County, N.Y."
+          ],
+          "dateStartYear": [
+            1941
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APR (Herkimer, N.Y.) 85-424 Index"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010483"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01012132"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210459"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636105431482,
+          "publicationStatement": [
+            "[New York : The Dept.], 1941-"
+          ],
+          "identifier": [
+            "urn:bnum:10010483",
+            "urn:undefined:NNSZ01012132",
+            "urn:undefined:(WaOLN)nyp0210459"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1941"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Church records and registers -- Herkimer -- Indexes.",
+            "Herkimer (N.Y.) -- Genealogy -- Indexes.",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.)"
+          ],
+          "titleDisplay": [
+            "Index of records Reformed Protestant Dutch Church of Herkimer / compiled by the Montgomery Department of History and Archives."
+          ],
+          "uri": "b10010483",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10010483"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901094",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Herkimer, N.Y.) 85-424 Index v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Herkimer, N.Y.) 85-424 Index v. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032068110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Herkimer, N.Y.) 85-424 Index"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032068110"
+                    ],
+                    "idBarcode": [
+                      "33433032068110"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Herkimer, N.Y.) 85-424 Index v. 000001-2"
+                  },
+                  "sort": [
+                    "aAPR (Herkimer, N.Y.) 85-424 Index v. 000001-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24831672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Herkimer, N.Y.) 85-424 Index v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Herkimer, N.Y.) 85-424 Index v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085274375"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Herkimer, N.Y.) 85-424 Index"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085274375"
+                    ],
+                    "idBarcode": [
+                      "33433085274375"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Herkimer, N.Y.) 85-424 Index v. 000002"
+                  },
+                  "sort": [
+                    "aAPR (Herkimer, N.Y.) 85-424 Index v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010674",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Italian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "anno 1-    magg./giugno 1977-"
+          ],
+          "subjectLiteral_exploded": [
+            "Music",
+            "Music -- Periodicals",
+            "Sound recordings",
+            "Sound recordings -- Reviews"
+          ],
+          "publisherLiteral": [
+            "Ed. Diapason Milano]"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica."
+          ],
+          "shelfMark": [
+            "*LA 81-296"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "79649506 /MN"
+          ],
+          "idIssn": [
+            "0392-5544"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LA 81-296"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010674"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0392-5544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79649506 /MN"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5909505"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000035"
+            }
+          ],
+          "idOclc": [
+            "5909505"
+          ],
+          "uniformTitle": [
+            "Musica (Milan, Italy)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1:1(May/Jun 1977)-12:53(Dec/Jan 1988/89),13:55(Apr/May 1989)-21:105(Oct/Dec 1997)-25:132(Dec 2001/Jan 2002),27:165(Apr 2005)-32:212(Dec/Jan 2010)",
+                "v. 32, no. 213 (2010-02) - v. 38, no. 269 (2015-09); v. 38, no. 271 (2015-11) - v. 40, no. 294 (2018-03); v. 41, no. 296 (2018-05) - v. 42, no. 332 (2021-11)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 41 No. 304 (Mar. 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 305 (Apr. 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 306 (May. 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 307 (Jun. 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 308 (Jul. 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 309 (Sep. 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 310 (Oct. 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 311 (Nov. 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 312 (Dec. 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 313 (Feb. 2020)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 314 (Mar. 2020)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 315 (Apr. 2020)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 316 (May. 2020)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 317 (Jun. 2020)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 318 (Jul. 2020)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 319 (Sep. 2020)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 320 (Oct. 2020)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 321 (Nov. 2020)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 322 (Dec. 2020)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 323 (Feb. 2021)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 324 (Mar. 2021)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 325 (Apr. 2021)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 326 (May. 2021)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 327 (Jun. 2021)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 328 (Jul. 2021)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 329 (Sep. 2021)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 330 (Oct. 2021)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 331 (Oct. 2021)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 332 (Nov. 2021)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 333 (Dec. 2021)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 334 (Jan. 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 335 (Feb. 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 336 (Mar. 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 337 (Apr. 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 338 (May. 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 339 (Jun. 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 340 (Jul. 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 341 (Aug. 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*LA 81-296"
+                }
+              ],
+              "notes": [
+                "CURRENT ISSUES IN R&H ARCHIVES"
+              ],
+              "physicalLocation": [
+                "*LA 81-296"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:myh",
+                  "label": "Performing Arts Research Collections - Recorded Sound"
+                }
+              ],
+              "uri": "h1036576",
+              "shelfMark": [
+                "*LA 81-296"
+              ]
+            }
+          ],
+          "updatedAt": 1644517240167,
+          "publicationStatement": [
+            "[Milano, Ed. Diapason Milano]"
+          ],
+          "identifier": [
+            "urn:bnum:10010674",
+            "urn:issn:0392-5544",
+            "urn:lccn:79649506 /MN",
+            "urn:oclc:5909505",
+            "urn:undefined:(WaOLN)nyp0000035"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music -- Periodicals.",
+            "Sound recordings -- Reviews."
+          ],
+          "titleDisplay": [
+            "Musica."
+          ],
+          "uri": "b10010674",
+          "lccClassification": [
+            "ML5 .M713595"
+          ],
+          "numItems": [
+            67
+          ],
+          "numAvailable": [
+            67
+          ],
+          "placeOfPublication": [
+            "[Milano,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10010674"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 67,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547826",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479813"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479813"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433064479813"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296"
+                    ],
+                    "shelfMark_sort": "a*LA 81-000296"
+                  },
+                  "sort": [
+                    "a*LA 81-000296"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547819",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479805"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479805"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433064479805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296"
+                    ],
+                    "shelfMark_sort": "a*LA 81-000296"
+                  },
+                  "sort": [
+                    "a*LA 81-000296"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547828",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479821"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479821"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433064479821"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296"
+                    ],
+                    "shelfMark_sort": "a*LA 81-000296"
+                  },
+                  "sort": [
+                    "a*LA 81-000296"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858857",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654198"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1980"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654198"
+                    ],
+                    "idBarcode": [
+                      "33433018654198"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001980"
+                  },
+                  "sort": [
+                    "a*LA 81-296 001980"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858858",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654073"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1981"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654073"
+                    ],
+                    "idBarcode": [
+                      "33433018654073"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001981"
+                  },
+                  "sort": [
+                    "a*LA 81-296 001981"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1982",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654560"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1982"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654560"
+                    ],
+                    "idBarcode": [
+                      "33433018654560"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001982"
+                  },
+                  "sort": [
+                    "a*LA 81-296 001982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858860",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1983"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1983",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654446"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1983"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654446"
+                    ],
+                    "idBarcode": [
+                      "33433018654446"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001983"
+                  },
+                  "sort": [
+                    "a*LA 81-296 001983"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1998"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1998",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022582096"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1998"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022582096"
+                    ],
+                    "idBarcode": [
+                      "33433022582096"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001998"
+                  },
+                  "sort": [
+                    "a*LA 81-296 001998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858856",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1977-1979"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1977-1979",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654313"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "1977-1979"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654313"
+                    ],
+                    "idBarcode": [
+                      "33433018654313"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 1977-001979"
+                  },
+                  "sort": [
+                    "a*LA 81-296 1977-001979"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858868",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Apr. 1989 - Jan. 1990"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Apr. 1989 - Jan. 1990",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654099"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Apr. 1989 - Jan. 1990"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654099"
+                    ],
+                    "idBarcode": [
+                      "33433018654099"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Apr. 1989 - Jan. 001990"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Apr. 1989 - Jan. 001990"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858867",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1988 - Jan. 1989"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1988 - Jan. 1989",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1988 - Jan. 1989"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654214"
+                    ],
+                    "idBarcode": [
+                      "33433018654214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1988 - Jan. 001989"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1988 - Jan. 001989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858870",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1990 - Jan. 1991"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1990 - Jan. 1991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654461"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1990 - Jan. 1991"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654461"
+                    ],
+                    "idBarcode": [
+                      "33433018654461"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1990 - Jan. 001991"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1990 - Jan. 001991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1991 - Jan. 1992"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1991 - Jan. 1992",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1991 - Jan. 1992"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654222"
+                    ],
+                    "idBarcode": [
+                      "33433018654222"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1991 - Jan. 001992"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1991 - Jan. 001992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858874",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1992 - Jan. 1993"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1992 - Jan. 1993",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654594"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1992 - Jan. 1993"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654594"
+                    ],
+                    "idBarcode": [
+                      "33433018654594"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1992 - Jan. 001993"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1992 - Jan. 001993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858876",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1993 - Jan. 1994"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1993 - Jan. 1994",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654354"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1993 - Jan. 1994"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654354"
+                    ],
+                    "idBarcode": [
+                      "33433018654354"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1993 - Jan. 001994"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1993 - Jan. 001994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858878",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1994 - Jan. 1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1994 - Jan. 1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654115"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1994 - Jan. 1995"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654115"
+                    ],
+                    "idBarcode": [
+                      "33433018654115"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1994 - Jan. 001995"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1994 - Jan. 001995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858880",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1995 - Jan. 1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1995 - Jan. 1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654487"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1995 - Jan. 1996"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654487"
+                    ],
+                    "idBarcode": [
+                      "33433018654487"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1995 - Jan. 001996"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1995 - Jan. 001996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858882",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1996 - Jan. 1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1996 - Jan. 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654248"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1996 - Jan. 1997"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654248"
+                    ],
+                    "idBarcode": [
+                      "33433018654248"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1996 - Jan. 001997"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Aug. 1996 - Jan. 001997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858883",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-Dec. 1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-Dec. 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654123"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-Dec. 1997"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654123"
+                    ],
+                    "idBarcode": [
+                      "33433018654123"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-Dec. 001997"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-Dec. 001997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858866",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1988"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1988",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654339"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1988"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654339"
+                    ],
+                    "idBarcode": [
+                      "33433018654339"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001988"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858869",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1990"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1990",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654586"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1990"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654586"
+                    ],
+                    "idBarcode": [
+                      "33433018654586"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001990"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001990"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858871",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1991"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654347"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1991"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654347"
+                    ],
+                    "idBarcode": [
+                      "33433018654347"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001991"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858873",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1992"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1992",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654107"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1992"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654107"
+                    ],
+                    "idBarcode": [
+                      "33433018654107"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001992"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858875",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1993"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1993",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654479"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1993"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654479"
+                    ],
+                    "idBarcode": [
+                      "33433018654479"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001993"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858877",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1994"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1994",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654230"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1994"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654230"
+                    ],
+                    "idBarcode": [
+                      "33433018654230"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001994"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858879",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654602"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1995"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654602"
+                    ],
+                    "idBarcode": [
+                      "33433018654602"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001995"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858881",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654362"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1996"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654362"
+                    ],
+                    "idBarcode": [
+                      "33433018654362"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001996"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Feb.-July 001996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858861",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Index (1977-1983)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Index (1977-1983)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654321"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Index (1977-1983)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654321"
+                    ],
+                    "idBarcode": [
+                      "33433018654321"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Index (1977-1983)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Index (1977-1983)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858862",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654206"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1984"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654206"
+                    ],
+                    "idBarcode": [
+                      "33433018654206"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001984"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Mar.-Dec. 001984"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858863",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1985"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1985",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654081"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1985"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654081"
+                    ],
+                    "idBarcode": [
+                      "33433018654081"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001985"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Mar.-Dec. 001985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858864",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654578"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1986"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654578"
+                    ],
+                    "idBarcode": [
+                      "33433018654578"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001986"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Mar.-Dec. 001986"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858865",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1987"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1987",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654453"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1987"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654453"
+                    ],
+                    "idBarcode": [
+                      "33433018654453"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001987"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Mar.-Dec. 001987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022619146"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 116-121 (Feb.-Nov. 2000)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022619146"
+                    ],
+                    "idBarcode": [
+                      "33433022619146"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785676",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022621456"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 122-126 (Dec. 2000 - May 2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022621456"
+                    ],
+                    "idBarcode": [
+                      "33433022621456"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785677",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 127-131 (June-Nov. 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 127-131 (June-Nov. 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022621332"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 127-131 (June-Nov. 2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022621332"
+                    ],
+                    "idBarcode": [
+                      "33433022621332"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 127-131 (June-Nov. 2001)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Nos. 127-131 (June-Nov. 2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064452513"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064452513"
+                    ],
+                    "idBarcode": [
+                      "33433064452513"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747162",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 137-141 (June-Nov. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 137-141 (June-Nov. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064452521"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 137-141 (June-Nov. 2002)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064452521"
+                    ],
+                    "idBarcode": [
+                      "33433064452521"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 137-141 (June-Nov. 2002)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 Nos. 137-141 (June-Nov. 2002)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747163",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470549"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470549"
+                    ],
+                    "idBarcode": [
+                      "33433064470549"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000025, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000025, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747164",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 26, nos. 146-150 (May-Oct. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 26, nos. 146-150 (May-Oct. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 26, nos. 146-150 (May-Oct. 2003)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470556"
+                    ],
+                    "idBarcode": [
+                      "33433064470556"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000026, nos. 146-150 (May-Oct. 2003)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000026, nos. 146-150 (May-Oct. 2003)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747165",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470564"
+                    ],
+                    "idBarcode": [
+                      "33433064470564"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000026, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000026, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 27, nos. 156-160 (May-Oct. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 27, nos. 156-160 (May-Oct. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064471521"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27, nos. 156-160 (May-Oct. 2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064471521"
+                    ],
+                    "idBarcode": [
+                      "33433064471521"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000027, nos. 156-160 (May-Oct. 2004)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000027, nos. 156-160 (May-Oct. 2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656928",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064471539"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064471539"
+                    ],
+                    "idBarcode": [
+                      "33433064471539"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000027, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000027, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656930",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 28, nos. 166-170 (Mar. - Oct. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 28, nos. 166-170 (Mar. - Oct. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075624639"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 28, nos. 166-170 (Mar. - Oct. 2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075624639"
+                    ],
+                    "idBarcode": [
+                      "33433075624639"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000028, nos. 166-170 (Mar. - Oct. 2005)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000028, nos. 166-170 (Mar. - Oct. 2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656929",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075624647"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075624647"
+                    ],
+                    "idBarcode": [
+                      "33433075624647"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000028, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000028, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 29, nos. 176-182 (May 2006-Jan. 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 29, nos. 176-182 (May 2006-Jan. 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073125134"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 29, nos. 176-182 (May 2006-Jan. 2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073125134"
+                    ],
+                    "idBarcode": [
+                      "33433073125134"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000029, nos. 176-182 (May 2006-Jan. 2007)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000029, nos. 176-182 (May 2006-Jan. 2007)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447363",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 29-30, nos. 183-187 (Feb.-June 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 29-30, nos. 183-187 (Feb.-June 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073125142"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 29-30, nos. 183-187 (Feb.-June 2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073125142"
+                    ],
+                    "idBarcode": [
+                      "33433073125142"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000029-30, nos. 183-187 (Feb.-June 2007)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000029-30, nos. 183-187 (Feb.-June 2007)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189796",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 30, nos. 188-192 (July 2007-Jan. 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 30, nos. 188-192 (July 2007-Jan. 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824939"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30, nos. 188-192 (July 2007-Jan. 2008)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824939"
+                    ],
+                    "idBarcode": [
+                      "33433060824939"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000030, nos. 188-192 (July 2007-Jan. 2008)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000030, nos. 188-192 (July 2007-Jan. 2008)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189797",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 30-31, nos. 193-197 (Feb.-June 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 30-31, nos. 193-197 (Feb.-June 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824947"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30-31, nos. 193-197 (Feb.-June 2008)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824947"
+                    ],
+                    "idBarcode": [
+                      "33433060824947"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000030-31, nos. 193-197 (Feb.-June 2008)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000030-31, nos. 193-197 (Feb.-June 2008)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189798",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 31, nos. 198-202 (July 2008-Jan. 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 31, nos. 198-202 (July 2008-Jan. 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824954"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 31, nos. 198-202 (July 2008-Jan. 2009)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824954"
+                    ],
+                    "idBarcode": [
+                      "33433060824954"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000031, nos. 198-202 (July 2008-Jan. 2009)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000031, nos. 198-202 (July 2008-Jan. 2009)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 31-32, nos. 203-207 (Feb.-June 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 31-32, nos. 203-207 (Feb.-June 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091153"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 31-32, nos. 203-207 (Feb.-June 2009)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091153"
+                    ],
+                    "idBarcode": [
+                      "33433073091153"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000031-32, nos. 203-207 (Feb.-June 2009)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000031-32, nos. 203-207 (Feb.-June 2009)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 50
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799021",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 32, nos. 208-212 (July 2009-Jan. 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 32, nos. 208-212 (July 2009-Jan. 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091161"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 32, nos. 208-212 (July 2009-Jan. 2010)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091161"
+                    ],
+                    "idBarcode": [
+                      "33433073091161"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000032, nos. 208-212 (July 2009-Jan. 2010)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000032, nos. 208-212 (July 2009-Jan. 2010)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 32-33, nos. 213-217 (Feb.-June 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 32-33, nos. 213-217 (Feb.-June 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091179"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 32-33, nos. 213-217 (Feb.-June 2010)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091179"
+                    ],
+                    "idBarcode": [
+                      "33433073091179"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000032-33, nos. 213-217 (Feb.-June 2010)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000032-33, nos. 213-217 (Feb.-June 2010)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 33, nos. 218-222 (July 2010-Jan. 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 33, nos. 218-222 (July 2010-Jan. 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091187"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 33, nos. 218-222 (July 2010-Jan. 2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091187"
+                    ],
+                    "idBarcode": [
+                      "33433073091187"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000033, nos. 218-222 (July 2010-Jan. 2011)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000033, nos. 218-222 (July 2010-Jan. 2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 33-34, nos. 223-227 (Feb.-June 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 33-34, nos. 223-227 (Feb.-June 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091195"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 33-34, nos. 223-227 (Feb.-June 2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091195"
+                    ],
+                    "idBarcode": [
+                      "33433073091195"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000033-34, nos. 223-227 (Feb.-June 2011)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000033-34, nos. 223-227 (Feb.-June 2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163856",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 34, nos. 228-232 (July 2011-Jan. 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 34, nos. 228-232 (July 2011-Jan. 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468618"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 34, nos. 228-232 (July 2011-Jan. 2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468618"
+                    ],
+                    "idBarcode": [
+                      "33433064468618"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000034, nos. 228-232 (July 2011-Jan. 2012)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000034, nos. 228-232 (July 2011-Jan. 2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 34-35, nos. 233-237 (Feb.-June 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 34-35, nos. 233-237 (Feb.-June 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468626"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 34-35, nos. 233-237 (Feb.-June 2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468626"
+                    ],
+                    "idBarcode": [
+                      "33433064468626"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000034-35, nos. 233-237 (Feb.-June 2012)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000034-35, nos. 233-237 (Feb.-June 2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163863",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 35, nos. 238-242 (July 2012-Jan. 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 35, nos. 238-242 (July 2012-Jan. 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468634"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35, nos. 238-242 (July 2012-Jan. 2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468634"
+                    ],
+                    "idBarcode": [
+                      "33433064468634"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000035, nos. 238-242 (July 2012-Jan. 2013)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000035, nos. 238-242 (July 2012-Jan. 2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163867",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 35-36, nos. 243-247 (Feb.-June 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 35-36, nos. 243-247 (Feb.-June 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468642"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-36, nos. 243-247 (Feb.-June 2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468642"
+                    ],
+                    "idBarcode": [
+                      "33433064468642"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000035-36, nos. 243-247 (Feb.-June 2013)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000035-36, nos. 243-247 (Feb.-June 2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627409",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 37-38, nos. 263-267 (Feb.-June 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 37-38, nos. 263-267 (Feb.-June 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416361"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 37-38, nos. 263-267 (Feb.-June 2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416361"
+                    ],
+                    "idBarcode": [
+                      "33433104416361"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000037-38, nos. 263-267 (Feb.-June 2015)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000037-38, nos. 263-267 (Feb.-June 2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627460",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416379"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416379"
+                    ],
+                    "idBarcode": [
+                      "33433104416379"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000038, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000038, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627481",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 38-39, nos. 273-277 (Feb.-June 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 38-39, nos. 273-277 (Feb.-June 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416387"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38-39, nos. 273-277 (Feb.-June 2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416387"
+                    ],
+                    "idBarcode": [
+                      "33433104416387"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000038-39, nos. 273-277 (Feb.-June 2016)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000038-39, nos. 273-277 (Feb.-June 2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369420",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 39, nos. 278-282 (July 2016-Jan. 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 39, nos. 278-282 (July 2016-Jan. 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987532"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 39, nos. 278-282 (July 2016-Jan. 2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987532"
+                    ],
+                    "idBarcode": [
+                      "33433108987532"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000039, nos. 278-282 (July 2016-Jan. 2017)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000039, nos. 278-282 (July 2016-Jan. 2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 39-40, nos. 283-287 (Feb.-June 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 39-40, nos. 283-287 (Feb.-June 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987540"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 39-40, nos. 283-287 (Feb.-June 2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987540"
+                    ],
+                    "idBarcode": [
+                      "33433108987540"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000039-40, nos. 283-287 (Feb.-June 2017)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000039-40, nos. 283-287 (Feb.-June 2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 40, nos. 288-292 (July 2017-Jan. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 40, nos. 288-292 (July 2017-Jan. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987557"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40, nos. 288-292 (July 2017-Jan. 2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987557"
+                    ],
+                    "idBarcode": [
+                      "33433108987557"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000040, nos. 288-292 (July 2017-Jan. 2018)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000040, nos. 288-292 (July 2017-Jan. 2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37372228",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987565"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987565"
+                    ],
+                    "idBarcode": [
+                      "33433108987565"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000040, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000040, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37372229",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987573"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "enumerationChronology": [
+                      "v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987573"
+                    ],
+                    "idBarcode": [
+                      "33433108987573"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000041, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                  },
+                  "sort": [
+                    "a*LA 81-296 v. 000041, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022619021"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-298"
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022619021"
+                    ],
+                    "idBarcode": [
+                      "33433022619021"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                  },
+                  "sort": [
+                    "a*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010676",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At head of title: No 704. Sénat. Année 1919. Session ordinaire ...",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "World War, 1914-1918"
+          ],
+          "publisherLiteral": [
+            "Impr. du Sénat,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1919
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rapport de la Commission d'enquête sur les faits de la guerre [microform]."
+          ],
+          "shelfMark": [
+            "*Z-3990 no. 9"
+          ],
+          "creatorLiteral": [
+            "France. Commission d'enquête sur les faits de la guerre."
+          ],
+          "createdString": [
+            "1919"
+          ],
+          "dateStartYear": [
+            1919
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3990 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010676"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "WWIa"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01112568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210652"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636125262067,
+          "publicationStatement": [
+            "Paris : Impr. du Sénat, 1919-"
+          ],
+          "identifier": [
+            "urn:bnum:10010676",
+            "urn:undefined:WWIa",
+            "urn:undefined:NNSZ01112568",
+            "urn:undefined:(WaOLN)nyp0210652"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1919"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "World War, 1914-1918."
+          ],
+          "titleDisplay": [
+            "Rapport de la Commission d'enquête sur les faits de la guerre [microform]."
+          ],
+          "uri": "b10010676",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v.1. Mémoire sur les responsabilités de la guerre/établi ... par Émile Bourgeois et Georges Pagès."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10010676"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24076474",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3990 no. 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3990 no. 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433106577558"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3990"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433106577558"
+                    ],
+                    "idBarcode": [
+                      "33433106577558"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3990 no. 000001-9"
+                  },
+                  "sort": [
+                    "a*Z-3990 no. 000001-9"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010704",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "World War, 1914-1918",
+            "World War, 1914-1918 -- Schools",
+            "World War, 1914-1918 -- Women"
+          ],
+          "publisherLiteral": [
+            "Govt. Print. Off.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "War work of women in colleges [microform]"
+          ],
+          "shelfMark": [
+            "*Z-4016 no. 7"
+          ],
+          "creatorLiteral": [
+            "United States. Committee on Public Information."
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "idLccn": [
+            "18026236"
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-4016 no. 7"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010704"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "18026236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "WWIa"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01112597"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210680"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143142429,
+          "publicationStatement": [
+            "Washington, Govt. Print. Off., 1918-"
+          ],
+          "identifier": [
+            "urn:bnum:10010704",
+            "urn:lccn:18026236",
+            "urn:undefined:WWIa",
+            "urn:undefined:NNSZ01112597",
+            "urn:undefined:(WaOLN)nyp0210680"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "World War, 1914-1918 -- Schools.",
+            "World War, 1914-1918 -- Women."
+          ],
+          "titleDisplay": [
+            "War work of women in colleges [microform] issued by the Committee on Public Information ..."
+          ],
+          "uri": "b10010704",
+          "lccClassification": [
+            "D639.W7 U5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10010704"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30102337",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-4016 no. 1-14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-4016 no. 1-14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433106577871"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-4016"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433106577871"
+                    ],
+                    "idBarcode": [
+                      "33433106577871"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-4016 no. 000001-14"
+                  },
+                  "sort": [
+                    "a*Z-4016 no. 000001-14"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-7b6e6ec126f3d1d563d59ea917fd2515.json
+++ b/test/fixtures/query-7b6e6ec126f3d1d563d59ea917fd2515.json
@@ -1,0 +1,905 @@
+{
+  "took": 26,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.2411,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.2411,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-81e8624b3b2218c64be9b9d517d20f25.json
+++ b/test/fixtures/query-81e8624b3b2218c64be9b9d517d20f25.json
@@ -1,0 +1,905 @@
+{
+  "took": 40,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.383019,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.383019,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-935bcc942d6c60e3f659a4a766990c6d.json
+++ b/test/fixtures/query-935bcc942d6c60e3f659a4a766990c6d.json
@@ -1,0 +1,11954 @@
+{
+  "took": 1043,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 17600234,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "publisherLiteral": [
+            "Stauffenburg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "contributorLiteral": [
+            "Baum, Richard.",
+            "Gmelin, Hermann, 1900-1958.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    "aJFE 86-003252"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Constable,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    "aJFF 89-000526"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    "a*OLB 84-001934"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "publisherLiteral": [
+            "Muzyka,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22,"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    "aJMF 83-000336"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām,"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    "a*OGC 84-001984"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar",
+            "Guitar -- Studies and exercises",
+            "Guitar music"
+          ],
+          "publisherLiteral": [
+            "Editio Musica,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar -- Studies and exercises.",
+            "Guitar music."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    "aJMG 83-000276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    "a*OLB 84-001986"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    "aJMG 83-000278"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    "a*OLB 84-001938"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Easter music (Organ)",
+            "Passion music",
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Boeijenga,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Easter music (Organ)",
+            "Passion music.",
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    "aJMG 83-000279"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    "a*OFS 84-001997"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    "aJMF 83-000366"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century",
+            "Panislamism"
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century.",
+            "Panislamism."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    "a*OGC 84-001996"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "American Music Collection."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    "a*OLB 84-001937"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    "aJMG 83-000395"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    "a*OFX 84-001995"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    "aJMG 83-000111"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLB 84-1936 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    "aJMG 83-000113"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "contributorLiteral": [
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952.",
+            "Peruntēvaṉār, active 11th century."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    "a*OLB 84-001935"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "publisherLiteral": [
+            "Shawnee Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    "aJMF 83-000038"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    "a*OFK 84-001944"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "Möseler,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    "aJMF 83-000107"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    "a*OFX 84-001953"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten,"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    "aJMF 83-000095"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama),"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    "a*OKTM 84-001945"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    "aJMF 83-000093"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "contributorLiteral": [
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Pāṇini.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-",
+            "Āpiśali.",
+            "Śākatāyana."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    "a*OKA 84-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "publisherLiteral": [
+            "W. Müller,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    "aJMG 83-000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    "a*OMP 84-002007"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ"
+          ],
+          "publisherLiteral": [
+            "Agápe,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Psalms (Music)",
+            "Sacred songs (Medium voice) with organ."
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    "aJMG 83-000059"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "contributorLiteral": [
+            "Agrawala, Prithvi Kumar.",
+            "Agrawala, Vasudeva Sharana.",
+            "Guṇāḍhya."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    "a*OKR 84-002006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade,"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    "aJMG 83-000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    "a*OKB 84-001928"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "publisherLiteral": [
+            "Donemus,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies,"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    "aJMG 83-000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    "a*OKP 84-001932"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "publisherLiteral": [
+            "C.F. Peters,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas,"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    "aJMG 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    "a*OLB 84-001947"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "publisherLiteral": [
+            "Primavera,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    "aJMF 83-000066"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    "a*OKN 84-001926"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    "aJMC 83-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884"
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Lamas -- Tibet -- Biography.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002361"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    "aJMG 82-000688"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries"
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Sa-skya-pa lamas -- Tibet -- Biography.",
+            "Tripiṭaka. -- Commentaries."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po.",
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002362"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    "aJMG 83-000079"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002382"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1643425443821,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    "aJMG 83-000080"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje,"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism.",
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    "a*OZ+ 82-002381"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik,"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "uniformTitle": [
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Den forsvundne.",
+            "Symphony, no. 2, op. 69c"
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    "aJMG 83-000075"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-94350e2a662ba0e00221dade56afbdfc.json
+++ b/test/fixtures/query-94350e2a662ba0e00221dade56afbdfc.json
@@ -1,0 +1,14 @@
+{
+  "took": 40,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 0,
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-a389c22c3188bb34ded53c845270959d.json
+++ b/test/fixtures/query-a389c22c3188bb34ded53c845270959d.json
@@ -1,0 +1,211 @@
+{
+  "took": 207,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 60.97598,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12709113",
+        "_score": 60.97598,
+        "_source": {
+          "extent": [
+            "iv, 350 p. : ill., port. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington County (Neb.)",
+            "Washington County (Neb.) -- History"
+          ],
+          "publisherLiteral": [
+            "Magic city printing co.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1937
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A history of Washington county, Nebraska"
+          ],
+          "shelfMark": [
+            "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+          ],
+          "creatorLiteral": [
+            "Shrader, Forrest B."
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "dateStartYear": [
+            1937
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12709113"
+            }
+          ],
+          "updatedAt": 1636332069027,
+          "publicationStatement": [
+            "[Omaha, : Magic city printing co., 1937]"
+          ],
+          "identifier": [
+            "urn:bnum:12709113"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington County (Neb.) -- History."
+          ],
+          "titleDisplay": [
+            "A history of Washington county, Nebraska / by Forrest B. Shrader."
+          ],
+          "uri": "b12709113",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Omaha, :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16202472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099509238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099509238"
+                    ],
+                    "idBarcode": [
+                      "33433099509238"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aIWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                  },
+                  "sort": [
+                    "aIWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-a4b83792e47ef129c9d89566d2d73a69.json
+++ b/test/fixtures/query-a4b83792e47ef129c9d89566d2d73a69.json
@@ -1,0 +1,905 @@
+{
+  "took": 96,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015295,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015295,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d0152895e522932aae19cd5937c913f6.json
+++ b/test/fixtures/query-d0152895e522932aae19cd5937c913f6.json
@@ -1,0 +1,14920 @@
+{
+  "took": 376,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 950960,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "publisherLiteral": [
+            "Stauffenburg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "contributorLiteral": [
+            "Baum, Richard.",
+            "Gmelin, Hermann, 1900-1958.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    "aJFE 86-003252"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000432",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "94 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah"
+          ],
+          "shelfMark": [
+            "*OMO 84-1527"
+          ],
+          "creatorLiteral": [
+            "Yūshīj, Nīmā."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-1527"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000432"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100386"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200431"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636117871714,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10000432",
+            "urn:undefined:NNSZ00100386",
+            "urn:undefined:(WaOLN)nyp0200431"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah / az Nīmā yūshīj."
+          ],
+          "uri": "b10000432",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khānah-ʼi Sarīvaylī."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000432"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000245",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMO 84-1527",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898497"
+                    ],
+                    "idBarcode": [
+                      "33433001898497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-001527"
+                  },
+                  "sort": [
+                    "a*OMO 84-001527"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000871",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784137",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784138",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784139",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784140",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784141",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784142",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784143",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784144",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784146",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 15",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784147",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784177",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 82-2276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276"
+                  },
+                  "sort": [
+                    "a*OKN 82-002276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001459",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFD 82-4488",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488"
+                  },
+                  "sort": [
+                    "a*OFD 82-004488"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002297",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Firdawsī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "shelfMark": [
+            "*OMZ 84-1529"
+          ],
+          "creatorLiteral": [
+            "Dawlatābādī, Àlī Muḥammad."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1529"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202293"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Firdawsī, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10002297",
+            "urn:undefined:NNSZ00202345",
+            "urn:undefined:(WaOLN)nyp0202293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "uri": "b10002297",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10002297"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1529",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539872"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539872"
+                    ],
+                    "idBarcode": [
+                      "33433014539872"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001529"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001529"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002303",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "280 p. : facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century",
+            "Political prisoners",
+            "Political prisoners -- Iran",
+            "Political prisoners -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Haftah,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1538"
+          ],
+          "creatorLiteral": [
+            "Khāmahʼī, Anvar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1538"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002303"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202351"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202299"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636121044994,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Haftah, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002303",
+            "urn:undefined:NNSZ00202351",
+            "urn:undefined:(WaOLN)nyp0202299"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century.",
+            "Political prisoners -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad / khāṭirāt-i Anvar Khāmah'ī."
+          ],
+          "uri": "b10002303",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002303"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942130",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1538",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539880"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539880"
+                    ],
+                    "idBarcode": [
+                      "33433014539880"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001538"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001538"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003134",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "397 p. : ill., port., facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Statesmen",
+            "Statesmen -- Iran",
+            "Statesmen -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1427"
+          ],
+          "creatorLiteral": [
+            "Mumtaḥin al-Dawlah Shaqāqī, Mahdī Khān."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "seriesStatement": [
+            "Majmūʻah-ʼi guzashtah-ʼi Īrān dar nivishtah-ʼi pīshīnīyān, 1"
+          ],
+          "contributorLiteral": [
+            "Khānshaqāqī, Ḥusaynqulī."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1427"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003134"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303485"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203127"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003134",
+            "urn:undefined:NNSZ00303485",
+            "urn:undefined:(WaOLN)nyp0203127"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Statesmen -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī / bi-kūshish-i Ḥusaynqulī Khānshaqāqī."
+          ],
+          "uri": "b10003134",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10003134"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942159",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1427",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539856"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539856"
+                    ],
+                    "idBarcode": [
+                      "33433014539856"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001427"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001427"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003171",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "412 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āvāz-i kushtigān"
+          ],
+          "shelfMark": [
+            "*OMP 84-2030"
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2030"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003171"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303522"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203164"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636145267451,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003171",
+            "urn:undefined:NNSZ00303522",
+            "urn:undefined:(WaOLN)nyp0203164"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Āvāz-i kushtigān / Rizā Barāhinī."
+          ],
+          "uri": "b10003171",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10003171"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002196",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2030",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173038"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173038"
+                    ],
+                    "idBarcode": [
+                      "33433013173038"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002030"
+                  },
+                  "sort": [
+                    "a*OMP 84-002030"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003179",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "101 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chāh bih chāh"
+          ],
+          "shelfMark": [
+            "*OMP 84-2039"
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2039"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003179"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203172"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636081623272,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003179",
+            "urn:undefined:NNSZ00303530",
+            "urn:undefined:(WaOLN)nyp0203172"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Chāh bih chāh / Rizā Barāhinī."
+          ],
+          "uri": "b10003179",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003179"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2039",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173053"
+                    ],
+                    "idBarcode": [
+                      "33433013173053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002039"
+                  },
+                  "sort": [
+                    "a*OMP 84-002039"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003180",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "235 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam and state",
+            "Islam and state -- Iran",
+            "Khomeini, Ruhollah"
+          ],
+          "publisherLiteral": [
+            "Org. of Act. Constitutionalist Iranians,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qizāvat"
+          ],
+          "shelfMark": [
+            "*OMZ 84-965"
+          ],
+          "creatorLiteral": [
+            "ʻAbd al-Raḥmān."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-965"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003180"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203173"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1636124389229,
+          "publicationStatement": [
+            "Los Angeles : Org. of Act. Constitutionalist Iranians, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003180",
+            "urn:undefined:NNSZ00303531",
+            "urn:undefined:(WaOLN)nyp0203173"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam and state -- Iran.",
+            "Khomeini, Ruhollah."
+          ],
+          "titleDisplay": [
+            "Qizāvat / ʻAbd al-Raḥmān..."
+          ],
+          "uri": "b10003180",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Los Angeles :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10003180"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-965",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539666"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539666"
+                    ],
+                    "idBarcode": [
+                      "33433014539666"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-000965"
+                  },
+                  "sort": [
+                    "a*OMZ 84-000965"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002358",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGM 84-702",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702"
+                  },
+                  "sort": [
+                    "a*OGM 84-000702"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002360",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002361",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002363",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 1"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002421",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QYN 82-2046 Dala 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1."
+                  },
+                  "sort": [
+                    "a*QYN 82-2046 Dala 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002566",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931"
+                  },
+                  "sort": [
+                    "a*OFP 82-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002601",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002602",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002603",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002604",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002605",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "39, 18, 83, 3 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Reprint of the 1910 ? ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1910"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn,"
+          ],
+          "shelfMark": [
+            "*OGL 83-2455"
+          ],
+          "creatorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "73960850"
+          ],
+          "contributorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGL 83-2455"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003958"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960850"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304319"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203950"
+            }
+          ],
+          "dateEndYear": [
+            1910
+          ],
+          "updatedAt": 1636072413178,
+          "publicationStatement": [
+            "Qum : Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī, 1405 [1984 or 1985]"
+          ],
+          "identifier": [
+            "urn:bnum:10003958",
+            "urn:lccn:73960850",
+            "urn:undefined:NNSZ00304319",
+            "urn:undefined:(WaOLN)nyp0203950"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn, taṣnīf Abī ʻAlī ibn Sīnā."
+          ],
+          "uri": "b10003958",
+          "lccClassification": [
+            "B751 .M4 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Qum :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10003958"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858216",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGL 83-2455",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058069919"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058069919"
+                    ],
+                    "idBarcode": [
+                      "33433058069919"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGL 83-002455"
+                  },
+                  "sort": [
+                    "a*OGL 83-002455"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858227",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-341 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 83-341 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003188",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  },
+                  "sort": [
+                    "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004788",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "277 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Plon,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Le château du soleil couchant : roman"
+          ],
+          "shelfMark": [
+            "JFE 84-3450"
+          ],
+          "creatorLiteral": [
+            "Grey, Marina."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Grey, Marina. Saga de l'exil ; \\[3]",
+            "La saga de l'exil / Marina Grey ; [3]"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 84-3450"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004788"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2259011187 :"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405900"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204778"
+            }
+          ],
+          "updatedAt": 1636112113505,
+          "publicationStatement": [
+            "Paris : Plon, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10004788",
+            "urn:isbn:2259011187 :",
+            "urn:undefined:NNSZ00405900",
+            "urn:undefined:(WaOLN)nyp0204778"
+          ],
+          "idIsbn": [
+            "2259011187 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Le château du soleil couchant : roman / Marina Grey."
+          ],
+          "uri": "b10004788",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004788"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858280",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 84-3450"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 84-3450",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113944"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 84-3450"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113944"
+                    ],
+                    "idBarcode": [
+                      "33433046113944"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 84-003450"
+                  },
+                  "sort": [
+                    "aJFE 84-003450"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-291 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001"
+                  },
+                  "sort": [
+                    "aJFK 84-291 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-221 11 Azerbaijani monographs",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs"
+                  },
+                  "sort": [
+                    "a*ZO-221 11 Azerbaijani monographs"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30087469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-220 collection of 10 titles (monographs)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)"
+                  },
+                  "sort": [
+                    "a*ZO-220 collection of 10 titles (monographs)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005870",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"D'après le livre et le montage audiovisual 'L'Evolution de l'amour' por D. Sonet, légèrement adapté avec l'aimable autorisation de l'auteur.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sex instruction",
+            "Sex instruction -- Haiti",
+            "Sonet, D"
+          ],
+          "publisherLiteral": [
+            "Action familiale d'Haïti,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable"
+          ],
+          "shelfMark": [
+            "Sc D 84-595"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Action familiale d'Haïti."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-595"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205860"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636069688379,
+          "publicationStatement": [
+            "Port-au-Prince : Action familiale d'Haïti, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005870",
+            "urn:undefined:NNSZ00507084",
+            "urn:undefined:(WaOLN)nyp0205860"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sex instruction -- Haiti.",
+            "Sonet, D."
+          ],
+          "titleDisplay": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable / Action familiale d'Haïti."
+          ],
+          "uri": "b10005870",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10005870"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-595"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-595",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-595"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649329"
+                    ],
+                    "idBarcode": [
+                      "33433036649329"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000595"
+                  },
+                  "sort": [
+                    "aSc D 84-000595"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005876",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxvii, 751 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Unesco International Scientific Committee for the Drafting of a General History of Africa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 692-733.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- History",
+            "Africa -- History -- To 1884"
+          ],
+          "publisherLiteral": [
+            "Heinemann ; University of California Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Africa from the twelfth to the sixteenth century"
+          ],
+          "shelfMark": [
+            "Sc E 84-288"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84256508 //r86"
+          ],
+          "seriesStatement": [
+            "General history of Africa ; 4"
+          ],
+          "contributorLiteral": [
+            "Niane, Djibril Tamsir.",
+            "Unesco. International Scientific Committee for the Drafting of a General History of Africa."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005876"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0435948105"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0520039157 (University of California Press)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84256508 //r86"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205866"
+            }
+          ],
+          "updatedAt": 1636071226912,
+          "publicationStatement": [
+            "London : Heinemann ; Berkeley, Calif. : University of California Press, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005876",
+            "urn:isbn:0435948105",
+            "urn:isbn:0520039157 (University of California Press)",
+            "urn:lccn:84256508 //r86",
+            "urn:undefined:(WaOLN)nyp0205866"
+          ],
+          "idIsbn": [
+            "0435948105",
+            "0520039157 (University of California Press)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- History -- To 1884."
+          ],
+          "titleDisplay": [
+            "Africa from the twelfth to the sixteenth century / editor, D.T. Niane."
+          ],
+          "uri": "b10005876",
+          "lccClassification": [
+            "DT20 .G45 1981 vol. 4 DT25"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London : Berkeley, Calif. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10005876"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003889",
+                    "status": [
+                      {
+                        "id": "status:m",
+                        "label": "Missing"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:m||Missing"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "*R-BK 90-2407"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*R-BK 90-2407",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*R-BK 90-2407"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:-",
+                        "label": "No restrictions"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:-||No restrictions"
+                    ],
+                    "shelfMark_sort": "a*R-BK 90-002407"
+                  },
+                  "sort": [
+                    "a*R-BK 90-002407"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-288"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-288",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021813997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-288"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021813997"
+                    ],
+                    "idBarcode": [
+                      "33433021813997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000288"
+                  },
+                  "sort": [
+                    "aSc E 84-000288"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005902",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "76 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs, English",
+            "Sacred songs, English -- Caribbean Area",
+            "Sacred songs, English -- Caribbean Area -- Texts",
+            "Sacred songs, English -- Jamaica",
+            "Sacred songs, English -- Jamaica -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "shelfMark": [
+            "Sc D 84-602"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-602"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005902"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205892"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636116687148,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10005902",
+            "urn:undefined:NNSZ00507117",
+            "urn:undefined:(WaOLN)nyp0205892"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs, English -- Caribbean Area -- Texts.",
+            "Sacred songs, English -- Jamaica -- Texts."
+          ],
+          "titleDisplay": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "uri": "b10005902",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005902"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900490",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-602"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-602",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058825831"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-602"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058825831"
+                    ],
+                    "idBarcode": [
+                      "33433058825831"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000602"
+                  },
+                  "sort": [
+                    "aSc D 84-000602"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005905",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "52 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\"
+          ],
+          "shelfMark": [
+            "Sc C 85-2"
+          ],
+          "creatorLiteral": [
+            "Passavant, Camille."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc C 85-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005905"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507120"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205895"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636132396392,
+          "publicationStatement": [
+            "[Fort-de-France? Martinique : s.n., 19--] 52"
+          ],
+          "identifier": [
+            "urn:bnum:10005905",
+            "urn:undefined:NNSZ00507120",
+            "urn:undefined:(WaOLN)nyp0205895"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\ Camille Passavant."
+          ],
+          "uri": "b10005905",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Fort-de-France? Martinique :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10005905"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900493",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc C 85-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc C 85-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036604563"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc C 85-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036604563"
+                    ],
+                    "idBarcode": [
+                      "33433036604563"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc C 85-000002"
+                  },
+                  "sort": [
+                    "aSc C 85-000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005910",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 99 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 99.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Universities and colleges",
+            "Universities and colleges -- Africa",
+            "Universities and colleges -- Zambia"
+          ],
+          "publisherLiteral": [
+            "Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The African university : issues and perspectives : speeches"
+          ],
+          "shelfMark": [
+            "Sc D 84-502"
+          ],
+          "creatorLiteral": [
+            "Goma, L. K. H."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84980558"
+          ],
+          "seriesStatement": [
+            "Zambian papers ; no. 14"
+          ],
+          "contributorLiteral": [
+            "Tembo, L. P.",
+            "University of Zambia. Institute for African Studies."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-502"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005910"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84980558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205900"
+            }
+          ],
+          "updatedAt": 1636133189056,
+          "publicationStatement": [
+            "Lusaka, Zambia : Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005910",
+            "urn:lccn:84980558",
+            "urn:undefined:(WaOLN)nyp0205900"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Universities and colleges -- Africa.",
+            "Universities and colleges -- Zambia."
+          ],
+          "titleDisplay": [
+            "The African university : issues and perspectives : speeches / by L.H.K. [i.e. L.K.H.] Goma ; selected and edited by L.P. Tembo."
+          ],
+          "uri": "b10005910",
+          "lccClassification": [
+            "DT963.A3 Z3 no. 14 LA1503"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Lusaka, Zambia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005910"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 86-224 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 86-224 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003630815"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 86-224"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003630815"
+                    ],
+                    "idBarcode": [
+                      "33433003630815"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 86-224 v. 000014"
+                  },
+                  "sort": [
+                    "aJFK 86-224 v. 000014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-502"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-502",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021791029"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-502"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021791029"
+                    ],
+                    "idBarcode": [
+                      "33433021791029"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000502"
+                  },
+                  "sort": [
+                    "aSc D 84-000502"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 microfilm reels ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes biographical notes, scope and contents note and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm of Mss.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington, Fredi, 1903-1994",
+            "African American actresses",
+            "African American actresses -- Correspondence",
+            "African American women journalists",
+            "African American women journalists -- Correspondence",
+            "African Americans in the performing arts",
+            "African American actors",
+            "African American journalists"
+          ],
+          "publisherLiteral": [
+            "Amistad Research Center"
+          ],
+          "description": [
+            "Contains approximately one hundred pieces of correspondence, news clippings containing reviews of productions in which Fredi Washington appeared, and Washington's columns for The People's voice. Other groups in the collection are theatre programs, scripts, photographs and documentation of honors conferred on Fredi Washington."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "shelfMark": [
+            "Sc Micro R-4205"
+          ],
+          "creatorLiteral": [
+            "Washington, Fredi, 1903-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Amistad Research Center."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4205"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11780064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11780064"
+            }
+          ],
+          "idOclc": [
+            "11780064"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1651087265505,
+          "publicationStatement": [
+            "New Orleans, La. : Amistad Research Center, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10006007",
+            "urn:oclc:11780064",
+            "urn:undefined:(OCoLC)11780064"
+          ],
+          "genreForm": [
+            "Personal correspondence."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington, Fredi, 1903-1994.",
+            "African American actresses -- Correspondence.",
+            "African American women journalists -- Correspondence.",
+            "African Americans in the performing arts.",
+            "African American actors.",
+            "African American journalists."
+          ],
+          "titleDisplay": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "uri": "b10006007",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New Orleans, La."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm"
+          ]
+        },
+        "sort": [
+          "b10006007"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242492"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242492"
+                    ],
+                    "idBarcode": [
+                      "33433031242492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000001"
+                  },
+                  "sort": [
+                    "aSc Micro R-4205 r. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242500"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242500"
+                    ],
+                    "idBarcode": [
+                      "33433031242500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000002"
+                  },
+                  "sort": [
+                    "aSc Micro R-4205 r. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .T000425"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    "aSc F 84-000135"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "79 p. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- Portuguese",
+            "Cão, Diogo, active 15th century",
+            "Dias, Bartolomeu",
+            "Gama, Vasco da, 1469-1524",
+            "Portuguese",
+            "Portuguese -- India",
+            "Portuguese -- India -- History"
+          ],
+          "publisherLiteral": [
+            "Basler Afrika Bibliographien,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen"
+          ],
+          "shelfMark": [
+            "Sc D 84-477"
+          ],
+          "creatorLiteral": [
+            "Kalthammer, Wilhelm."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Beiträge zur Afrikakunde, 0171-1660; 5"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-477"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006034"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507257"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206027"
+            }
+          ],
+          "updatedAt": 1636088600902,
+          "publicationStatement": [
+            "Basel : Basler Afrika Bibliographien, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10006034",
+            "urn:undefined:NNSZ00507257",
+            "urn:undefined:(WaOLN)nyp0206027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- Portuguese.",
+            "Cão, Diogo, active 15th century.",
+            "Dias, Bartolomeu.",
+            "Gama, Vasco da, 1469-1524.",
+            "Portuguese -- India -- History."
+          ],
+          "titleDisplay": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen / Wilhelm Kalthammer."
+          ],
+          "uri": "b10006034",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Basel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006034"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900606",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-477"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-477",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-477"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649683"
+                    ],
+                    "idBarcode": [
+                      "33433036649683"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000477"
+                  },
+                  "sort": [
+                    "aSc D 84-000477"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "205 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa, Sub-Saharan",
+            "Africa, Sub-Saharan -- Relations",
+            "Africa, Sub-Saharan -- Relations -- Arab countries",
+            "Arab countries",
+            "Arab countries -- Relations",
+            "Arab countries -- Relations -- Africa, Sub-Saharan"
+          ],
+          "publisherLiteral": [
+            "Unesco,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "shelfMark": [
+            "Sc E 84-236"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "General history of Africa: studies and documents; 7"
+          ],
+          "contributorLiteral": [
+            "Unesco."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-236"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206036"
+            }
+          ],
+          "updatedAt": 1636103134727,
+          "publicationStatement": [
+            "Paris : Unesco, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10006043",
+            "urn:undefined:(WaOLN)nyp0206036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa, Sub-Saharan -- Relations -- Arab countries.",
+            "Arab countries -- Relations -- Africa, Sub-Saharan."
+          ],
+          "titleDisplay": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "uri": "b10006043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006043"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900614",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-236"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-236",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036807315"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-236"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036807315"
+                    ],
+                    "idBarcode": [
+                      "33433036807315"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000236"
+                  },
+                  "sort": [
+                    "aSc E 84-000236"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    "aSc Micro R-004202"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Black people",
+            "Black people -- Caribbean Area",
+            "Black people -- Caribbean Area -- Social conditions",
+            "Middle class",
+            "Middle class -- Caribbean Area"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The making of a middle class [microform]"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10459"
+          ],
+          "creatorLiteral": [
+            "Franks, W. Stanley."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10459"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206335"
+            }
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1646227218179,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006344",
+            "urn:undefined:NNSZ00507572",
+            "urn:undefined:(WaOLN)nyp0206335"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Black people -- Caribbean Area -- Social conditions.",
+            "Middle class -- Caribbean Area."
+          ],
+          "titleDisplay": [
+            "The making of a middle class [microform] / by W. S. Franks ; with a foreword by Lee Llewellyn Moore."
+          ],
+          "uri": "b10006344",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10006344"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10459",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058831748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058831748"
+                    ],
+                    "idBarcode": [
+                      "33433058831748"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010459"
+                  },
+                  "sort": [
+                    "aSc Micro F-010459"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-184 v. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2"
+                  },
+                  "sort": [
+                    "aJFK 84-184 v. 000001-2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636102841759,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "aHDK 84-1693 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006645",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "a, 257 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of: Algoritmy upravlen︠i︡a rabotami-manipul︠i︡atorami.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"JPRS 59717.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 245-252.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial"
+          ],
+          "publisherLiteral": [
+            "Joint Publications Research Service,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1973"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Robot-manipulator control algorithms"
+          ],
+          "shelfMark": [
+            "JSF 83-552"
+          ],
+          "creatorLiteral": [
+            "Ignatʹev, M. B. (Mikhail Borisovich)"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Kulakov, F. M. (Feliks Mikhaĭlovich)",
+            "Pokrovskiĭ, A. M."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 83-552"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006645"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206634"
+            }
+          ],
+          "uniformTitle": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami. English"
+          ],
+          "dateEndYear": [
+            1973
+          ],
+          "updatedAt": 1636073144930,
+          "publicationStatement": [
+            "Arlington, Va. : Joint Publications Research Service, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10006645",
+            "urn:undefined:(WaOLN)nyp0206634"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial."
+          ],
+          "titleDisplay": [
+            "Robot-manipulator control algorithms / by M.B. Ignatʹyev, F.M. Kulakov, A.M. Pokrovskiy."
+          ],
+          "uri": "b10006645",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Arlington, Va. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006645"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 83-552"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 83-552",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 83-552"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693748"
+                    ],
+                    "idBarcode": [
+                      "33433037693748"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 83-000552"
+                  },
+                  "sort": [
+                    "aJSF 83-000552"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003945",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003946",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003947",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006699",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "483 p. : ill., ports ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 476-483.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dominican literature",
+            "Dominican literature -- Manuals, handbooks, etc",
+            "Latin American literature",
+            "Latin American literature -- Study and teaching",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media"
+          ],
+          "shelfMark": [
+            "JFF 84-820"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Gómez de Michel, Fiume."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 84-820"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006699"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507932"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206688"
+            }
+          ],
+          "updatedAt": 1636114816670,
+          "publicationStatement": [
+            "[Santo Domingo, R. D. : s.n.], 1984"
+          ],
+          "identifier": [
+            "urn:bnum:10006699",
+            "urn:undefined:NNSZ00507932",
+            "urn:undefined:(WaOLN)nyp0206688"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dominican literature -- Manuals, handbooks, etc.",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc."
+          ],
+          "titleDisplay": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media / [compilación] Fiumé Gómez de Michel."
+          ],
+          "uri": "b10006699",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Santo Domingo, R. D. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006699"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 84-820"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 84-820",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050352214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 84-820"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050352214"
+                    ],
+                    "idBarcode": [
+                      "33433050352214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 84-000820"
+                  },
+                  "sort": [
+                    "aJFF 84-000820"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006705",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Architecture, Domestic",
+            "Architecture, Domestic -- Greece",
+            "Vernacular architecture",
+            "Vernacular architecture -- Greece"
+          ],
+          "publisherLiteral": [
+            "Ekdot. Oikos \"Melissa,\""
+          ],
+          "language": [
+            {
+              "id": "lang:gre",
+              "label": "Greek, Modern (1453- )"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hellēnikē paradosiakē architektonikē"
+          ],
+          "shelfMark": [
+            "3-MQW+ 84-2551"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83177376"
+          ],
+          "contributorLiteral": [
+            "Philippidēs, Dēmētrēs."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "3-MQW+ 84-2551"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83177376"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206694"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636102156834,
+          "publicationStatement": [
+            "Athēna : Ekdot. Oikos \"Melissa,\" c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006705",
+            "urn:lccn:83177376",
+            "urn:undefined:(WaOLN)nyp0206694"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Architecture, Domestic -- Greece.",
+            "Vernacular architecture -- Greece."
+          ],
+          "titleDisplay": [
+            "Hellēnikē paradosiakē architektonikē / symvoulos kai syntonistēs tēs ekdosēs, Dēmētrēs Philippidēs ; [phōtographies, V. Voutsas]."
+          ],
+          "uri": "b10006705",
+          "lccClassification": [
+            "NA1091 .H44 1982"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Athēna :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "t. 1. Anatoliko Aigaio. Sporades. Heptanēsa -- t. 2. Kyklades -- t. 3. Dōdekanēsa-Krētē -- t. 4. Peloponnēsos I -- t. 5 Peloponnesos II, Sterea Hellada -- t. 6. Thessalia-Ēpeiros -- t. 7. Makedonia I."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10006705"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746669",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160612"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160612"
+                    ],
+                    "idBarcode": [
+                      "33433105160612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000001"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746670",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160620"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160620"
+                    ],
+                    "idBarcode": [
+                      "33433105160620"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000002"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746671",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160638"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160638"
+                    ],
+                    "idBarcode": [
+                      "33433105160638"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000003"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160646"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160646"
+                    ],
+                    "idBarcode": [
+                      "33433105160646"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000004"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746673",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160653"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160653"
+                    ],
+                    "idBarcode": [
+                      "33433105160653"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000005"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160661"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160661"
+                    ],
+                    "idBarcode": [
+                      "33433105160661"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000006"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160679"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160679"
+                    ],
+                    "idBarcode": [
+                      "33433105160679"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000007"
+                  },
+                  "sort": [
+                    "a3-MQW+ 84-2551 v. 000007"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006715",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some ed.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: 2222.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Austria",
+            "Austria -- Relations",
+            "Austria -- Relations -- United States",
+            "United States",
+            "United States -- Relations",
+            "United States -- Relations -- Austria"
+          ],
+          "publisherLiteral": [
+            "The author,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadruple 2"
+          ],
+          "shelfMark": [
+            "ICM (Austria) 85-584"
+          ],
+          "creatorLiteral": [
+            "Humes, John P."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ICM (Austria) 85-584"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006715"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507948"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206704"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124417162,
+          "publicationStatement": [
+            "[S.l. : The author, 197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10006715",
+            "urn:undefined:NNSZ00507948",
+            "urn:undefined:(WaOLN)nyp0206704"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Austria -- Relations -- United States.",
+            "United States -- Relations -- Austria."
+          ],
+          "titleDisplay": [
+            "Quadruple 2 / by John P. Humes."
+          ],
+          "uri": "b10006715",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "2222.",
+            "Quadruple two."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006715"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "ICM (Austria) 85-584 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ICM (Austria) 85-584 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090390752"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "ICM (Austria) 85-584"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090390752"
+                    ],
+                    "idBarcode": [
+                      "33433090390752"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aICM (Austria) 85-584 v. 000002"
+                  },
+                  "sort": [
+                    "aICM (Austria) 85-584 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006720",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[24] p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Issued in portfolio.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Delius, Frederick, 1862-1934"
+          ],
+          "publisherLiteral": [
+            "The Trust,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Delius, 1862-1934"
+          ],
+          "shelfMark": [
+            "JMF 84-424"
+          ],
+          "creatorLiteral": [
+            "Delius Trust."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 84-424"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006720"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507953"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000020"
+            }
+          ],
+          "updatedAt": 1636086826287,
+          "publicationStatement": [
+            "London : The Trust, [1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10006720",
+            "urn:undefined:NNSZ00507953",
+            "urn:undefined:(WaOLN)nyp0000020"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Delius, Frederick, 1862-1934."
+          ],
+          "titleDisplay": [
+            "Delius, 1862-1934 / compiled by the Delius Trust to mark the 50th anniversary of his death."
+          ],
+          "uri": "b10006720",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "A short biography -- A select bibliography -- A select discography -- List of works -- The collected edition. -- Calendar of performances and events, 1984."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10006720"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942253",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032723599"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032723599"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433032723599"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "JMF 84-424"
+                    ],
+                    "shelfMark_sort": "aJMF 84-000424"
+                  },
+                  "sort": [
+                    "aJMF 84-000424"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d224e5356d87412de7d37d6118a0973f.json
+++ b/test/fixtures/query-d224e5356d87412de7d37d6118a0973f.json
@@ -1,0 +1,905 @@
+{
+  "took": 66,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.7560005,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.7560005,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d4111e08b82452ecbe7477a97437198a.json
+++ b/test/fixtures/query-d4111e08b82452ecbe7477a97437198a.json
@@ -1,0 +1,20975 @@
+{
+  "took": 346,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 299,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858227",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-341 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 83-341 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003188",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  },
+                  "sort": [
+                    "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008327",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editors vary.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk literature, Kannada",
+            "Folk literature, Kannada -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jānapada sāhityadarśana"
+          ],
+          "shelfMark": [
+            "*OLA 83-2636"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75904046"
+          ],
+          "seriesStatement": [
+            "Jānapada sammēḷana smaraṇe ; 1-2, 4"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2636"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008327"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75904046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609733"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208308"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108824394,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10008327",
+            "urn:lccn:75904046",
+            "urn:undefined:NNSZ00609733",
+            "urn:undefined:(WaOLN)nyp0208308"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk literature, Kannada -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Jānapada sāhityadarśana / sampādakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10008327",
+          "lccClassification": [
+            "PL4654 .J3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10008327"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004639",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544238"
+                    ],
+                    "idBarcode": [
+                      "33433005544238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004640",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544246"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544246"
+                    ],
+                    "idBarcode": [
+                      "33433005544246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004641",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-2636 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119130"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119130"
+                    ],
+                    "idBarcode": [
+                      "33433013119130"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 83-2636 v. 000004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011457",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographic references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada and Sanskrit (Kannada script), includes quotations in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic music",
+            "Carnatic music -- History and criticism",
+            "Music",
+            "Music -- India",
+            "Music -- India -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisuru Viśvavidyanilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Śārṅgadēva viracita Saṅgītaratnākara : Nihśaṅkahrdaya vemba Kannaḍa vyākhyāna samēta"
+          ],
+          "shelfMark": [
+            "JMM 86-1"
+          ],
+          "creatorLiteral": [
+            "Śārṅgadeva."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "contributorLiteral": [
+            "Satyanarayana, R."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMM 86-1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011457"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213437"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211429"
+            }
+          ],
+          "uniformTitle": [
+            "Saṅgītaratnākara"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636128327571,
+          "publicationStatement": [
+            "Maisūru : Prasārāṅga, Maisuru Viśvavidyanilaya, 1968-"
+          ],
+          "identifier": [
+            "urn:bnum:10011457",
+            "urn:undefined:NNSZ01213437",
+            "urn:undefined:(WaOLN)nyp0211429"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic music -- History and criticism.",
+            "Music -- India -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Śrī Śārṅgadēva viracita Saṅgītaratnākara : Nihśaṅkahrdaya vemba Kannaḍa vyākhyāna samēta / anuvāda mattu vyākhyāna, Ra. Satyanārāyaṇa (Maisūru Sahōdararu)."
+          ],
+          "uri": "b10011457",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Niḥśaṅkahrdaya.",
+            "Saṅgītaratnākara"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10011457"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747261",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMM 86-1 v. 1, pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMM 86-1 v. 1, pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068848849"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMM 86-1"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, pt. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068848849"
+                    ],
+                    "idBarcode": [
+                      "33433068848849"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMM 86-1 v. 000001, pt. 1"
+                  },
+                  "sort": [
+                    "aJMM 86-1 v. 000001, pt. 1"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011462",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus., maps (part fold.)"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "India",
+            "India -- Description and travel"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pravāsi kaṇḍa Iṇḍiyā."
+          ],
+          "shelfMark": [
+            "*OLA 86-308"
+          ],
+          "creatorLiteral": [
+            "Nāgēgauḍa, H. L."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 67002221"
+          ],
+          "seriesStatement": [
+            "Maisūru Viśvavidyānilaya Kannaḍa granthamāle, 71, 84"
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-308"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011462"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 67002221"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211434"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636123272140,
+          "publicationStatement": [
+            "[Maisūru] Prasārāṅga, Maisūru Viśvavidyānilaya, 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10011462",
+            "urn:lccn:sa 67002221",
+            "urn:undefined:NNSZ01213442",
+            "urn:undefined:(WaOLN)nyp0211434"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "India -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Pravāsi kaṇḍa Iṇḍiyā. [Lēkhaka] Ec. El. Nāgēgauḍa."
+          ],
+          "uri": "b10011462",
+          "lccClassification": [
+            "DS409 .N3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10011462"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005557",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999656"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999656"
+                    ],
+                    "idBarcode": [
+                      "33433012999656"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005558",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999664"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999664"
+                    ],
+                    "idBarcode": [
+                      "33433012999664"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes Jambukhaṇḍi Vadirājacāryaʼs Bhavāsucana ṭ̄kā and Vyāsadāsa's Siddhānta Kaumudī ṭīkā in Sanskrit (Kannada Script) with Kannada rendering by Kēśavācārya Jālihāḷa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Dates taken from the book; vol. 6 published in 1964.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; explanatory notes in Sanskrit (Kannada script) and Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dvaita (Vedanta)",
+            "Vishnu (Hindu deity)",
+            "Vishnu (Hindu deity) -- Poetry"
+          ],
+          "publisherLiteral": [
+            "H. Gorabāḷa,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Harikathāmrtasāra ṭīkā Pañcaratna prakāśikā"
+          ],
+          "shelfMark": [
+            "*OLA 86-1120"
+          ],
+          "creatorLiteral": [
+            "Jagannātha Dāsa, 1487-1547."
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "seriesStatement": [
+            "Śrī Varadēndra Haridāsa Sāhitya Maṇḍala prakaṭane ; 72"
+          ],
+          "contributorLiteral": [
+            "Gorabāḷa, Hanumantarāva.",
+            "Jalihāḷa, Kēśavācārya."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-1120"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011472"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213452"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211444"
+            }
+          ],
+          "uniformTitle": [
+            "Harikathāmrtasāra"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636101423150,
+          "publicationStatement": [
+            "Lingasūgūru : H. Gorabāḷa, 1959?-"
+          ],
+          "identifier": [
+            "urn:bnum:10011472",
+            "urn:undefined:NNSZ01213452",
+            "urn:undefined:(WaOLN)nyp0211444"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dvaita (Vedanta)",
+            "Vishnu (Hindu deity) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Śrī Harikathāmrtasāra ṭīkā Pañcaratna prakāśikā / Śrīmajjagannātha Dāsārya viracita ; sandhigaḷa sāra Gorabāḷa (Sundara Viṭhala)"
+          ],
+          "uri": "b10011472",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lingasūgūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Harikathāmrtasāra",
+            "Pancaratna prakāśikā."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10011472"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005568",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-1120|zLibrary has: Vol. 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-1120|zLibrary has: Vol. 6. v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013000082"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-1120|zLibrary has: Vol. 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013000082"
+                    ],
+                    "idBarcode": [
+                      "33433013000082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-1120|zLibrary has: Vol. 6. v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA 86-1120|zLibrary has: Vol. 6. v. 000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011759",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes music in letter notation.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [204]",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic music",
+            "Carnatic music -- History and criticism",
+            "Songs, Telugu"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kīrtana darpaṇa : prāyōgika saṅgītaśāstra"
+          ],
+          "shelfMark": [
+            "JML 86-5"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75907259"
+          ],
+          "seriesStatement": [
+            "Paṭhyapustaka māle ; 76"
+          ],
+          "contributorLiteral": [
+            "Anantharamaiah, R. L., 1937-",
+            "Ramaratnam, V., 1917-",
+            "Ratna, M. V."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JML 86-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011759"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75907259"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211726"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636110092201,
+          "publicationStatement": [
+            "Maisūru : Prasārāṅga, Maisūru Viśvavidyānilaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10011759",
+            "urn:lccn:75907259",
+            "urn:undefined:NNSZ01314591",
+            "urn:undefined:(WaOLN)nyp0211726"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic music -- History and criticism.",
+            "Songs, Telugu."
+          ],
+          "titleDisplay": [
+            "Kīrtana darpaṇa : prāyōgika saṅgītaśāstra / sampādakaru Vi. Rāmaratnaṃ, Eṃ. Vi. Ratna, Ār. El. Anantarāmayya."
+          ],
+          "uri": "b10011759",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10011759"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747298",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 86-5 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 86-5 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068817299"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 86-5"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068817299"
+                    ],
+                    "idBarcode": [
+                      "33433068817299"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 86-5 v. 000001"
+                  },
+                  "sort": [
+                    "aJML 86-5 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Encyclopedias and dictionaries, Kannada",
+            "Folklore",
+            "Folklore -- Karnataka",
+            "Folklore -- Karnataka -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Kannada Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa jānapada viśvakōśa"
+          ],
+          "shelfMark": [
+            "*OLA 86-2952"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85904648"
+          ],
+          "contributorLiteral": [
+            "Kambar, Chandrasekhara, 1938-"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-2952"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011947"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85904648"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01313921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211913"
+            }
+          ],
+          "updatedAt": 1636108864346,
+          "publicationStatement": [
+            "Beṅgaḷūru : Kannada Sāhitya Pariṣattu, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10011947",
+            "urn:lccn:85904648",
+            "urn:undefined:NNSZ01313921",
+            "urn:undefined:(WaOLN)nyp0211913"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Encyclopedias and dictionaries, Kannada.",
+            "Folklore -- Karnataka -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Kannaḍa jānapada viśvakōśa / sampadakaru, Candraśēkhara Kambāra."
+          ],
+          "uri": "b10011947",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10011947"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-2952 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-2952 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013001767"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-2952"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013001767"
+                    ],
+                    "idBarcode": [
+                      "33433013001767"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-2952 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 86-2952 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-2952 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-2952 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013001759"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-2952"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013001759"
+                    ],
+                    "idBarcode": [
+                      "33433013001759"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-2952 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 86-2952 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012152",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xviii, 128, [16] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Texts of English poems translated by B. M. Srikantayya, 1884-1946, with titles also in Kannada and citations for Kannada translations: p. [57]-128, [16].",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added title in English on verso of t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Śrīkaṇṭhayya, Bi. Eṃ., 1884-1946"
+          ],
+          "publisherLiteral": [
+            "Bi. Eṃ. Śrī. Smāraka Pratiṣṭhāna,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīgandha : Bi. Eṃ. Śrī. janmaśatamānōtsava saṃsmaraṇa sañcike"
+          ],
+          "shelfMark": [
+            "*OLA 86-3118"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85910191"
+          ],
+          "contributorLiteral": [
+            "Śrīnivāsarāju, Ci., 1942-2007."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-3118"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012152"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85910191"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212117"
+            }
+          ],
+          "updatedAt": 1636145472428,
+          "publicationStatement": [
+            "Beṅgaḷūru : Bi. Eṃ. Śrī. Smāraka Pratiṣṭhāna, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10012152",
+            "urn:lccn:85910191",
+            "urn:undefined:NNSZ01314127",
+            "urn:undefined:(WaOLN)nyp0212117"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Śrīkaṇṭhayya, Bi. Eṃ., 1884-1946."
+          ],
+          "titleDisplay": [
+            "Śrīgandha : Bi. Eṃ. Śrī. janmaśatamānōtsava saṃsmaraṇa sañcike / sampādakaru Ci. Śrīnivāsarāju ... [et al.]."
+          ],
+          "uri": "b10012152",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10012152"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-3118"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 86-3118",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013002005"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-3118"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013002005"
+                    ],
+                    "idBarcode": [
+                      "33433013002005"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003118"
+                  },
+                  "sort": [
+                    "a*OLA 86-003118"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015200",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxi, 220, 14 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A poem, with prose version.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bhīma (Hindu mythology)",
+            "Bhīma (Hindu mythology) -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sāhasabhīmavijayaṃ (Gadāyuddhaṃ)"
+          ],
+          "shelfMark": [
+            "*OLA 87-2376"
+          ],
+          "creatorLiteral": [
+            "Ranna, active 993."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86903378"
+          ],
+          "seriesStatement": [
+            "Vajramahōtsava varṣa pañcavārṣika yōjaneya pustakamāle"
+          ],
+          "contributorLiteral": [
+            "Kulakarṇi, Ār. Vi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-2376"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86903378"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618431"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215159"
+            }
+          ],
+          "uniformTitle": [
+            "Gadayuddha"
+          ],
+          "updatedAt": 1636098054027,
+          "publicationStatement": [
+            "Beṅgaḷūru : Kannaḍa Sāhitya Pariṣattu, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10015200",
+            "urn:lccn:86903378",
+            "urn:undefined:NNSZ01618431",
+            "urn:undefined:(WaOLN)nyp0215159"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bhīma (Hindu mythology) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Sāhasabhīmavijayaṃ (Gadāyuddhaṃ) / Kavicakravarti Kaviranna viracitam ; gadyānuvāda Ār. Vi. Kulakarṇi."
+          ],
+          "uri": "b10015200",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Gadayuddha",
+            "Sāhasabhīma vijaya."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10015200"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007322",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128214"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128214"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013128214"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-2376"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002376"
+                  },
+                  "sort": [
+                    "a*OLA 87-002376"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015230",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kannada and Sanskrit; introductory matter in Kannada.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 5 published in 1978.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added English t.p.: a practical Samskrita-Kannada dictionary.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Dictionaries",
+            "Sanskrit language -- Dictionaries -- Kannada"
+          ],
+          "publisherLiteral": [
+            "Gōpālācārya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śabdārthakaustubhaṃ : prāyōgika Saṃskrta-Karṇāṭaka śabdakōśa = Saṃskrta-Kannaḍa śabdakōśa"
+          ],
+          "shelfMark": [
+            "*OLA 87-2131"
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "contributorLiteral": [
+            "Gōpālācārya, Cakravarti Śrīnivāsa."
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-2131"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015230"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618462"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215189"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636145443545,
+          "publicationStatement": [
+            "Beṅgaḷūru : Gōpālācārya, 1978?-"
+          ],
+          "identifier": [
+            "urn:bnum:10015230",
+            "urn:undefined:NNSZ01618462",
+            "urn:undefined:(WaOLN)nyp0215189"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Dictionaries -- Kannada."
+          ],
+          "titleDisplay": [
+            "Śabdārthakaustubhaṃ : prāyōgika Saṃskrta-Karṇāṭaka śabdakōśa = Saṃskrta-Kannaḍa śabdakōśa / granthakarta-prakāśaka Cakravarti Śrīnivāsa Gōpālācārya."
+          ],
+          "uri": "b10015230",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Practical Samskrita-Kannada dictionary.",
+            "Sanskrit-Kannada dictionary.",
+            "Saṃskrta-Kannaḍa śabdakōśa."
+          ],
+          "tableOfContents": [
+            "4. Namaskāra-Bahuvīrya -- 5. Bahuvrīhi - Vēdānta -- 6. Vedāntin- Hveya."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10015230"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007344",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128164"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128164"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013128164"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131"
+                  },
+                  "sort": [
+                    "a*OLA 87-002131"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007342",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128149"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128149"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013128149"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131"
+                  },
+                  "sort": [
+                    "a*OLA 87-002131"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007343",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128156"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128156"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013128156"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131"
+                  },
+                  "sort": [
+                    "a*OLA 87-002131"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015231",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Pañcama puṣpa.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 5 published in 1966.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; includes quotations in Sanskrit (Kannada script).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dvaita (Vedanta)",
+            "Vādirāja, active 16th century"
+          ],
+          "publisherLiteral": [
+            "Gurukrpā Granthamālā : pustaka doreyuva sthaḷa, Gōvindarāv, Beṅgaḷūru,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Vādirāja rjutva prakāśikā"
+          ],
+          "shelfMark": [
+            "*OKN 87-2441"
+          ],
+          "creatorLiteral": [
+            "Guru Gōvinda Viṭhala Dāsaru."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 87-2441"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618463"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215190"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636145475965,
+          "publicationStatement": [
+            "Maisūru : Gurukrpā Granthamālā : pustaka doreyuva sthaḷa, Gōvindarāv, Beṅgaḷūru, 1966-"
+          ],
+          "identifier": [
+            "urn:bnum:10015231",
+            "urn:undefined:NNSZ01618463",
+            "urn:undefined:(WaOLN)nyp0215190"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dvaita (Vedanta)",
+            "Vādirāja, active 16th century."
+          ],
+          "titleDisplay": [
+            "Śrī Vādirāja rjutva prakāśikā / Guru Gōvinda Vithala Dāsaru."
+          ],
+          "uri": "b10015231",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10015231"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13786568",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 87-2441 Library has: Vol. 5. v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 87-2441 Library has: Vol. 5. v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058620984"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 87-2441 Library has: Vol. 5."
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058620984"
+                    ],
+                    "idBarcode": [
+                      "33433058620984"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKN 87-2441 Library has: Vol. 5. v. 000005"
+                  },
+                  "sort": [
+                    "a*OKN 87-2441 Library has: Vol. 5. v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016133",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "43 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yakṣagāna plays"
+          ],
+          "publisherLiteral": [
+            "Ār. Viṭṭappa Śeṇai eṇḍ Sans,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1985"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Krṣṇagāruḍi emba yakṣagāna prasaṅgavu : Bhīmārjuna garvabhaṅga : Mahabhārata purāṇāntargata"
+          ],
+          "shelfMark": [
+            "*OLA 87-3857"
+          ],
+          "creatorLiteral": [
+            "Śrīnivāsa Nāyak, Kōṭa."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "idLccn": [
+            "77913591"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-3857"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016133"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77913591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719432"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216084"
+            }
+          ],
+          "dateEndYear": [
+            1985
+          ],
+          "updatedAt": 1636109877952,
+          "publicationStatement": [
+            "Kārkaḷa, Da. Ka. : Ār. Viṭṭappa Śeṇai eṇḍ Sans, [19-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10016133",
+            "urn:lccn:77913591",
+            "urn:undefined:NNSZ01719432",
+            "urn:undefined:(WaOLN)nyp0216084"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yakṣagāna plays."
+          ],
+          "titleDisplay": [
+            "Krṣṇagāruḍi emba yakṣagāna prasaṅgavu : Bhīmārjuna garvabhaṅga : Mahabhārata purāṇāntargata / lēkhaka, Kōta Śrīnivāsa Nāyak."
+          ],
+          "uri": "b10016133",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kārkaḷa, Da. Ka. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10016133"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126648"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126648"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126648"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-3857"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-003857"
+                  },
+                  "sort": [
+                    "a*OLA 87-003857"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016294",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xliv, 96, 22 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada (Kannada and roman scripts); paraphrase in English and Kannada; introd. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Asian Educational Services,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1884"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nāga Varmā's Karnātaka bhāshā-bhūshana : the oldest grammar extant of the language Karṇāṭaka bhāṣābhūṣana"
+          ],
+          "shelfMark": [
+            "*OLA 87-1958"
+          ],
+          "creatorLiteral": [
+            "Nāgavarma, active 12th century."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85901530"
+          ],
+          "contributorLiteral": [
+            "Rice, B. Lewis (Benjamin Lewis), 1837-1927."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-1958"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016294"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85901530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719593"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216245"
+            }
+          ],
+          "uniformTitle": [
+            "Karṇāṭaka bhāṣabhūṣaṇa"
+          ],
+          "dateEndYear": [
+            1884
+          ],
+          "updatedAt": 1636108982258,
+          "publicationStatement": [
+            "New Delhi : Asian Educational Services, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10016294",
+            "urn:lccn:85901530",
+            "urn:undefined:NNSZ01719593",
+            "urn:undefined:(WaOLN)nyp0216245"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Nāga Varmā's Karnātaka bhāshā-bhūshana : the oldest grammar extant of the language Karṇāṭaka bhāṣābhūṣana / Nāgavarma krta ; edited with an introduction, Lewis Rice."
+          ],
+          "uri": "b10016294",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Karṇāṭaka bhāṣabhūṣaṇa"
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016294"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007686",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128081"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128081"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013128081"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-1958"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-001958"
+                  },
+                  "sort": [
+                    "a*OLA 87-001958"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016426",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1968.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; introductory matter in English or Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhairavēśvara kāvyada kathāmaṇisūtraratnākara"
+          ],
+          "shelfMark": [
+            "*OLA 87-3543"
+          ],
+          "creatorLiteral": [
+            "Śāntaliṅgadēśika."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "seriesStatement": [
+            "Karnāṭaka Viśvavidyālaya : Kannaḍa kāvyamāle ; 7"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-",
+            "Sunkapur, M. S."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-3543"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719726"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216377"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636077680351,
+          "publicationStatement": [
+            "Dhāravāḍa : Karnāṭaka Viśvavidyālaya, 1968-"
+          ],
+          "identifier": [
+            "urn:bnum:10016426",
+            "urn:undefined:NNSZ01719726",
+            "urn:undefined:(WaOLN)nyp0216377"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Bhairavēśvara kāvyada kathāmaṇisūtraratnākara / Śāntaliṅgadēśika krta ; sampādakaru Ār. Si. Hirēmaṭha, Eṃ. Es. Sunkāpura."
+          ],
+          "uri": "b10016426",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016426"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10007795",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126325"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126325"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126325"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-3543"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-003543"
+                  },
+                  "sort": [
+                    "a*OLA 87-003543"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016756",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "vii, 262 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Five hundred Indian plants, in Kanarese.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; includes scientific names in Latin; popular names in English and Indic languages (Kannada script).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicinal plants",
+            "Medicinal plants -- India",
+            "Medicinal plants -- India -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Periodical Expert Book Agency,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1922"
+          ],
+          "createdYear": [
+            1986
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five hundred Indian plants, their use in medicine and arts Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "shelfMark": [
+            "*OLA 87-4611"
+          ],
+          "createdString": [
+            "1986"
+          ],
+          "idLccn": [
+            "87900750"
+          ],
+          "dateStartYear": [
+            1986
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-4611"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016756"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "87900750"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01820065"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216706"
+            }
+          ],
+          "dateEndYear": [
+            1922
+          ],
+          "updatedAt": 1636096234866,
+          "publicationStatement": [
+            "Delhi, India : Periodical Expert Book Agency, 1986."
+          ],
+          "identifier": [
+            "urn:bnum:10016756",
+            "urn:lccn:87900750",
+            "urn:undefined:NNSZ01820065",
+            "urn:undefined:(WaOLN)nyp0216706"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1986"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicinal plants -- India -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Five hundred Indian plants, their use in medicine and arts Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "uri": "b10016756",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delhi, India :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016756"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10008066",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 87-4611"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 87-4611",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013271295"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 87-4611"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013271295"
+                    ],
+                    "idBarcode": [
+                      "33433013271295"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-004611"
+                  },
+                  "sort": [
+                    "a*OLA 87-004611"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10315622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on: 46, 1 (Mar./Apr. 1964); title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: Sampuṭa 85, san̄ike 336/338 (2005/2006).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- Periodicals",
+            "Karnataka (India)",
+            "Karnataka (India) -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Maisūru Viśvevidyānilaya."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Prabuddha Karṇāṭaka."
+          ],
+          "shelfMark": [
+            "*OLA 76-1248"
+          ],
+          "createdString": [
+            "999"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 76-1248"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10315622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0318890"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "46(1964/65)-56(1974/75),60(1978/79), 62(1980/81)-63(1981/82), 65(1983/84)-68(1986/87),70(1988)-71(1989/90), 74(1992/93)-80(1999), 84(2003)-85(2004/2007)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 74 (1992)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 75 (1993)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 76-77 (1996)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 78-79 (1998)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 80 (1999)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 82 No. 323/326 (2001)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 84 No. 331/334 (2003)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 85 No. 335-338 (2004)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 88 No. 343-346 (2010)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 89 No. 347-350 (2013)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 91 No. 351 (2014)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*OLA 76-1248"
+                }
+              ],
+              "physicalLocation": [
+                "*OLA 76-1248"
+              ],
+              "location": [
+                {
+                  "code": "loc:rc2ma",
+                  "label": "Offsite"
+                }
+              ],
+              "uri": "h1066378",
+              "shelfMark": [
+                "*OLA 76-1248"
+              ]
+            }
+          ],
+          "updatedAt": 1644377210610,
+          "publicationStatement": [
+            "Maisūru, Maisūru Viśvevidyānilaya."
+          ],
+          "identifier": [
+            "urn:bnum:10315622",
+            "urn:undefined:(WaOLN)nyp0318890"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- Periodicals.",
+            "Karnataka (India) -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Prabuddha Karṇāṭaka."
+          ],
+          "uri": "b10315622",
+          "numItems": [
+            36
+          ],
+          "numAvailable": [
+            36
+          ],
+          "placeOfPublication": [
+            "Maisūru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10315622"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 36,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074596",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001543184"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001543184"
+                    ],
+                    "idBarcode": [
+                      "33433001543184"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-001248"
+                  },
+                  "sort": [
+                    "a*OLA 76-001248"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074570",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 46, no. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 46, no. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575934"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46, no. 1-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575934"
+                    ],
+                    "idBarcode": [
+                      "33433014575934"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000046, no. 1-3"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000046, no. 1-3"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074571",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 46, no. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 46, no. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575942"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46, no. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575942"
+                    ],
+                    "idBarcode": [
+                      "33433014575942"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000046, no. 4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000046, no. 4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074572",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 47, no. 1-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 47, no. 1-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575959"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 47, no. 1-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575959"
+                    ],
+                    "idBarcode": [
+                      "33433014575959"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000047, no. 1-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000047, no. 1-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074574",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 48 no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 48 no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575975"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 no. 3-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575975"
+                    ],
+                    "idBarcode": [
+                      "33433014575975"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000048 no. 3-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000048 no. 3-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074573",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 48, no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 48, no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575967"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48, no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575967"
+                    ],
+                    "idBarcode": [
+                      "33433014575967"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000048, no. 1-2"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000048, no. 1-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074575",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 49"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 49",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575983"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 49"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575983"
+                    ],
+                    "idBarcode": [
+                      "33433014575983"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000049"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000049"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074576",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 50, no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 50, no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575991"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50, no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575991"
+                    ],
+                    "idBarcode": [
+                      "33433014575991"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000050, no. 1-2"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000050, no. 1-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074577",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 50, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 50, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50, no. 3-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576007"
+                    ],
+                    "idBarcode": [
+                      "33433014576007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000050, no. 3-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000050, no. 3-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074578",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 51, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 51, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576015"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 51, no. 3-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576015"
+                    ],
+                    "idBarcode": [
+                      "33433014576015"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000051, no. 3-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000051, no. 3-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074579",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 52, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 52, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576023"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 52, no. 3-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576023"
+                    ],
+                    "idBarcode": [
+                      "33433014576023"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000052, no. 3-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000052, no. 3-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074580",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 53"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 53",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576031"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 53"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576031"
+                    ],
+                    "idBarcode": [
+                      "33433014576031"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000053"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000053"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 54"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 54",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576049"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 54"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576049"
+                    ],
+                    "idBarcode": [
+                      "33433014576049"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000054"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000054"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 55"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 55",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576411"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 55"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576411"
+                    ],
+                    "idBarcode": [
+                      "33433014576411"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000055"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000055"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074583",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 56, no. 1-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 56, no. 1-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576429"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 56, no. 1-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576429"
+                    ],
+                    "idBarcode": [
+                      "33433014576429"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000056, no. 1-4"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000056, no. 1-4"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074584",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 60"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 60",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576437"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576437"
+                    ],
+                    "idBarcode": [
+                      "33433014576437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000060"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000060"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 62"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 62",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576445"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576445"
+                    ],
+                    "idBarcode": [
+                      "33433014576445"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000062"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000062"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074586",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 63"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 63",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576452"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576452"
+                    ],
+                    "idBarcode": [
+                      "33433014576452"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000063"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000063"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 65"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 65",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576494"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576494"
+                    ],
+                    "idBarcode": [
+                      "33433014576494"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000065"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000065"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074589",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576486"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576486"
+                    ],
+                    "idBarcode": [
+                      "33433014576486"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000066"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000066"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074587",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576460"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576460"
+                    ],
+                    "idBarcode": [
+                      "33433014576460"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000067"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000067"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074588",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 68"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 68",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576478"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 68"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576478"
+                    ],
+                    "idBarcode": [
+                      "33433014576478"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000068"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000068"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074593",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576528"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 70"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576528"
+                    ],
+                    "idBarcode": [
+                      "33433014576528"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000070"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000070"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074591",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 71"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 71",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576502"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 71"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576502"
+                    ],
+                    "idBarcode": [
+                      "33433014576502"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000071"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000071"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074592",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 72"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 72",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576510"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 72"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576510"
+                    ],
+                    "idBarcode": [
+                      "33433014576510"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000072"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000072"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31158194",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 73 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 73 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433111366286"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433111366286"
+                    ],
+                    "idBarcode": [
+                      "33433111366286"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000073 (1992)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000073 (1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074594",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 74"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 74",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575900"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 74"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575900"
+                    ],
+                    "idBarcode": [
+                      "33433014575900"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000074"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000074"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575918"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 75"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575918"
+                    ],
+                    "idBarcode": [
+                      "33433014575918"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000075"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000075"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12950094",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 76-77 (1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 76-77 (1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015942182"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 76-77 (1996)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015942182"
+                    ],
+                    "idBarcode": [
+                      "33433015942182"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000076-77 (1996)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000076-77 (1996)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074597",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 78-79 (1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 78-79 (1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013574946"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 78-79 (1998)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013574946"
+                    ],
+                    "idBarcode": [
+                      "33433013574946"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000078-79 (1998)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000078-79 (1998)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17458423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 82, no. 323/326 (2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 82, no. 323/326 (2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074631197"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 82, no. 323/326 (2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074631197"
+                    ],
+                    "idBarcode": [
+                      "33433074631197"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000082, no. 323/326 (2001)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000082, no. 323/326 (2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23191779",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 84, no. 331/334 (2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 84, no. 331/334 (2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085541104"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 84, no. 331/334 (2003)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085541104"
+                    ],
+                    "idBarcode": [
+                      "33433085541104"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000084, no. 331/334 (2003)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000084, no. 331/334 (2003)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23191778",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 85, no. 335/338 (2004/ 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 85, no. 335/338 (2004/ 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085539777"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 85, no. 335/338 (2004/ 2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085539777"
+                    ],
+                    "idBarcode": [
+                      "33433085539777"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000085, no. 335/338 (2004/ 2007)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000085, no. 335/338 (2004/ 2007)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33721281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 88 no. 343-346 (2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 88 no. 343-346 (2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117980106"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 no. 343-346 (2010)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117980106"
+                    ],
+                    "idBarcode": [
+                      "33433117980106"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000088 no. 343-346 (2010)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000088 no. 343-346 (2010)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33724983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 89 no. 347-350 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 89 no. 347-350 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117979967"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 no. 347-350 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117979967"
+                    ],
+                    "idBarcode": [
+                      "33433117979967"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000089 no. 347-350 (2013)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000089 no. 347-350 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36286477",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 91 no. 351 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 91 no. 351 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121642221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 no. 351 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121642221"
+                    ],
+                    "idBarcode": [
+                      "33433121642221"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000091 no. 351 (2014)"
+                  },
+                  "sort": [
+                    "a*OLA 76-1248 v. 000091 no. 351 (2014)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10379755",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 v. : ill. (part col.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published by the Institute of Kannada studies, University of Mysore.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Encyclopedias and dictionaries, Kannada"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidāyanilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa viśvakośa"
+          ],
+          "shelfMark": [
+            "*OLA+ 76-462"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "sa 73910921"
+          ],
+          "contributorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-",
+            "University of Mysore. Institute of Kannada Studies."
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 76-462"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10379755"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 73910921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN764423629"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0383283"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108872056,
+          "publicationStatement": [
+            "Maisūru : Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidāyanilaya, 1971-2004."
+          ],
+          "identifier": [
+            "urn:bnum:10379755",
+            "urn:lccn:sa 73910921",
+            "urn:undefined:NN764423629",
+            "urn:undefined:(WaOLN)nyp0383283"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Encyclopedias and dictionaries, Kannada."
+          ],
+          "titleDisplay": [
+            "Kannaḍa viśvakośa / chief editor D. Javare Gowda."
+          ],
+          "uri": "b10379755",
+          "numItems": [
+            12
+          ],
+          "numAvailable": [
+            12
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10379755"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 12,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837524",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842191"
+                    ],
+                    "idBarcode": [
+                      "33433057842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837525",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842209"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842209"
+                    ],
+                    "idBarcode": [
+                      "33433057842209"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837526",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842217"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842217"
+                    ],
+                    "idBarcode": [
+                      "33433057842217"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837527",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842225"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842225"
+                    ],
+                    "idBarcode": [
+                      "33433057842225"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842233"
+                    ],
+                    "idBarcode": [
+                      "33433057842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837529",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842241"
+                    ],
+                    "idBarcode": [
+                      "33433057842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837530",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842258"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842258"
+                    ],
+                    "idBarcode": [
+                      "33433057842258"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000007"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837531",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842266"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842266"
+                    ],
+                    "idBarcode": [
+                      "33433057842266"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000009"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837532",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 11"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 11",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842274"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842274"
+                    ],
+                    "idBarcode": [
+                      "33433057842274"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000011"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13837533",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 12"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 12",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842282"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842282"
+                    ],
+                    "idBarcode": [
+                      "33433057842282"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000012"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17460426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:65",
+                        "label": "book, good condition, non-MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:65||book, good condition, non-MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 13"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 13",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069710790"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069710790"
+                    ],
+                    "idBarcode": [
+                      "33433069710790"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000013"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17460427",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:65",
+                        "label": "book, good condition, non-MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:65||book, good condition, non-MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 76-462 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069710808"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069710808"
+                    ],
+                    "idBarcode": [
+                      "33433069710808"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000014"
+                  },
+                  "sort": [
+                    "a*OLA+ 76-462 v. 000014"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10387344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. <1-9> ; "
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 1-5, & 7 has subtitle: Mudrita Kannaḍa krtigaḷa vivarāṇātmaka granthasūci 1817-1968.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada imprints"
+          ],
+          "publisherLiteral": [
+            "Prasarāṅga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa granthasūci; mudrita Kannaḍa krtigala vivaraṇātmaka granthasūci."
+          ],
+          "shelfMark": [
+            "*OLA 75-3000"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "sa 71922330"
+          ],
+          "contributorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 75-3000"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10387344"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 71922330"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN764506752"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0390904"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108871889,
+          "publicationStatement": [
+            "Maisūru] Prasarāṅga, Maisūru Viśvavidyānilaya, 1971-<2003>"
+          ],
+          "identifier": [
+            "urn:bnum:10387344",
+            "urn:lccn:sa 71922330",
+            "urn:undefined:NN764506752",
+            "urn:undefined:(WaOLN)nyp0390904"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada imprints."
+          ],
+          "titleDisplay": [
+            "Kannaḍa granthasūci; mudrita Kannaḍa krtigala vivaraṇātmaka granthasūci. [Compiled by an Editorial Committee consisting of D. Javaregowda and others."
+          ],
+          "uri": "b10387344",
+          "lccClassification": [
+            "Z3201 .K35"
+          ],
+          "numItems": [
+            9
+          ],
+          "numAvailable": [
+            9
+          ],
+          "placeOfPublication": [
+            "Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Śuddha vijñānagaḷu -- 2. Bhāṣe-vyākaraṇa-dharma-tattva-lalitkalegaḷu-upayukta kalegaḷu-nighantugaḷu-vyakaraṇagaḷu -- 3. Sāhitya-vimarśe-kāvya-hosagannaḍa kāvya -- 4. Gadya saṇṇakathe-nāṭaka-prabandha -- 5. Kādambari-aitihāsika-pattēdāri -- 6. Bāla sāhitya -- 7. Anuvāda sāhitya -- 8. Jīvana caritre-patra sāhitya-pravāsa sāhitya-jānapada sāhitya -- 9. Samājaśāstra-vāṇijyaśāstra-sikṣaṇaśāstra-bhūgōla mattu itihāsa"
+          ],
+          "dimensions": [
+            " 30 cm."
+          ]
+        },
+        "sort": [
+          "b10387344"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 9,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546589"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546589"
+                    ],
+                    "idBarcode": [
+                      "33433005546589"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092424",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546597"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546597"
+                    ],
+                    "idBarcode": [
+                      "33433005546597"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092425",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546605"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546605"
+                    ],
+                    "idBarcode": [
+                      "33433005546605"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546613"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546613"
+                    ],
+                    "idBarcode": [
+                      "33433005546613"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092427",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546621"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546621"
+                    ],
+                    "idBarcode": [
+                      "33433005546621"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092428",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546639"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546639"
+                    ],
+                    "idBarcode": [
+                      "33433005546639"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092429",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546647"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546647"
+                    ],
+                    "idBarcode": [
+                      "33433005546647"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000007"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546415"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546415"
+                    ],
+                    "idBarcode": [
+                      "33433005546415"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000008"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092431",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546423"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546423"
+                    ],
+                    "idBarcode": [
+                      "33433005546423"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000009"
+                  },
+                  "sort": [
+                    "a*OLA 75-3000 v. 000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10430533",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "- v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa Sāhitya Paṛiṣattina Kannaḍa nighaṇṭu."
+          ],
+          "shelfMark": [
+            "*OLA+ 77-1212"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 68015538"
+          ],
+          "contributorLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 77-1212"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10430533"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68015538"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774598719"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0434297"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108873568,
+          "publicationStatement": [
+            "Biṅgaḷoru, Kannaḍa Sāhitya Pariṣattu, 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10430533",
+            "urn:lccn:sa 68015538",
+            "urn:undefined:NN774598719",
+            "urn:undefined:(WaOLN)nyp0434297"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Kannaḍa Sāhitya Paṛiṣattina Kannaḍa nighaṇṭu."
+          ],
+          "uri": "b10430533",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Biṅgaḷoru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10430533"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13844383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 77-1212 v. 1 nos. 1-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 77-1212 v. 1 nos. 1-7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842290"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 77-1212"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1 nos. 1-7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842290"
+                    ],
+                    "idBarcode": [
+                      "33433057842290"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 77-1212 v. 000001 nos. 1-7"
+                  },
+                  "sort": [
+                    "a*OLA+ 77-1212 v. 000001 nos. 1-7"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10448884",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus., maps."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Prakaṭaṇa Mattu Pracārō Panyāsa Vibhāga, Beṅgaḷūru Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Samagra Kannaḍa sāhitya caritre. [Pradhāna Sampādakaru Jī. Esau. Sivarudrappa]"
+          ],
+          "shelfMark": [
+            "*OLA 77-1564"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75907097"
+          ],
+          "contributorLiteral": [
+            "Sivarudrappa, G. S., 1926-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 77-1564"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10448884"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75907097"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774800277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0452778"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127961114,
+          "publicationStatement": [
+            "Beṅgaḷūru, Prakaṭaṇa Mattu Pracārō Panyāsa Vibhāga, Beṅgaḷūru Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10448884",
+            "urn:lccn:75907097",
+            "urn:undefined:NN774800277",
+            "urn:undefined:(WaOLN)nyp0452778"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Samagra Kannaḍa sāhitya caritre. [Pradhāna Sampādakaru Jī. Esau. Sivarudrappa]"
+          ],
+          "uri": "b10448884",
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10448884"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545185"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545185"
+                    ],
+                    "idBarcode": [
+                      "33433005545185"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105098",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545193"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545193"
+                    ],
+                    "idBarcode": [
+                      "33433005545193"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545201"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545201"
+                    ],
+                    "idBarcode": [
+                      "33433005545201"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544733"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544733"
+                    ],
+                    "idBarcode": [
+                      "33433005544733"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 1"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 1"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105101",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544741"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544741"
+                    ],
+                    "idBarcode": [
+                      "33433005544741"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 2"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105102",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544758"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544758"
+                    ],
+                    "idBarcode": [
+                      "33433005544758"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000006"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10448885",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "- v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kannaḍa Adhyayana Saṃstheya prakaṭaṇe: Sāmānyamāle.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidyānilaya: Mārāṭagāraru, Prasārāṅga,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa Adhyayana Saṃstheya Kannaḍa sāhitya caritre. Pradhāna Sampādaka, Hā. Mā. Nāyaka: Sampādaka, Ṭi. Vi. Veṅkaṭācala Śāstrī. 1st ed."
+          ],
+          "shelfMark": [
+            "*OLA 77-1563"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75905691"
+          ],
+          "contributorLiteral": [
+            "Nayak, Harogadde Manappa, 1931-",
+            "Venkatachala Sastry, T. V., 1933-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 77-1563"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10448885"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75905691"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774800289"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0452779"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108874575,
+          "publicationStatement": [
+            "Maisūru: Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidyānilaya: Mārāṭagāraru, Prasārāṅga, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10448885",
+            "urn:lccn:75905691",
+            "urn:undefined:NN774800289",
+            "urn:undefined:(WaOLN)nyp0452779"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Kannaḍa Adhyayana Saṃstheya Kannaḍa sāhitya caritre. Pradhāna Sampādaka, Hā. Mā. Nāyaka: Sampādaka, Ṭi. Vi. Veṅkaṭācala Śāstrī. 1st ed."
+          ],
+          "uri": "b10448885",
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Maisūru:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10448885"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545128"
+                    ],
+                    "idBarcode": [
+                      "33433005545128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545136"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545136"
+                    ],
+                    "idBarcode": [
+                      "33433005545136"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105105",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545144"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545144"
+                    ],
+                    "idBarcode": [
+                      "33433005545144"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 4 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 4 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545151"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545151"
+                    ],
+                    "idBarcode": [
+                      "33433005545151"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000004 pt. 1"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000004 pt. 1"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105107",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 4 pt. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 4 pt. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545169"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545169"
+                    ],
+                    "idBarcode": [
+                      "33433005545169"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000004 pt. 2"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000004 pt. 2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105108",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 5 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 5 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545177"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545177"
+                    ],
+                    "idBarcode": [
+                      "33433005545177"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000005 pt. 1"
+                  },
+                  "sort": [
+                    "a*OLA 77-1563 v. 000005 pt. 1"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10621864",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "-v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994",
+            "Kuvempu, 1904-1994 -- Correspondence"
+          ],
+          "publisherLiteral": [
+            "Bayalunēmi Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu patragaḷu. Sampādaka Hariharapriya. 1. Āvṛtti."
+          ],
+          "shelfMark": [
+            "*OLA 79-209"
+          ],
+          "creatorLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75905629"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 79-209"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10621864"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75905629"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN804084236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0627536"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109952581,
+          "publicationStatement": [
+            "Mandagere, Bayalunēmi Prakāśana, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10621864",
+            "urn:lccn:75905629",
+            "urn:undefined:NN804084236",
+            "urn:undefined:(WaOLN)nyp0627536"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994 -- Correspondence."
+          ],
+          "titleDisplay": [
+            "Kuvempu patragaḷu. Sampādaka Hariharapriya. 1. Āvṛtti."
+          ],
+          "uri": "b10621864",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Mandagere,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10621864"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10139695",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576221"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576221"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433014576221"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 79-209"
+                    ],
+                    "shelfMark_sort": "a*OLA 79-000209"
+                  },
+                  "sort": [
+                    "a*OLA 79-000209"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10691564",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic (India)",
+            "Carnatic (India) -- Biography"
+          ],
+          "publisherLiteral": [
+            "Kāvyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jñāpaka citraśāle."
+          ],
+          "shelfMark": [
+            "*OLA 81-2012"
+          ],
+          "creatorLiteral": [
+            "Gundappa, D. V."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "70911699"
+          ],
+          "seriesStatement": [
+            "Kannaḍa Kāvyamāle"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 81-2012"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10691564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70911699"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0698090"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108838366,
+          "publicationStatement": [
+            "Maisūru, Kāvyālaya [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10691564",
+            "urn:lccn:70911699",
+            "urn:undefined:(WaOLN)nyp0698090"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic (India) -- Biography."
+          ],
+          "titleDisplay": [
+            "Jñāpaka citraśāle. [Lēkhaka] Di. Vi. Ji."
+          ],
+          "uri": "b10691564",
+          "lccClassification": [
+            "DS485.C24 G85"
+          ],
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Maisūru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10691564"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153972",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118744"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118744"
+                    ],
+                    "idBarcode": [
+                      "33433013118744"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 81-2012 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153973",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118751"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118751"
+                    ],
+                    "idBarcode": [
+                      "33433013118751"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLA 81-2012 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153974",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118769"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118769"
+                    ],
+                    "idBarcode": [
+                      "33433013118769"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000007"
+                  },
+                  "sort": [
+                    "a*OLA 81-2012 v. 000007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153975",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122498"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122498"
+                    ],
+                    "idBarcode": [
+                      "33433013122498"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000008"
+                  },
+                  "sort": [
+                    "a*OLA 81-2012 v. 000008"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10734117",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography",
+            "Karanth, Kota Shivarama, 1902-"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Smrti pataladinda"
+          ],
+          "shelfMark": [
+            "*OLA 81-2376"
+          ],
+          "creatorLiteral": [
+            "Karanth, Kota Shivarama, 1902-"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 81-2376"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10734117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0740886"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636129696869,
+          "identifier": [
+            "urn:bnum:10734117",
+            "urn:undefined:(WaOLN)nyp0740886"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Authors, Kannada -- 20th century -- Biography.",
+            "Karanth, Kota Shivarama, 1902-"
+          ],
+          "titleDisplay": [
+            "Smrti pataladinda / Śivarāma Kāranta."
+          ],
+          "uri": "b10734117",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10734117"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161644",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122274"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122274"
+                    ],
+                    "idBarcode": [
+                      "33433013122274"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 81-2376 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161645",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122282"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122282"
+                    ],
+                    "idBarcode": [
+                      "33433013122282"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 81-2376 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161646",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122290"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122290"
+                    ],
+                    "idBarcode": [
+                      "33433013122290"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 81-2376 v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10756472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. in illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title, text and musical notation in Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Music, Kannada",
+            "Songs, Tamil"
+          ],
+          "publisherLiteral": [
+            "Guru Guha Gana Nilaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maharaja Sri Swati Tirunal kritis. With notation."
+          ],
+          "shelfMark": [
+            "JML 82-4"
+          ],
+          "creatorLiteral": [
+            "Svātitirunāḷ, 1813-1846."
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 66002381"
+          ],
+          "seriesStatement": [
+            "Karnataka sangeetha tarangini series book 5-"
+          ],
+          "contributorLiteral": [
+            "Shankara Murthy, Mathur R.",
+            "Sreenivasa Iyer, Semmangudi R."
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JML 82-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10756472"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 66002381"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0763357"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636114431948,
+          "publicationStatement": [
+            "Bangalore, Guru Guha Gana Nilaya [1963-"
+          ],
+          "identifier": [
+            "urn:bnum:10756472",
+            "urn:lccn:sa 66002381",
+            "urn:undefined:(WaOLN)nyp0763357"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music, Kannada.",
+            "Songs, Tamil."
+          ],
+          "titleDisplay": [
+            "Maharaja Sri Swati Tirunal kritis. With notation. / Tamil original edited by Semmangudi Srinivasa Aiyar. [Translated] by M.R. Shankaramurthy."
+          ],
+          "uri": "b10756472",
+          "lccClassification": [
+            "M1808.R256 M3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Bangalore,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10756472"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902564",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812019"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812019"
+                    ],
+                    "idBarcode": [
+                      "33433068812019"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000001"
+                  },
+                  "sort": [
+                    "aJML 82-4 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902565",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 2-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 2-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812027"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812027"
+                    ],
+                    "idBarcode": [
+                      "33433068812027"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000002-3"
+                  },
+                  "sort": [
+                    "aJML 82-4 v. 000002-3"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902566",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 4-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 4-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812035"
+                    ],
+                    "idBarcode": [
+                      "33433068812035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000004-5"
+                  },
+                  "sort": [
+                    "aJML 82-4 v. 000004-5"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10836580",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without the music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Songs, Kannada",
+            "Songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yakṣagāna chandassu."
+          ],
+          "shelfMark": [
+            "*OLA 82-1982"
+          ],
+          "creatorLiteral": [
+            "Kedilaya, K. P. Seetharama, 1930-"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 68015716"
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-1982"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10836580"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68015716"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0843597"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636240316036,
+          "publicationStatement": [
+            "Śiśila, [s.n.] 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10836580",
+            "urn:lccn:sa 68015716",
+            "urn:undefined:(WaOLN)nyp0843597"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Yakṣagāna chandassu. Lēkhaka mattu prakāśaka Ka. Pu. Sītārāma Kedilāya."
+          ],
+          "uri": "b10836580",
+          "lccClassification": [
+            "M1803.K427 Y3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śiśila,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10836580"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10179896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013124239"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013124239"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013124239"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-1982"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-001982"
+                  },
+                  "sort": [
+                    "a*OLA 82-001982"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10840234",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography",
+            "Kaṭṭīmani, Basavarāja, 1919-1989",
+            "Kaṭṭīmani, Basavarāja, 1919-1989 -- Biography"
+          ],
+          "publisherLiteral": [
+            "Sāhityaśrī : mārāṭagāraruSam̲aja Pustuk̲alaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavarāja Kaṭṭīmani avara ātmakathe."
+          ],
+          "shelfMark": [
+            "*OLA 82-4677"
+          ],
+          "creatorLiteral": [
+            "Kaṭṭīmani, Basavarāja, 1919-1989."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901672"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-4677"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10840234"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901672"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0847257"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636173090017,
+          "publicationStatement": [
+            "Dhāravāḍa : Sāhityaśrī : mārāṭagāraruSam̲aja Pustuk̲alaya, 1976-"
+          ],
+          "identifier": [
+            "urn:bnum:10840234",
+            "urn:lccn:76901672",
+            "urn:undefined:(WaOLN)nyp0847257"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Authors, Kannada -- 20th century -- Biography.",
+            "Kaṭṭīmani, Basavarāja, 1919-1989 -- Biography."
+          ],
+          "titleDisplay": [
+            "Basavarāja Kaṭṭīmani avara ātmakathe."
+          ],
+          "uri": "b10840234",
+          "lccClassification": [
+            "PL4659.K35 Z463"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Kundaranāḍina kanda."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10840234"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180475",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-4677"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 82-4677",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013117753"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 82-4677"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013117753"
+                    ],
+                    "idBarcode": [
+                      "33433013117753"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-004677"
+                  },
+                  "sort": [
+                    "a*OLA 82-004677"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10840658",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "Gurumūrti Prākāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa janapada sāhitya bhaṇḍāra"
+          ],
+          "shelfMark": [
+            "*OLA 82-5593"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900850"
+          ],
+          "contributorLiteral": [
+            "Krishnamurthy, Matighatta.",
+            "Krishnasarma, Betageri Shrinivasarao, 1900-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5593"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10840658"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900850"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0847681"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202086193,
+          "publicationStatement": [
+            "Beṅgaḷūru : Gurumūrti Prākāśana, 1975-"
+          ],
+          "identifier": [
+            "urn:bnum:10840658",
+            "urn:lccn:76900850",
+            "urn:undefined:(WaOLN)nyp0847681"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Kannaḍa janapada sāhitya bhaṇḍāra / sangrāhaka, sampādaka, Matighaṭṭa Krṣṇamūrti ; Beṭagēri Krṣṇaśarma avara munnuḍiyondige."
+          ],
+          "uri": "b10840658",
+          "lccClassification": [
+            "PL4656 .K33"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Gītegaḷu."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10840658"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180545",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126176"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126176"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126176"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5593"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005593"
+                  },
+                  "sort": [
+                    "a*OLA 82-005593"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10841472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Plays; some previously published in various periodicals.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bi. Es. Śāstri,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kṣīrasāgarara nāṭakagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 82-5560"
+          ],
+          "creatorLiteral": [
+            "Kṣīrasāgara."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5560"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10841472"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0848495"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636203053494,
+          "publicationStatement": [
+            "Beṅgaḷūru : Bi. Es. Śāstri, 1967̲"
+          ],
+          "identifier": [
+            "urn:bnum:10841472",
+            "urn:undefined:(WaOLN)nyp0848495"
+          ],
+          "genreForm": [
+            "Kannada drama."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kṣīrasāgarara nāṭakagaḷu."
+          ],
+          "uri": "b10841472",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10841472"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180727",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126093"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126093"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126093"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5560"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005560"
+                  },
+                  "sort": [
+                    "a*OLA 82-005560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180726",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126085"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126085"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126085"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5560"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005560"
+                  },
+                  "sort": [
+                    "a*OLA 82-005560"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10841507",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Inscriptions, Kannada"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayanapīṭha, Karnāṭaska Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śāsana vy̲asaṅga"
+          ],
+          "shelfMark": [
+            "*OLA 82-3004"
+          ],
+          "creatorLiteral": [
+            "Kalaburgi, M. M."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75900286"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-3004"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10841507"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75900286"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0848530"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636241729029,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayanapīṭha, Karnāṭaska Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10841507",
+            "urn:lccn:75900286",
+            "urn:undefined:(WaOLN)nyp0848530"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Inscriptions, Kannada."
+          ],
+          "titleDisplay": [
+            "Śāsana vy̲asaṅga / Em. Em. Kalaburgi; pradhāna samp̲adakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10841507",
+          "lccClassification": [
+            "PL4654 .K27"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10841507"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180743",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013123785"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013123785"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013123785"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-3004"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-003004"
+                  },
+                  "sort": [
+                    "a*OLA 82-003004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180742",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013123777"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013123777"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013123777"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-3004"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-003004"
+                  },
+                  "sort": [
+                    "a*OLA 82-003004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10843261",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. in"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 1-3 in 1 vol., previously published seperately.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Style"
+          ],
+          "publisherLiteral": [
+            "Kāvyālaya Prakāśakaru,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śaili."
+          ],
+          "shelfMark": [
+            "*OLA 82-5545"
+          ],
+          "creatorLiteral": [
+            "Raṅgaṇṇa, Es. Vi., 1898-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72904770"
+          ],
+          "seriesStatement": [
+            "Kannaḍa kāvyamāle"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5545"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10843261"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72904770"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0850287"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636241707264,
+          "publicationStatement": [
+            "Maisūru, Kāvyālaya Prakāśakaru, 1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10843261",
+            "urn:lccn:72904770",
+            "urn:undefined:(WaOLN)nyp0850287"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Style."
+          ],
+          "titleDisplay": [
+            "Śaili. [Lēkhaka] Es. Vi. Raṅgaṇṇa."
+          ],
+          "uri": "b10843261",
+          "lccClassification": [
+            "PL4649 .R3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10843261"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10181027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126036"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126036"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126036"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5545"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005545"
+                  },
+                  "sort": [
+                    "a*OLA 82-005545"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10843271",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Eṃ. El. Śrīkaṇṭhēśagauḍa Saṃsmaraṇa Samiti, Kannaḍa Adhyayana Saṃsthe,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīkaṇṭhēśagauḍara krtigaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-2833"
+          ],
+          "creatorLiteral": [
+            "Śrīkaṇṭhēśagauḍa, Eṃ. El., 1852-1926."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902729"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2833"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10843271"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902729"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0850297"
+            }
+          ],
+          "uniformTitle": [
+            "Works"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636239739681,
+          "publicationStatement": [
+            "Maisūru : Eṃ. El. Śrīkaṇṭhēśagauḍa Saṃsmaraṇa Samiti, Kannaḍa Adhyayana Saṃsthe, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10843271",
+            "urn:lccn:75902729",
+            "urn:undefined:(WaOLN)nyp0850297"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Śrīkaṇṭhēśagauḍara krtigaḷu."
+          ],
+          "uri": "b10843271",
+          "lccClassification": [
+            "PL4659 .S6464 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Works"
+          ],
+          "tableOfContents": [
+            "1. Mūlakrtigaḷa saṅgraha."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10843271"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10181030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119056"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119056"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013119056"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2833"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-002833"
+                  },
+                  "sort": [
+                    "a*OLA 83-002833"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10848968",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes biographical sketches of the composers.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Composers",
+            "Composers -- Karnataka",
+            "Composers -- Karnataka -- Biography",
+            "Songs, Kannada",
+            "Songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "Mejisṭik Pres"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1962
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dāsara kīrtanegaḷu."
+          ],
+          "shelfMark": [
+            "JMK 82-18"
+          ],
+          "createdString": [
+            "1962"
+          ],
+          "idLccn": [
+            "sa 64006360 /M"
+          ],
+          "contributorLiteral": [
+            "Mañjunāthayya, K.."
+          ],
+          "dateStartYear": [
+            1962
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMK 82-18"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10848968"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 64006360 /M"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0855999"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636187117717,
+          "publicationStatement": [
+            "Uḍupi, Mejisṭik Pres [1962-"
+          ],
+          "identifier": [
+            "urn:bnum:10848968",
+            "urn:lccn:sa 64006360 /M",
+            "urn:undefined:(WaOLN)nyp0855999"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1962"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Composers -- Karnataka -- Biography.",
+            "Songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Dāsara kīrtanegaḷu. Saṅgrāhakaru Ke. Mañjunāthayya. [Pariśōdhakaru Eṃ. Rājagōpālācārya]"
+          ],
+          "uri": "b10848968",
+          "lccClassification": [
+            "M1808.S55 D4"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Uḍupi,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10848968"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14915102",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMK 82-18 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMK 82-18 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071260776"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMK 82-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071260776"
+                    ],
+                    "idBarcode": [
+                      "33433071260776"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMK 82-18 v. 000001"
+                  },
+                  "sort": [
+                    "aJMK 82-18 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14915103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMK 82-18 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMK 82-18 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071260552"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMK 82-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071260552"
+                    ],
+                    "idBarcode": [
+                      "33433071260552"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMK 82-18 v. 000002"
+                  },
+                  "sort": [
+                    "aJMK 82-18 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10864908",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "India",
+            "India -- History"
+          ],
+          "publisherLiteral": [
+            "Prasārāṇga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhāratada caritre."
+          ],
+          "shelfMark": [
+            "*OLL 82-770"
+          ],
+          "creatorLiteral": [
+            "Narasayya, K."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 68002831"
+          ],
+          "seriesStatement": [
+            "Maisūru Viśvavidyānilayada Kannaḍa granthamāle, 54"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLL 82-770"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10864908"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68002831"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0871959"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636174153874,
+          "publicationStatement": [
+            "[Maisūru] Prasārāṇga, Maisūru Viśvavidyānilaya, 196-"
+          ],
+          "identifier": [
+            "urn:bnum:10864908",
+            "urn:lccn:sa 68002831",
+            "urn:undefined:(WaOLN)nyp0871959"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "India -- History."
+          ],
+          "titleDisplay": [
+            "Bhāratada caritre. [Lēkhaka] Ke. Narasayya."
+          ],
+          "uri": "b10864908",
+          "lccClassification": [
+            "DS436 .N37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10864908"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13932012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLL 82-770"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLL 82-770",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061320531"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLL 82-770"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061320531"
+                    ],
+                    "idBarcode": [
+                      "33433061320531"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLL 82-000770"
+                  },
+                  "sort": [
+                    "a*OLL 82-000770"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10893177",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"State level school reader in Kannada for non-Kannada speaking students.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t. p. in English: Kannada nudi /editor, M. S.Thirumalai.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada and Hindi ;introductory and explanatory matter in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Textbooks for foreign speakers"
+          ],
+          "publisherLiteral": [
+            "Senṭral Insṭiṭyūte āph Iṇḍiyan Lāngvējas,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa nuḍi"
+          ],
+          "shelfMark": [
+            "*OLA 84-2050"
+          ],
+          "creatorLiteral": [
+            "Mallikārjuna, B."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "83901906"
+          ],
+          "seriesStatement": [
+            "CIIL second language textbooks series ; 6,7"
+          ],
+          "contributorLiteral": [
+            "Thirumalai, M. S."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-2050"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10893177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83901906"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0900270"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202089293,
+          "publicationStatement": [
+            "Maisūru : Senṭral Insṭiṭyūte āph Iṇḍiyan Lāngvējas, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10893177",
+            "urn:lccn:83901906",
+            "urn:undefined:(WaOLN)nyp0900270"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Textbooks for foreign speakers."
+          ],
+          "titleDisplay": [
+            "Kannaḍa nuḍi / lēkhaka, Bha. Mallikārjuna ;sampadaka, Mā. Su. Tirumalai."
+          ],
+          "uri": "b10893177",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10893177"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997635"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997635"
+                    ],
+                    "idBarcode": [
+                      "33433012997635"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187926",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997627"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997627"
+                    ],
+                    "idBarcode": [
+                      "33433012997627"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187928",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997643"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997643"
+                    ],
+                    "idBarcode": [
+                      "33433012997643"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10893183",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Songs without music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1974.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic music",
+            "Purandaradāsa, 1484-1564",
+            "Purandaradāsa, 1484-1564 -- Criticism and interpretation"
+          ],
+          "publisherLiteral": [
+            "Śrīpurandaradāsara Nānnūraneya Varṣada Utsava Maṇḍala,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "̄Srī Purandaradāsara sāhitya"
+          ],
+          "shelfMark": [
+            "JMK 84-11"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "contributorLiteral": [
+            "Huccarāyaru, Beṅgēri.",
+            "Krṣṇaśarmā, Beṭagēri, 1900-",
+            "Purandaradāsa, 1484-1564."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMK 84-11"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10893183"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0900276"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636241887334,
+          "publicationStatement": [
+            "Dhāravāḍa : Śrīpurandaradāsara Nānnūraneya Varṣada Utsava Maṇḍala, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10893183",
+            "urn:undefined:(WaOLN)nyp0900276"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic music.",
+            "Purandaradāsa, 1484-1564 -- Criticism and interpretation."
+          ],
+          "titleDisplay": [
+            "̄Srī Purandaradāsara sāhitya / sampādakaru Śrī Beṭagēri Krṣṇaśarma ; Śrī Beṅgēri Huccarāyaru."
+          ],
+          "uri": "b10893183",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "2. Ārtabhāva."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10893183"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14916909",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMK 84-11 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMK 84-11 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068805302"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMK 84-11"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068805302"
+                    ],
+                    "idBarcode": [
+                      "33433068805302"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMK 84-11 v. 000002"
+                  },
+                  "sort": [
+                    "aJMK 84-11 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10894417",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Actors",
+            "Actors -- Karnataka",
+            "Actors -- Karnataka -- Biography",
+            "Yakṣagāna"
+          ],
+          "publisherLiteral": [
+            "Mayura Prakashana : adhikrta mārātagāraru, Pragatiśīla Sāhitya Saṅgha,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yakṣagāna kalāvidaru"
+          ],
+          "shelfMark": [
+            "*OLA 84-1994"
+          ],
+          "creatorLiteral": [
+            "Alse, A. Ganapaiah, 1940-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75906010"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-1994"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10894417"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0901510"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636240319125,
+          "publicationStatement": [
+            "Beṅgaḷūru : Mayura Prakashana : adhikrta mārātagāraru, Pragatiśīla Sāhitya Saṅgha, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10894417",
+            "urn:lccn:75906010",
+            "urn:undefined:(WaOLN)nyp0901510"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Actors -- Karnataka -- Biography.",
+            "Yakṣagāna."
+          ],
+          "titleDisplay": [
+            "Yakṣagāna kalāvidaru / A. Gaṇapayya Alse."
+          ],
+          "uri": "b10894417",
+          "lccClassification": [
+            "PN2881.5 .A4"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10894417"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10188096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-1994|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-1994|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997601"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-1994|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997601"
+                    ],
+                    "idBarcode": [
+                      "33433012997601"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-1994|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 84-1994|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10894424",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1959.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Rājya Sāhitya Akāḍemiyinda puraskrta grantha, 1960.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v.1, p. [290]-296.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Samāja Pustakālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sāhitya saṃśōdhane mattu samālōcane"
+          ],
+          "shelfMark": [
+            "*OLA 83-4874"
+          ],
+          "creatorLiteral": [
+            "Naik, Sadanand Narayan, 1913-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74904049"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-4874"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10894424"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74904049"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0901517"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636226029438,
+          "publicationStatement": [
+            "Dhāravāḍa : Samāja Pustakālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10894424",
+            "urn:lccn:74904049",
+            "urn:undefined:(WaOLN)nyp0901517"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sāhitya saṃśōdhane mattu samālōcane / lēkhakaru Sadānanda N̄yaka."
+          ],
+          "uri": "b10894424",
+          "lccClassification": [
+            "PL4650.5 .N26 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10894424"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10188098",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-4874|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-4874|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012996918"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-4874|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012996918"
+                    ],
+                    "idBarcode": [
+                      "33433012996918"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-4874|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 83-4874|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10902372",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without the music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 7: Karnāṭaka Viśvavidyālaya, Rajata Mahōtsava prakaṭane.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Viśvavidyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jīvana Jōkāli."
+          ],
+          "shelfMark": [
+            "*OLA 84-3320"
+          ],
+          "creatorLiteral": [
+            "Sunkapur, M. S."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "70928091"
+          ],
+          "seriesStatement": [
+            "Janapada sāhitya māle, 11, 16, 17"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-3320"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10902372"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70928091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0909480"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202044347,
+          "publicationStatement": [
+            "Dhāravāḍa, Karnāṭaka Viśvavidyālaya [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10902372",
+            "urn:lccn:70928091",
+            "urn:undefined:(WaOLN)nyp0909480"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Jīvana Jōkāli. Sampādakaru Eṃ. Es. Suṅkāpura."
+          ],
+          "uri": "b10902372",
+          "lccClassification": [
+            "M1808.S795 J6"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "6. Ḍoḷḷina hāḍu. -- 7. Gaṇgigauri saṃvāda-Bedeṇḍegabba. -- 8 K̲olupada."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10902372"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10189107",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998187"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998187"
+                    ],
+                    "idBarcode": [
+                      "33433012998187"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000006"
+                  },
+                  "sort": [
+                    "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10189108",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998195"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998195"
+                    ],
+                    "idBarcode": [
+                      "33433012998195"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000007"
+                  },
+                  "sort": [
+                    "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10189109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998203"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998203"
+                    ],
+                    "idBarcode": [
+                      "33433012998203"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000008"
+                  },
+                  "sort": [
+                    "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000008"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920342",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Comprises collected writings of the author, chiefly prefaces to his own works.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Viśvabhārati Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ciracētana."
+          ],
+          "shelfMark": [
+            "*OLA 84-4187"
+          ],
+          "creatorLiteral": [
+            "Krishnarao, A. N., 1908-1971."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72907646"
+          ],
+          "contributorLiteral": [
+            "Krṣṇarāya, Śā. Maṃ."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4187"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920342"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72907646"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927484"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636178095705,
+          "publicationStatement": [
+            "Maḍagāṃva, Viśvabhārati Prakāśana 1894- i.e. 1972-"
+          ],
+          "identifier": [
+            "urn:bnum:10920342",
+            "urn:lccn:72907646",
+            "urn:undefined:(WaOLN)nyp0927484"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ciracētana. Sampādaka Śā. Maṃ. Krṣṇarāya."
+          ],
+          "uri": "b10920342",
+          "lccClassification": [
+            "PL4659.K68 C5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maḍagāṃva,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920342"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4187|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4187|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998468"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4187|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998468"
+                    ],
+                    "idBarcode": [
+                      "33433012998468"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4187|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 84-4187|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920356",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Kannada Saṃśōdhana Saṃsthe, Karnāṭaka Viśvavidyāla,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa vyākaraṇada kelavu samasyegaḷu"
+          ],
+          "shelfMark": [
+            "*OLA 84-4185"
+          ],
+          "creatorLiteral": [
+            "Krṣṇa Bhaṭṭa, Seḍiyāpu, 1902-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75906826"
+          ],
+          "seriesStatement": [
+            "Saṃśōdhana upanyāsamāle ; 10-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4185"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920356"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906826"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927498"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202089429,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannada Saṃśōdhana Saṃsthe, Karnāṭaka Viśvavidyāla, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10920356",
+            "urn:lccn:75906826",
+            "urn:undefined:(WaOLN)nyp0927498"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Kannaḍa vyākaraṇada kelavu samasyegaḷu / upanyāsakaru sēḍiy̲apu lrṣṇabhaṭṭa."
+          ],
+          "uri": "b10920356",
+          "lccClassification": [
+            "PL4644 .K7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920356"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194093",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4185|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4185|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4185|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998450"
+                    ],
+                    "idBarcode": [
+                      "33433012998450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4185|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 84-4185|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920641",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published on the occasion of the golden jubilee celebration of the Kannada Sahitya Parishat.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa sāhitya sammēḷanagaḷa adhyakṣara bhāṣaṇagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 84-4113"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "76922271"
+          ],
+          "seriesStatement": [
+            "Trivārṣika yōjaneya pustakamāle, 10"
+          ],
+          "contributorLiteral": [
+            "Kannada Literary Akademy.",
+            "Kannada Literary Conference."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920641"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76922271"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927784"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202089293,
+          "publicationStatement": [
+            "Beṅgaḷūru, Kannaḍa Sāhitya Pariṣattu, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10920641",
+            "urn:lccn:76922271",
+            "urn:undefined:(WaOLN)nyp0927784"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- Congresses."
+          ],
+          "titleDisplay": [
+            "Kannaḍa sāhitya sammēḷanagaḷa adhyakṣara bhāṣaṇagaḷu."
+          ],
+          "uri": "b10920641",
+          "lccClassification": [
+            "PL4650 .A27"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920641"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194135",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4113|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4113|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998286"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4113|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998286"
+                    ],
+                    "idBarcode": [
+                      "33433012998286"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4113|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 84-4113|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10926039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geḷeyara Gumpu (Karnataka, India)"
+          ],
+          "publisherLiteral": [
+            "Rājahaṃsa Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nānu kaṇḍa Geḷeyara Gumpu"
+          ],
+          "shelfMark": [
+            "*OLA 84-2972"
+          ],
+          "creatorLiteral": [
+            "Kulakarṇi, S. G."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idLccn": [
+            "79900881 /SA"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-2972"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10926039"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79900881 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0933193"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636213547527,
+          "publicationStatement": [
+            "Dhāravāḍa : Rājahaṃsa Prakāśana, [1978]-"
+          ],
+          "identifier": [
+            "urn:bnum:10926039",
+            "urn:lccn:79900881 /SA",
+            "urn:undefined:(WaOLN)nyp0933193"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geḷeyara Gumpu (Karnataka, India)"
+          ],
+          "titleDisplay": [
+            "Nānu kaṇḍa Geḷeyara Gumpu / Śē. Gō. Kulakarṇi."
+          ],
+          "uri": "b10926039",
+          "lccClassification": [
+            "PL4650.A243 K84 1978"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Śānti-Nikētana.--2. Jayakarnāṭka.--3. Sādhana Mudraṇālaya mattu Jīvana māsapatrike."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10926039"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997973"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997973"
+                    ],
+                    "idBarcode": [
+                      "33433012997973"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997981"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997981"
+                    ],
+                    "idBarcode": [
+                      "33433012997981"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997999"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997999"
+                    ],
+                    "idBarcode": [
+                      "33433012997999"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000003"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10946973",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1971.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kālidāsa.",
+            "Kālidāsa. -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Rāsa Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śākuntalā."
+          ],
+          "shelfMark": [
+            "*OLA 84-4754"
+          ],
+          "creatorLiteral": [
+            "Rāmarāya, Samētanahaḷḷi, 1917-1999."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "seriesStatement": [
+            "Rāsa prakāśana, 9",
+            "S. Rama Raya. Rāsa sāhitya, 16"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4754"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10946973"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0954152"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636241730470,
+          "publicationStatement": [
+            "[Maṇḍya?] Rāsa Prakāśana [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10946973",
+            "urn:undefined:(WaOLN)nyp0954152"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kālidāsa. -- Poetry."
+          ],
+          "titleDisplay": [
+            "Śākuntalā. [Lēkhaka] Samētanahaḷḷi Rāmarāya."
+          ],
+          "uri": "b10946973",
+          "lccClassification": [
+            "PK4659.R316 S2"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Maṇḍya?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "2. Vyavahārāṅgaṃ."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10946973"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10198402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4754|zLibrary has: Vol. 2."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4754|zLibrary has: Vol. 2.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998641"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4754|zLibrary has: Vol. 2."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998641"
+                    ],
+                    "idBarcode": [
+                      "33433012998641"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4754|zLibrary has: Vol. 2."
+                  },
+                  "sort": [
+                    "a*OLA 84-4754|zLibrary has: Vol. 2."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10956213",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit (Kannada script); introductory matter in English and Kannada; commentary in Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dvaita (Vedanta)",
+            "Dvaita (Vedanta) -- Early works to 1800",
+            "Madhva, active 13th century"
+          ],
+          "publisherLiteral": [
+            "Śrī Sarvajñācārya Sēvā Saṅgha,"
+          ],
+          "description": [
+            "Exposition of philosophical concepts according to the Dvaita (dualism) school in Indian philosophy as propounded by Madhva, 13th cent."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yuktimallikā : mūlasahita Kannaḍa arthānuvāda"
+          ],
+          "shelfMark": [
+            "*OKN 85-1560"
+          ],
+          "creatorLiteral": [
+            "Vādirāja, active 16th century."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idLccn": [
+            "83901597 /SA"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 85-1560"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10956213"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83901597 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0963410"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636240638908,
+          "publicationStatement": [
+            "Dāvaṇagere : Śrī Sarvajñācārya Sēvā Saṅgha, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10956213",
+            "urn:lccn:83901597 /SA",
+            "urn:undefined:(WaOLN)nyp0963410"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dvaita (Vedanta) -- Early works to 1800.",
+            "Madhva, active 13th century."
+          ],
+          "titleDisplay": [
+            "Yuktimallikā : mūlasahita Kannaḍa arthānuvāda / anuvādakaru Bi. Bhīmarāv."
+          ],
+          "uri": "b10956213",
+          "lccClassification": [
+            "BL1286.292.M34 V33 1978"
+          ],
+          "numItems": [
+            10
+          ],
+          "numAvailable": [
+            10
+          ],
+          "placeOfPublication": [
+            "Dāvaṇagere :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10956213"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 10,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618822"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618822"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951317",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618830"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618830"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618830"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618764"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618764"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618764"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951309",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618772"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618772"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618772"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951311",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618798"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618798"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618798"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951310",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618780"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618780"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951315",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618749"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618749"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618749"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951312",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618806"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618806"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618806"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951314",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618731"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618731"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618731"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951313",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618814"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618814"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618814"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-001560"
+                  },
+                  "sort": [
+                    "a*OKN 85-001560"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960071",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Dhāwār (District)",
+            "Folk songs, Kannada -- Dhāwār (District) -- Texts"
+          ],
+          "publisherLiteral": [
+            "Bhārati Prakāśana ayāṇḍa Buk Ḍipō,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gī gī padagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 85-1273"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78903423 /SA"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 85-1273"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960071"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78903423 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967274"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636195364637,
+          "publicationStatement": [
+            "Hubbaḷḷi : Bhārati Prakāśana ayāṇḍa Buk Ḍipō, [197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10960071",
+            "urn:lccn:78903423 /SA",
+            "urn:undefined:(WaOLN)nyp0967274"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Dhāwār (District) -- Texts."
+          ],
+          "titleDisplay": [
+            "Gī gī padagaḷu."
+          ],
+          "uri": "b10960071",
+          "lccClassification": [
+            "PL4658.5.D482 G5 1970z"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Hubbaḷḷi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10960071"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10200106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 85-1273"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 85-1273",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999102"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1273"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999102"
+                    ],
+                    "idBarcode": [
+                      "33433012999102"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-001273"
+                  },
+                  "sort": [
+                    "a*OLA 85-001273"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960726",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2-   Pradhāna sampādakaru Es. Eṃ. Vrṣabhēndrasvāmi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Criticism and interpretation",
+            "Lingayats"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayanapīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavamārga"
+          ],
+          "shelfMark": [
+            "*OLA 85-1658"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82903291 /SA"
+          ],
+          "contributorLiteral": [
+            "Kalaburgi, Eṃ. Eṃ., 1938-",
+            "Sunkapur, M. S."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 85-1658"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960726"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82903291 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967929"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636173089685,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayanapīṭha, Karnāṭaka Viśvavidyālaya, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10960726",
+            "urn:lccn:82903291 /SA",
+            "urn:undefined:(WaOLN)nyp0967929"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Criticism and interpretation.",
+            "Lingayats."
+          ],
+          "titleDisplay": [
+            "Basavamārga / pradhāna sampādakaru Eṃ. Es. Suṅkāpura, sampādakaru Eṃ. Eṃ. Kalaburgi."
+          ],
+          "uri": "b10960726",
+          "lccClassification": [
+            "PL4659.B34 Z64 1980"
+          ],
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1-2. Basavamārga.--3. Śivaśaraṇara kāyaka siddhānta.--4. Basavēśvara-Gāndhīji."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10960726"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10200271",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999292"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999292"
+                    ],
+                    "idBarcode": [
+                      "33433012999292"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000001"
+                  },
+                  "sort": [
+                    "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10200272",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999284"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999284"
+                    ],
+                    "idBarcode": [
+                      "33433012999284"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000002"
+                  },
+                  "sort": [
+                    "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10200273",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999318"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999318"
+                    ],
+                    "idBarcode": [
+                      "33433012999318"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10200274",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999300"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999300"
+                    ],
+                    "idBarcode": [
+                      "33433012999300"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000004"
+                  },
+                  "sort": [
+                    "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960742",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2-   published by: Rāyabḡa, Jille Beḷagāvi : Kālagati Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Beṅgaḷūru Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pravāha patitara karma ʻHindūʼ emba dharma"
+          ],
+          "shelfMark": [
+            "*OLY 85-1572"
+          ],
+          "creatorLiteral": [
+            "Joshi, Shankar Baldixit, 1896-"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77904440"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 85-1572"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960742"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77904440"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967945"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636217462897,
+          "publicationStatement": [
+            "Beṅgaḷūru : Prasārāṅga, Beṅgaḷūru Viśvavidyālaya, c1976-"
+          ],
+          "identifier": [
+            "urn:bnum:10960742",
+            "urn:lccn:77904440",
+            "urn:undefined:(WaOLN)nyp0967945"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism."
+          ],
+          "titleDisplay": [
+            "Pravāha patitara karma ʻHindūʼ emba dharma / Śaṃ. Bā. Jōśi."
+          ],
+          "uri": "b10960742",
+          "lccClassification": [
+            "BL1210 .J63 1976"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. [Without special title] -- 2. Vaivasvata Manupranita Manava dharma."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10960742"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13952122",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 85-1572 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 85-1572 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060421959"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 85-1572"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060421959"
+                    ],
+                    "idBarcode": [
+                      "33433060421959"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 85-1572 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLY 85-1572 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13952123",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 85-1572 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 85-1572 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060421967"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 85-1572"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060421967"
+                    ],
+                    "idBarcode": [
+                      "33433060421967"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 85-1572 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLY 85-1572 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10977467",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lingayat poetry, Kannada",
+            "Lingayat poetry, Kannada -- History and criticism",
+            "Śūnyasampādane"
+          ],
+          "publisherLiteral": [
+            "Ṡrī śaila Jagadguru Niḍumāmiḍi Nivāsa,"
+          ],
+          "description": [
+            "On the Śūnyasampādane, 15th century anthology of Virasaivite poetry."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sampādaneya sompu : samagra vivēcane"
+          ],
+          "shelfMark": [
+            "*OLA 84-4577"
+          ],
+          "creatorLiteral": [
+            "Ja. Ca. Ni., 1911-"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78904240 /SA"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4577"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10977467"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78904240 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0984696"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636221945765,
+          "publicationStatement": [
+            "Beṅgaḷūru : Ṡrī śaila Jagadguru Niḍumāmiḍi Nivāsa, 1977-"
+          ],
+          "identifier": [
+            "urn:bnum:10977467",
+            "urn:lccn:78904240 /SA",
+            "urn:undefined:(WaOLN)nyp0984696"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lingayat poetry, Kannada -- History and criticism.",
+            "Śūnyasampādane."
+          ],
+          "titleDisplay": [
+            "Sampādaneya sompu : samagra vivēcane / Ja.Ca.Ni."
+          ],
+          "uri": "b10977467",
+          "lccClassification": [
+            "PL4656.S953 J3 1977"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Esaḷondu. Anubhava sampuṭa."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10977467"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10202056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4577|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4577|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4577|zLibrary has: Vol. 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998591"
+                    ],
+                    "idBarcode": [
+                      "33433012998591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4577|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    "a*OLA 84-4577|zLibrary has: Vol. 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10996867",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography",
+            "Kuvempu, 1904-1994",
+            "Kuvempu, 1904-1994 -- Biography"
+          ],
+          "publisherLiteral": [
+            "Sahyādri Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nenapina dōṇiyalli"
+          ],
+          "shelfMark": [
+            "*OLA 86-3268"
+          ],
+          "creatorLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81901148 /SA"
+          ],
+          "seriesStatement": [
+            "Sahyādri Prakāśana ; 25"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-3268"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10996867"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81901148 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1004145"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636212578924,
+          "publicationStatement": [
+            "Maisūru : Sahyādri Prakāśana 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10996867",
+            "urn:lccn:81901148 /SA",
+            "urn:undefined:(WaOLN)nyp1004145"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Authors, Kannada -- 20th century -- Biography.",
+            "Kuvempu, 1904-1994 -- Biography."
+          ],
+          "titleDisplay": [
+            "Nenapina dōṇiyalli / Kuvempu."
+          ],
+          "uri": "b10996867",
+          "lccClassification": [
+            "PL4659.K94 Z468"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10996867"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10209586",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013120682"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013120682"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013120682"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-3268"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003268"
+                  },
+                  "sort": [
+                    "a*OLA 86-003268"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10209587",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013120096"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013120096"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013120096"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-3268"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003268"
+                  },
+                  "sort": [
+                    "a*OLA 86-003268"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d9a9829261ef7a5f13f361244b66b8b1.json
+++ b/test/fixtures/query-d9a9829261ef7a5f13f361244b66b8b1.json
@@ -1,0 +1,905 @@
+{
+  "took": 36,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.7560005,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.7560005,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-dda295c4180c739a669bdc0ebedd1608.json
+++ b/test/fixtures/query-dda295c4180c739a669bdc0ebedd1608.json
@@ -1,0 +1,13306 @@
+{
+  "took": 251,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5,
+    "max_score": 33.256466,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11826883",
+        "_score": 33.256466,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Applied science & technology index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "R]pertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art and archaeology technical abstracts",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Artbibliographies modern",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Vols. 1 (1965)-10 (1974). 1 v.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Vol. 1 (1965)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Furniture",
+            "Furniture -- England",
+            "Furniture -- England -- History",
+            "Furniture -- England -- History -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "The Society,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "shelfMark": [
+            "JQL 08-18"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "66053650 //r89"
+          ],
+          "idIssn": [
+            "0016-3058"
+          ],
+          "contributorLiteral": [
+            "Furniture History Society (London, England)"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-18"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11826883"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0016-3058"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "66053650 //r89"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0280126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1832956"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1965)-44(2008)-",
+                "v. 3636 (2000) - v. 45 (2000); v. 44 (2008); v. 45 (2009); v. 46 (2010); v. 47 (2011); v. 48 (2012); v. 49 (2013); v. 50 (2014); v. 55 (2019)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 30 (1994)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 31 (1995)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 32 (1996)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (1997)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 34 (1998)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 35 (1999)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26-35 (1990 - 1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 37 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 38 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 39 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 40 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 41 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 42 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 43 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 44 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 45 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 46 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 47 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 48 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36-45 (2000 - 2009)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 49 (2013)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 50 (2014)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 51 (2015)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 52 (2016)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 53 (2017)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 54 (2018)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 55 (2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 56 (2020)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 57 (2021)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 58 (2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-18"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-18"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1066822",
+              "shelfMark": [
+                "JQL 08-18"
+              ]
+            }
+          ],
+          "updatedAt": 1649888604293,
+          "publicationStatement": [
+            "[London] : The Society,"
+          ],
+          "identifier": [
+            "urn:bnum:11826883",
+            "urn:issn:0016-3058",
+            "urn:lccn:66053650 //r89",
+            "urn:undefined:0280126",
+            "urn:undefined:(WaOLN)nyp1832956"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Furniture -- England -- History -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "uri": "b11826883",
+          "lccClassification": [
+            "NK2528 .F8"
+          ],
+          "numItems": [
+            37
+          ],
+          "numAvailable": [
+            37
+          ],
+          "placeOfPublication": [
+            "[London] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Furnit. hist.",
+            "Furniture history"
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 37,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 1-4 (1965-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 1-4 (1965-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272113"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1965-1968)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272113"
+                    ],
+                    "idBarcode": [
+                      "33433078272113"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000001-4 (1965-1968)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000001-4 (1965-1968)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 5-6 (1969-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 5-6 (1969-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-6 (1969-1970)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272121"
+                    ],
+                    "idBarcode": [
+                      "33433078272121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000005-6 (1969-1970)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000005-6 (1969-1970)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753886",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 7 (1971)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 7 (1971)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272139"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7 (1971)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272139"
+                    ],
+                    "idBarcode": [
+                      "33433078272139"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000007 (1971)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000007 (1971)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 8-9 (1972-1973)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 8-9 (1972-1973)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9 (1972-1973)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272147"
+                    ],
+                    "idBarcode": [
+                      "33433078272147"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000008-9 (1972-1973)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000008-9 (1972-1973)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 10 (1974) + Index v. 1-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272154"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272154"
+                    ],
+                    "idBarcode": [
+                      "33433078272154"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000010 (1974) + Index v. 1-10"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000010 (1974) + Index v. 1-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 11-12 (1975-1976)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 11-12 (1975-1976)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272162"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12 (1975-1976)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272162"
+                    ],
+                    "idBarcode": [
+                      "33433078272162"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000011-12 (1975-1976)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000011-12 (1975-1976)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 13 (1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 13 (1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272170"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13 (1977)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272170"
+                    ],
+                    "idBarcode": [
+                      "33433078272170"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000013 (1977)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000013 (1977)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 14-15 (1978-1979)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 14-15 (1978-1979)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14-15 (1978-1979)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272188"
+                    ],
+                    "idBarcode": [
+                      "33433078272188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000014-15 (1978-1979)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000014-15 (1978-1979)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 16-17 (1980-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 16-17 (1980-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272196"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-17 (1980-1981)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272196"
+                    ],
+                    "idBarcode": [
+                      "33433078272196"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000016-17 (1980-1981)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000016-17 (1980-1981)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 18 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 18 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 18 (1982)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272204"
+                    ],
+                    "idBarcode": [
+                      "33433078272204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000018 (1982)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000018 (1982)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 19-20 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 19-20 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272212"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-20 (1983-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272212"
+                    ],
+                    "idBarcode": [
+                      "33433078272212"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000019-20 (1983-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000019-20 (1983-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 21-22 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 21-22 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 21-22 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272220"
+                    ],
+                    "idBarcode": [
+                      "33433078272220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000021-22 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000021-22 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 23-24 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 23-24 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-24 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272238"
+                    ],
+                    "idBarcode": [
+                      "33433078272238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000023-24 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000023-24 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272246"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272246"
+                    ],
+                    "idBarcode": [
+                      "33433078272246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000025-26 (1989-90) + Index v. 16-25 (1980-90)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000025-26 (1989-90) + Index v. 16-25 (1980-90)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 27 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 27 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272253"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27 (1991)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272253"
+                    ],
+                    "idBarcode": [
+                      "33433078272253"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000027 (1991)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000027 (1991)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 28 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 28 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272261"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 28 (1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272261"
+                    ],
+                    "idBarcode": [
+                      "33433078272261"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000028 (1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000028 (1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 29 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 29 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272279"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 29 (1993)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272279"
+                    ],
+                    "idBarcode": [
+                      "33433078272279"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000029 (1993)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000029 (1993)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 30 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 30 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272287"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30 (1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272287"
+                    ],
+                    "idBarcode": [
+                      "33433078272287"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000030 (1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000030 (1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 31 (1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 31 (1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272295"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 31 (1995)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272295"
+                    ],
+                    "idBarcode": [
+                      "33433078272295"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000031 (1995)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000031 (1995)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 32-34 (1996-1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 32-34 (1996-1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272303"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 32-34 (1996-1998)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272303"
+                    ],
+                    "idBarcode": [
+                      "33433078272303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000032-34 (1996-1998)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000032-34 (1996-1998)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 35-37 (1999-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 35-37 (1999-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272311"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-37 (1999-2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272311"
+                    ],
+                    "idBarcode": [
+                      "33433078272311"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000035-37 (1999-2001)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000035-37 (1999-2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 36-45 (2000-2009) + index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 36-45 (2000-2009) + index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101083917"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 36-45 (2000-2009) + index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101083917"
+                    ],
+                    "idBarcode": [
+                      "33433101083917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000036-45 (2000-2009) + index"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000036-45 (2000-2009) + index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 38-39 (2002-2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 38-39 (2002-2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38-39 (2002-2003)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272329"
+                    ],
+                    "idBarcode": [
+                      "33433078272329"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000038-39 (2002-2003)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000038-39 (2002-2003)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627525",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 40-41 (2004-2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 40-41 (2004-2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440389"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40-41 (2004-2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440389"
+                    ],
+                    "idBarcode": [
+                      "33433102440389"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000040-41 (2004-2005)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000040-41 (2004-2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 42-43 (2006-2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 42-43 (2006-2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440397"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 42-43 (2006-2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440397"
+                    ],
+                    "idBarcode": [
+                      "33433102440397"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000042-43 (2006-2007)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000042-43 (2006-2007)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627803",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 44-45 (2008-2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 44-45 (2008-2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084525736"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 44-45 (2008-2009)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084525736"
+                    ],
+                    "idBarcode": [
+                      "33433084525736"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000044-45 (2008-2009)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000044-45 (2008-2009)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26216680",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 46 (2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 46 (2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088832484"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46 (2010)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088832484"
+                    ],
+                    "idBarcode": [
+                      "33433088832484"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000046 (2010)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000046 (2010)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878768",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 47 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 47 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101072555"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 47 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101072555"
+                    ],
+                    "idBarcode": [
+                      "33433101072555"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000047 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000047 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011841",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 48 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 48 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101084204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101084204"
+                    ],
+                    "idBarcode": [
+                      "33433101084204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000048 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000048 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31146937",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 49 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 49 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101062549"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101062549"
+                    ],
+                    "idBarcode": [
+                      "33433101062549"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000049 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000049 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32204255",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 50 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 50 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112607373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112607373"
+                    ],
+                    "idBarcode": [
+                      "33433112607373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000050 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000050 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33587281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 51 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 51 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069825366"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069825366"
+                    ],
+                    "idBarcode": [
+                      "33433069825366"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000051 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000051 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36041027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 53 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 53 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433086720046"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433086720046"
+                    ],
+                    "idBarcode": [
+                      "33433086720046"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000053 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000053 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 54 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 54 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433083531677"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433083531677"
+                    ],
+                    "idBarcode": [
+                      "33433083531677"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000054 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000054 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 55 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 55 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076528763"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076528763"
+                    ],
+                    "idBarcode": [
+                      "33433076528763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000055 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000055 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 56 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 56 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076529019"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076529019"
+                    ],
+                    "idBarcode": [
+                      "33433076529019"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000056 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000056 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39175596",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 57 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 57 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072299997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2021)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072299997"
+                    ],
+                    "idBarcode": [
+                      "33433072299997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000057 (2021)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000057 (2021)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b16775643",
+        "_score": 15.618275,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from cover.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "No. 16 (fall 1982)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Research",
+            "Art -- Research -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "University of Illinois Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Visual arts research."
+          ],
+          "shelfMark": [
+            "JQL 08-3"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83644328 "
+          ],
+          "idIssn": [
+            "0736-0770"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16775643"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0736-0770"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83644328 "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)9069635"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S240000007"
+            },
+            {
+              "type": "bf:Issn",
+              "identifierStatus": "incorrect",
+              "value": "0160-3221"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "9(1983)-27(2001)-"
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-3"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-3"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab82",
+                  "label": "Schwarzman Building M1 - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1090282",
+              "shelfMark": [
+                "JQL 08-3"
+              ]
+            }
+          ],
+          "updatedAt": 1636752116421,
+          "publicationStatement": [
+            "[Champaign, Ill.] : University of Illinois Press, c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:16775643",
+            "urn:issn:0736-0770",
+            "urn:lccn:83644328 ",
+            "urn:undefined:(OCoLC)9069635",
+            "urn:undefined:(WaOLN)S240000007",
+            "b16775643#1.0001",
+            "urn:issn:0160-3221"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Research -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Visual arts research."
+          ],
+          "uri": "b16775643",
+          "lccClassification": [
+            "N81 .R49"
+          ],
+          "numItems": [
+            10
+          ],
+          "numAvailable": [
+            10
+          ],
+          "placeOfPublication": [
+            "[Champaign, Ill.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Vis. arts res.",
+            "Visual arts research"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 10,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 11-12 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 11-12 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083159"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "11-12 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083159"
+                    ],
+                    "idBarcode": [
+                      "33433074083159"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 11-12 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 11-12 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 13-14 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 13-14 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083175"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "13-14 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083175"
+                    ],
+                    "idBarcode": [
+                      "33433074083175"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 13-14 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 13-14 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 17-18 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 17-18 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083225"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "17-18 (1991-1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083225"
+                    ],
+                    "idBarcode": [
+                      "33433074083225"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 17-18 (1991-1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 17-18 (1991-1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 19-20 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 19-20 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083209"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "19-20 (1993-1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083209"
+                    ],
+                    "idBarcode": [
+                      "33433074083209"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 19-20 (1993-1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 19-20 (1993-1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 21-23 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 21-23 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083217"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "21-23 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083217"
+                    ],
+                    "idBarcode": [
+                      "33433074083217"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 21-23 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 21-23 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662015",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 24-25 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 24-25 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "24-25 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083191"
+                    ],
+                    "idBarcode": [
+                      "33433074083191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 24-25 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 24-25 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 26-27 (2000-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 26-27 (2000-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083142"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "26-27 (2000-2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083142"
+                    ],
+                    "idBarcode": [
+                      "33433074083142"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 26-27 (2000-2001)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 26-27 (2000-2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 9-10 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 9-10 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083183"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "9-10 (1983-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083183"
+                    ],
+                    "idBarcode": [
+                      "33433074083183"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 9-10 (1983-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 9-10 (1983-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627807",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 15-16 (1989-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 15-16 (1989-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255586"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15-16 (1989-90)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255586"
+                    ],
+                    "idBarcode": [
+                      "33433105255586"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000015-16 (1989-90)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 v. 000015-16 (1989-90)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29405160",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433115147914"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433115147914"
+                    ],
+                    "idBarcode": [
+                      "33433115147914"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000038, no. 1, Issue 74 (Sum. 2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 v. 000038, no. 1, Issue 74 (Sum. 2012)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b21506221",
+        "_score": 15.535671,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A magazine of art, design and architecture.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on: Issue 01 (2007/08); title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: Issue 01 (2007/08)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Issue 01 (2007-08)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Faculty of Art, Design and Architecture, Kingston University,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kiosk."
+          ],
+          "shelfMark": [
+            "JQL 18-4"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "idIssn": [
+            "1755-9626"
+          ],
+          "contributorLiteral": [
+            "Kingston University (London, England). Faculty of Art, Design and Architecture."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 18-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21506221"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "1755-9626"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)190792176"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636807100803,
+          "publicationStatement": [
+            "London : Faculty of Art, Design and Architecture, Kingston University, 2007-"
+          ],
+          "identifier": [
+            "urn:bnum:21506221",
+            "urn:issn:1755-9626",
+            "urn:undefined:(OCoLC)190792176"
+          ],
+          "genreForm": [
+            "Periodicals."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Periodicals.",
+            "Art."
+          ],
+          "titleDisplay": [
+            "Kiosk."
+          ],
+          "uri": "b21506221",
+          "lccClassification": [
+            "N1 .K56"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i35913145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab82",
+                        "label": "Schwarzman Building M1 - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab82||Schwarzman Building M1 - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 18-4 issue 1 (2007/08)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 18-4 issue 1 (2007/08)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116522354"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 18-4"
+                    ],
+                    "enumerationChronology": [
+                      "issue 1 (2007/08)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116522354"
+                    ],
+                    "idBarcode": [
+                      "33433116522354"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 18-4 issue 1 (2007/08)"
+                  },
+                  "sort": [
+                    "aJQL 18-4 issue 1 (2007/08)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12525718",
+        "_score": 12.831403,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published: Fratelli Palombi Editori, 1954-1984; L'Erma di Bretschneider, 1985- .",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Anno 25 (1978)-27 (1980) combined.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Anno 1, n. 1-2 (1954)-anno 32 (1985) ; nuova serie, 1 (1987)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Rome (Italy)",
+            "Rome (Italy) -- Galleries and museums"
+          ],
+          "publisherLiteral": [
+            "Gli Amici,"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1954
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "shelfMark": [
+            "JQL 08-17"
+          ],
+          "createdString": [
+            "1954"
+          ],
+          "idLccn": [
+            "64036787 //r882"
+          ],
+          "idIssn": [
+            "0523-9346"
+          ],
+          "contributorLiteral": [
+            "Amici dei musei di Roma (Italy)"
+          ],
+          "dateStartYear": [
+            1954
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12525718"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0523-9346"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "64036787 //r882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S010000043"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1954)-6(1959),8(1961)-32(1985) [N.S] 1(1987)-18(2004),25(2011)28(2014),32(2018)-",
+                "v. 25 (2011) - v. 28 (2014); v. 32 (2020)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 7 (1993)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 8 (1994)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 9 (1995)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 10 (1996)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 11 (1997)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 12 (1998)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 13 (1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 14 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 15 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 16 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 17 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 18 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 19 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 20 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 21 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 22 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 23 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 24 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 25 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 27 (2013)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 28 (2014)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 29 (2015)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 30 (2018)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 31 (2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 32 (2018)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (2021)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 34 (2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-17"
+                }
+              ],
+              "notes": [
+                "Order transferred from GRD to ART per CCK/ART 7/29/04 ?EP"
+              ],
+              "physicalLocation": [
+                "JQL 08-17"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1069076",
+              "shelfMark": [
+                "JQL 08-17"
+              ]
+            }
+          ],
+          "updatedAt": 1644388628630,
+          "publicationStatement": [
+            "[Roma] : Gli Amici, [1954]-"
+          ],
+          "identifier": [
+            "urn:bnum:12525718",
+            "urn:issn:0523-9346",
+            "urn:lccn:64036787 //r882",
+            "urn:undefined:(WaOLN)S010000043"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1954"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rome (Italy) -- Galleries and museums."
+          ],
+          "titleDisplay": [
+            "Bollettino dei Musei comunali di Roma / a cura degli Amici dei musei di Roma."
+          ],
+          "uri": "b12525718",
+          "lccClassification": [
+            "AM55.R6 B6"
+          ],
+          "numItems": [
+            17
+          ],
+          "numAvailable": [
+            17
+          ],
+          "placeOfPublication": [
+            "[Roma] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Boll. Mus. comunali Roma",
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 17,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757466",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 1-2 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857576"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857576"
+                    ],
+                    "idBarcode": [
+                      "33433019857576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000001-2 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000001-2 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 3-4 (1989-1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857584"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857584"
+                    ],
+                    "idBarcode": [
+                      "33433019857584"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000003-4 (1989-1990)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000003-4 (1989-1990)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757468",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 5-6 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857592"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857592"
+                    ],
+                    "idBarcode": [
+                      "33433019857592"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000005-6 (1991-1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000005-6 (1991-1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 7-8 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857600"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857600"
+                    ],
+                    "idBarcode": [
+                      "33433019857600"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000007-8 (1993-1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000007-8 (1993-1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757470",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 9-11 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857618"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857618"
+                    ],
+                    "idBarcode": [
+                      "33433019857618"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000009-11 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000009-11 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757471",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 12-13 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857626"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857626"
+                    ],
+                    "idBarcode": [
+                      "33433019857626"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000012-13 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000012-13 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 14-16 (2000-2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857634"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857634"
+                    ],
+                    "idBarcode": [
+                      "33433019857634"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000014-16 (2000-2002)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000014-16 (2000-2002)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14288461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 17-18 (2003-2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060930082"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060930082"
+                    ],
+                    "idBarcode": [
+                      "33433060930082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000017-18 (2003-2004)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000017-18 (2003-2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30890910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 25  (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 25  (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101055220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 25  (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101055220"
+                    ],
+                    "idBarcode": [
+                      "33433101055220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000025 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000025 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32391069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 26 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 26 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112611961"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 26 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112611961"
+                    ],
+                    "idBarcode": [
+                      "33433112611961"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000026 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000026 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33682199",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 27 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 27 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117979173"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 27 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117979173"
+                    ],
+                    "idBarcode": [
+                      "33433117979173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000027 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000027 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33860628",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 28 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 28 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117119341"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 28 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117119341"
+                    ],
+                    "idBarcode": [
+                      "33433117119341"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000028 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000028 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37359040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 32 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 32 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121729853"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 32 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121729853"
+                    ],
+                    "idBarcode": [
+                      "33433121729853"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000032 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000032 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757462",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 1-6 (1954-1959)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 1-6 (1954-1959)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857535"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-6 (1954-1959)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857535"
+                    ],
+                    "idBarcode": [
+                      "33433019857535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000001-6 (1954-1959)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000001-6 (1954-1959)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757463",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 8-15 (1961-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 8-15 (1961-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857543"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-15 (1961-1968)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857543"
+                    ],
+                    "idBarcode": [
+                      "33433019857543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000008-15 (1961-1968)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000008-15 (1961-1968)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757464",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 16-24 (1969-1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 16-24 (1969-1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857550"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-24 (1969-1977)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857550"
+                    ],
+                    "idBarcode": [
+                      "33433019857550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000016-24 (1969-1977)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000016-24 (1969-1977)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757465",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 25-32 (1978-1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 25-32 (1978-1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-32 (1978-1985)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857568"
+                    ],
+                    "idBarcode": [
+                      "33433019857568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000025-32 (1978-1985)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000025-32 (1978-1985)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11560439",
+        "_score": 12.750666,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals. Second edition. Revised and enlarged. Supplement",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Summaries in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1. jaarg., nr. 1/2 (1953)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Amsterdam",
+            "Art -- Amsterdam -- Periodicals",
+            "Art -- Periodicals",
+            "Rijksmuseum (Netherlands)",
+            "Rijksmuseum (Netherlands) -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Rijks-Museum,"
+          ],
+          "language": [
+            {
+              "id": "lang:dut",
+              "label": "Dutch"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1953
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Bulletin."
+          ],
+          "shelfMark": [
+            "JQL 08-19"
+          ],
+          "createdString": [
+            "1953"
+          ],
+          "idLccn": [
+            "sn 86000271"
+          ],
+          "idIssn": [
+            "0165-9510"
+          ],
+          "dateStartYear": [
+            1953
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-19"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11560439"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0165-9510"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sn 86000271"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4272788"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1568914"
+            }
+          ],
+          "idOclc": [
+            "4272788"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1953)-65(2017), 66:2(2018)-67:3(2019),68:1(2020)-68:2(2020)-",
+                "v. 66, no. 1 (2018); v. 66, no. 4 (2018) - v. 67, no. 3 (2019); v. 68, no. 1 (2020) - no. 3 (2020); v. 69, no. 3 (2021)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 66 No. 1 (2018)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 2 (2018)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 3 (2018)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 4 (2018)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 1 (2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 2 (2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 3 (2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 4 (2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 68 No. 1 (2020)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 2 (2020)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 3 (2020)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 4 (2020)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 1 (2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 2 (2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 3 (2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 4 (2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 70 No. 1 (2022)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-19"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-19"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:rcmb2",
+                  "label": "Offsite"
+                }
+              ],
+              "uri": "h1059577",
+              "shelfMark": [
+                "JQL 08-19"
+              ]
+            }
+          ],
+          "updatedAt": 1647266949911,
+          "publicationStatement": [
+            "Amsterdam : Rijks-Museum, 1953-"
+          ],
+          "identifier": [
+            "urn:bnum:11560439",
+            "urn:issn:0165-9510",
+            "urn:lccn:sn 86000271",
+            "urn:oclc:4272788",
+            "urn:undefined:(WaOLN)nyp1568914"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1953"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Amsterdam -- Periodicals.",
+            "Art -- Periodicals.",
+            "Rijksmuseum (Netherlands) -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Bulletin."
+          ],
+          "uri": "b11560439",
+          "lccClassification": [
+            "N2460 .A3"
+          ],
+          "numItems": [
+            69
+          ],
+          "numAvailable": [
+            67
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Bull. Rÿksmus.",
+            "Bulletin Mauritshuis",
+            "Bulletin van het Rijksmuseum"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 69,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 1-4 (1953-1956)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 1-4 (1953-1956)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846041"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1953-1956)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846041"
+                    ],
+                    "idBarcode": [
+                      "33433019846041"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000001-4 (1953-1956)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000001-4 (1953-1956)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 5-8 (1957-1960)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 5-8 (1957-1960)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846058"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-8 (1957-1960)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846058"
+                    ],
+                    "idBarcode": [
+                      "33433019846058"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000005-8 (1957-1960)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000005-8 (1957-1960)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693366",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 9-12 (1961-1964)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 9-12 (1961-1964)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846066"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-12 (1961-1964)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846066"
+                    ],
+                    "idBarcode": [
+                      "33433019846066"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000009-12 (1961-1964)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000009-12 (1961-1964)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693367",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 13-15 (1965-1967)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 13-15 (1965-1967)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846074"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13-15 (1965-1967)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846074"
+                    ],
+                    "idBarcode": [
+                      "33433019846074"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000013-15 (1965-1967)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000013-15 (1965-1967)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693368",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 16-18 (1968-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 16-18 (1968-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846082"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-18 (1968-1970)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846082"
+                    ],
+                    "idBarcode": [
+                      "33433019846082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000016-18 (1968-1970)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000016-18 (1968-1970)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693369",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 19-22 (1971-1974)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 19-22 (1971-1974)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846090"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-22 (1971-1974)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846090"
+                    ],
+                    "idBarcode": [
+                      "33433019846090"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000019-22 (1971-1974)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000019-22 (1971-1974)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693370",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 23-26 (1975-1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 23-26 (1975-1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846108"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-26 (1975-1978)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846108"
+                    ],
+                    "idBarcode": [
+                      "33433019846108"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000023-26 (1975-1978)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000023-26 (1975-1978)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693371",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 27-29 (1979-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 27-29 (1979-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846116"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27-29 (1979-1981)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846116"
+                    ],
+                    "idBarcode": [
+                      "33433019846116"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000027-29 (1979-1981)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000027-29 (1979-1981)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693372",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 30-32 (1982-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 30-32 (1982-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846124"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30-32 (1982-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846124"
+                    ],
+                    "idBarcode": [
+                      "33433019846124"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000030-32 (1982-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000030-32 (1982-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693373",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 33-34 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 33-34 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846132"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 33-34 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846132"
+                    ],
+                    "idBarcode": [
+                      "33433019846132"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000033-34 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000033-34 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693374",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 35-36 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 35-36 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846140"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-36 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846140"
+                    ],
+                    "idBarcode": [
+                      "33433019846140"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000035-36 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000035-36 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693375",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 37 (1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 37 (1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846157"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 37 (1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846157"
+                    ],
+                    "idBarcode": [
+                      "33433019846157"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000037 (1989)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000037 (1989)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693376",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 38 (1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 38 (1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846165"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38 (1990)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846165"
+                    ],
+                    "idBarcode": [
+                      "33433019846165"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000038 (1990)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000038 (1990)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693377",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 39 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 39 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846173"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 39 (1991)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846173"
+                    ],
+                    "idBarcode": [
+                      "33433019846173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000039 (1991)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000039 (1991)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693378",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 40 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 40 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846181"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40 (1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846181"
+                    ],
+                    "idBarcode": [
+                      "33433019846181"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000040 (1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000040 (1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693379",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 41 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 41 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846199"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 41 (1993)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846199"
+                    ],
+                    "idBarcode": [
+                      "33433019846199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000041 (1993)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000041 (1993)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693380",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 42 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 42 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846207"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 42 (1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846207"
+                    ],
+                    "idBarcode": [
+                      "33433019846207"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000042 (1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000042 (1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693381",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 43-45 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 43-45 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846215"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 43-45 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846215"
+                    ],
+                    "idBarcode": [
+                      "33433019846215"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000043-45 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000043-45 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693382",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 46-47 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 46-47 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846223"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46-47 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846223"
+                    ],
+                    "idBarcode": [
+                      "33433019846223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000046-47 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000046-47 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 48 (2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 48 (2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255578"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2000)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255578"
+                    ],
+                    "idBarcode": [
+                      "33433105255578"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000048 (2000)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000048 (2000)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 49 (2001) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 49 (2001) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526143"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2001) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526143"
+                    ],
+                    "idBarcode": [
+                      "33433071526143"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000049 (2001) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000049 (2001) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508058",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 50 (2002) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 50 (2002) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526218"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2002) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526218"
+                    ],
+                    "idBarcode": [
+                      "33433071526218"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000050 (2002) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000050 (2002) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508059",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 51 (2003) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 51 (2003) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526226"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2003) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526226"
+                    ],
+                    "idBarcode": [
+                      "33433071526226"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000051 (2003) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000051 (2003) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508060",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 52 (2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 52 (2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526234"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 52 (2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526234"
+                    ],
+                    "idBarcode": [
+                      "33433071526234"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000052 (2004)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000052 (2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508061",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 53 (2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 53 (2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526242"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526242"
+                    ],
+                    "idBarcode": [
+                      "33433071526242"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000053 (2005)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000053 (2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756731",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 54 (2006) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 54 (2006) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2006) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608188"
+                    ],
+                    "idBarcode": [
+                      "33433099608188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000054 (2006) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000054 (2006) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756751",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 55 (2007) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 55 (2007) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608063"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2007) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608063"
+                    ],
+                    "idBarcode": [
+                      "33433099608063"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000055 (2007) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000055 (2007) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757051",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 56 (2008) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 56 (2008) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099607917"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2008) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099607917"
+                    ],
+                    "idBarcode": [
+                      "33433099607917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000056 (2008) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000056 (2008) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757661",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 57 (2009) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 57 (2009) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608055"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2009) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608055"
+                    ],
+                    "idBarcode": [
+                      "33433099608055"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000057 (2009) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000057 (2009) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757665",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 58 (2010) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 58 (2010) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608048"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 58 (2010) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608048"
+                    ],
+                    "idBarcode": [
+                      "33433099608048"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000058 (2010) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000058 (2010) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36975113",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:29",
+                        "label": "bundled materials (vols.)"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:29||bundled materials (vols.)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124984265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124984265"
+                    ],
+                    "idBarcode": [
+                      "33433124984265"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587267",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 1 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 1 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930839"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 1 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930839"
+                    ],
+                    "idBarcode": [
+                      "33433124930839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 1 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 1 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 2 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 2 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938352"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 2 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938352"
+                    ],
+                    "idBarcode": [
+                      "33433124938352"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 2 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 2 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809085",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 3 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 3 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938360"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 3 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938360"
+                    ],
+                    "idBarcode": [
+                      "33433124938360"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 3 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 3 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 4 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 4 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938378"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 4 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938378"
+                    ],
+                    "idBarcode": [
+                      "33433124938378"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 4 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 4 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 1 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 1 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938386"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 1 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938386"
+                    ],
+                    "idBarcode": [
+                      "33433124938386"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 1 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 1 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809089",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 2 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 2 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938394"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 2 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938394"
+                    ],
+                    "idBarcode": [
+                      "33433124938394"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 2 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 2 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809091",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 3 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 3 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938402"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 3 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938402"
+                    ],
+                    "idBarcode": [
+                      "33433124938402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 3 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 3 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809092",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 4 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 4 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938410"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 4 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938410"
+                    ],
+                    "idBarcode": [
+                      "33433124938410"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 4 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 4 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809095",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 1 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 1 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938428"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 1 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938428"
+                    ],
+                    "idBarcode": [
+                      "33433124938428"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 1 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 1 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 2 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 2 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938436"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 2 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938436"
+                    ],
+                    "idBarcode": [
+                      "33433124938436"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 2 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 2 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 3 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 3 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938444"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 3 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938444"
+                    ],
+                    "idBarcode": [
+                      "33433124938444"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 3 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 3 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 4 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 4 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938451"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 4 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938451"
+                    ],
+                    "idBarcode": [
+                      "33433124938451"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 4 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 4 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587273",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 1 (2014) "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 1 (2014) ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 1 (2014) "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930854"
+                    ],
+                    "idBarcode": [
+                      "33433124930854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 1 (2014) "
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 1 (2014) "
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 2 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 2 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938469"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 2 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938469"
+                    ],
+                    "idBarcode": [
+                      "33433124938469"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 2 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 2 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 3 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 3 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938477"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 3 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938477"
+                    ],
+                    "idBarcode": [
+                      "33433124938477"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 3 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 3 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 4 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 4 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938485"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 4 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938485"
+                    ],
+                    "idBarcode": [
+                      "33433124938485"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 4 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 4 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 1 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 1 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 1 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938568"
+                    ],
+                    "idBarcode": [
+                      "33433124938568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 1 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 1 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809110",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 2 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 2 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938550"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 2 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938550"
+                    ],
+                    "idBarcode": [
+                      "33433124938550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 2 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 2 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809112",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 3 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 3 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938543"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 3 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938543"
+                    ],
+                    "idBarcode": [
+                      "33433124938543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 3 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 3 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 50
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 4 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 4 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938535"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 4 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938535"
+                    ],
+                    "idBarcode": [
+                      "33433124938535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 4 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 4 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809118",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 1 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 1 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938493"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 1 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938493"
+                    ],
+                    "idBarcode": [
+                      "33433124938493"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 1 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 1 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809120",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 2 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 2 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938501"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 2 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938501"
+                    ],
+                    "idBarcode": [
+                      "33433124938501"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 2 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 2 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809121",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 3 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 3 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938519"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 3 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938519"
+                    ],
+                    "idBarcode": [
+                      "33433124938519"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 3 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 3 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809123",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 4 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 4 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938527"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 4 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938527"
+                    ],
+                    "idBarcode": [
+                      "33433124938527"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 4 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 4 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587336",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 1 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 1 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 1 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930862"
+                    ],
+                    "idBarcode": [
+                      "33433124930862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 1 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 1 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809126",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 2 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 2 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938592"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 2 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938592"
+                    ],
+                    "idBarcode": [
+                      "33433124938592"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 2 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 2 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 3 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 3 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938584"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 3 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938584"
+                    ],
+                    "idBarcode": [
+                      "33433124938584"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 3 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 3 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809132",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 4 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 4 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938576"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 4 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938576"
+                    ],
+                    "idBarcode": [
+                      "33433124938576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 4 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 4 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36842152",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 1 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 1 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121700144"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 1 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121700144"
+                    ],
+                    "idBarcode": [
+                      "33433121700144"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 1 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066 no. 1 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36785774",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 4 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 4 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121696201"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 4 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121696201"
+                    ],
+                    "idBarcode": [
+                      "33433121696201"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 4 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066 no. 4 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587546",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 2  (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 2  (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611381"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 2  (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611381"
+                    ],
+                    "idBarcode": [
+                      "33433122611381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 2 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066, no. 2 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587547",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 3 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 3 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 3 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611373"
+                    ],
+                    "idBarcode": [
+                      "33433122611373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 3 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066, no. 3 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37012009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67 no. 1 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67 no. 1 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121711620"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67 no. 1 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121711620"
+                    ],
+                    "idBarcode": [
+                      "33433121711620"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067 no. 1 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067 no. 1 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37379200",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 2 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 2 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121962835"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 2 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121962835"
+                    ],
+                    "idBarcode": [
+                      "33433121962835"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 2 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067, no. 2 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37528681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 3 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 3 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128509571"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 3 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128509571"
+                    ],
+                    "idBarcode": [
+                      "33433128509571"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 3 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067, no. 3 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094662",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68 no. 3 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68 no. 3 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132313184"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 68 no. 3 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132313184"
+                    ],
+                    "idBarcode": [
+                      "33433132313184"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068 no. 3 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000068 no. 3 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 67
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38109693",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68, no. 2 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68, no. 2 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128589565"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 68, no. 2 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128589565"
+                    ],
+                    "idBarcode": [
+                      "33433128589565"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068, no. 2 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000068, no. 2 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 68
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094674",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 69 no. 3 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 69 no. 3 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132312749"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 no. 3 (2021)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132312749"
+                    ],
+                    "idBarcode": [
+                      "33433132312749"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000069 no. 3 (2021)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000069 no. 3 (2021)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-de1c2c079c8554493653f49ef4587d1e.json
+++ b/test/fixtures/query-de1c2c079c8554493653f49ef4587d1e.json
@@ -1,0 +1,14597 @@
+{
+  "took": 695,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 9549844,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "publisherLiteral": [
+            "Stauffenburg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "contributorLiteral": [
+            "Baum, Richard.",
+            "Gmelin, Hermann, 1900-1958.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "updatedAt": 1643425443933,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    "aJFE 86-003252"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Constable,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "updatedAt": 1643425444170,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    "aJFF 89-000526"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxii, 321 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [305]-321).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Americans",
+            "Americans -- History",
+            "Americans -- History -- China",
+            "Americans -- History -- China -- 19th century",
+            "China",
+            "China -- Description and travel",
+            "China -- History",
+            "China -- History -- 19th century",
+            "China -- In popular culture",
+            "China -- Relations",
+            "China -- Relations -- United States",
+            "Public opinion",
+            "Public opinion -- United States",
+            "Public opinion -- United States -- History",
+            "Public opinion -- United States -- History -- 19th century",
+            "United States",
+            "United States -- Chinese influences",
+            "United States -- Intellectual life",
+            "United States -- Intellectual life -- 19th century",
+            "United States -- Relations",
+            "United States -- Relations -- China"
+          ],
+          "publisherLiteral": [
+            "Columbia University Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            2008
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876"
+          ],
+          "shelfMark": [
+            "JFE 09-1362"
+          ],
+          "creatorLiteral": [
+            "Haddad, John Rogers."
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "idLccn": [
+            "2008037637"
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000109"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780231130943 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0231130945 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008037637"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)184821618"
+            }
+          ],
+          "idOclc": [
+            "184821618"
+          ],
+          "updatedAt": 1643425447071,
+          "publicationStatement": [
+            "New York : Columbia University Press, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:10000109",
+            "urn:isbn:9780231130943 (cloth : alk. paper)",
+            "urn:isbn:0231130945 (cloth : alk. paper)",
+            "urn:lccn:2008037637",
+            "urn:oclc:184821618",
+            "urn:undefined:(OCoLC)184821618"
+          ],
+          "idIsbn": [
+            "9780231130943 (cloth : alk. paper)",
+            "0231130945 (cloth : alk. paper)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Americans -- History -- China -- 19th century.",
+            "China -- Description and travel.",
+            "China -- History -- 19th century.",
+            "China -- In popular culture.",
+            "China -- Relations -- United States.",
+            "Public opinion -- United States -- History -- 19th century.",
+            "United States -- Chinese influences.",
+            "United States -- Intellectual life -- 19th century.",
+            "United States -- Relations -- China."
+          ],
+          "titleDisplay": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876 / John Rogers Haddad."
+          ],
+          "uri": "b10000109",
+          "lccClassification": [
+            "E183.8.C5 H175 2008"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Xanadu : an envoy at the throne of a monarch -- Romantic domesticity : a Chinese world invented at home -- Pursuing the China effect : a country described through marketing -- China in miniature : Nathan Dunn's Chinese museum -- A floating ethnology : the strange voyage of the Chinese junk Keying -- God's China : the Middle Kingdom of Samuel Wells Williams -- The cultural fruits of diplomacy : Chinese museum and panorama -- The ugly face of China : Bayard Taylor's travels in Asia -- Traditional China and Chinese Yankees : the Centennial Exposition of 1876."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000109"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLF 82-5145",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061318089"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061318089"
+                    ],
+                    "idBarcode": [
+                      "33433061318089"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLF 82-005145"
+                  },
+                  "sort": [
+                    "a*OLF 82-005145"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23117386",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084847221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084847221"
+                    ],
+                    "idBarcode": [
+                      "33433084847221"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001362"
+                  },
+                  "sort": [
+                    "aJFE 09-001362"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000432",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "94 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah"
+          ],
+          "shelfMark": [
+            "*OMO 84-1527"
+          ],
+          "creatorLiteral": [
+            "Yūshīj, Nīmā."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-1527"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000432"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100386"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200431"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636117871714,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10000432",
+            "urn:undefined:NNSZ00100386",
+            "urn:undefined:(WaOLN)nyp0200431"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah / az Nīmā yūshīj."
+          ],
+          "uri": "b10000432",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khānah-ʼi Sarīvaylī."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000432"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000245",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMO 84-1527",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898497"
+                    ],
+                    "idBarcode": [
+                      "33433001898497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-001527"
+                  },
+                  "sort": [
+                    "a*OMO 84-001527"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000871",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  },
+                  "sort": [
+                    "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001377",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill., music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 69).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Improvisation (Music)",
+            "Improvisation (Music) -- Instruction and study",
+            "Organ (Musical instrument)",
+            "Organ (Musical instrument) -- Instruction and study",
+            "Organ builders",
+            "Organ builders -- Germany",
+            "Organ music",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Silbermann, Gottfried, 1683-1753"
+          ],
+          "publisherLiteral": [
+            "Verlag Klaus-Jürgen Kamprad,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns"
+          ],
+          "shelfMark": [
+            "JMG 09-710"
+          ],
+          "creatorLiteral": [
+            "Wagler, Dietrich, 1940-"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "seriesStatement": [
+            "Freiberger Studien zur Orgel ; 10"
+          ],
+          "contributorLiteral": [
+            "Gottfried-Silbermann-Gesellschaft."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 09-710"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001377"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783930550494 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3930550490 (pbk.)"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)439765611"
+            }
+          ],
+          "updatedAt": 1636081466070,
+          "publicationStatement": [
+            "[Altenburg] : Verlag Klaus-Jürgen Kamprad, c2007."
+          ],
+          "identifier": [
+            "urn:bnum:10001377",
+            "urn:isbn:9783930550494 (pbk.)",
+            "urn:isbn:3930550490 (pbk.)",
+            "urn:undefined:(OCoLC)439765611"
+          ],
+          "idIsbn": [
+            "9783930550494 (pbk.)",
+            "3930550490 (pbk.)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Improvisation (Music) -- Instruction and study.",
+            "Organ (Musical instrument) -- Instruction and study.",
+            "Organ builders -- Germany.",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Silbermann, Gottfried, 1683-1753."
+          ],
+          "titleDisplay": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns / Dietrich Wagler ; [Hrsg.: Gottfried-Silbermann-Gesellschaft]."
+          ],
+          "uri": "b10001377",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Altenburg] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10001377"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24299761",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 09-710"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 09-710",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089337251"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 09-710"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089337251"
+                    ],
+                    "idBarcode": [
+                      "33433089337251"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJMG 09-000710"
+                  },
+                  "sort": [
+                    "aJMG 09-000710"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784137",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784138",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784139",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784140",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784141",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784142",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784143",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784144",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784146",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 15",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784147",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Map Div. 84-146 v. 17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017"
+                  },
+                  "sort": [
+                    "aMap Div. 84-146 v. 000017"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784177",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 82-2276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276"
+                  },
+                  "sort": [
+                    "a*OKN 82-002276"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001459",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFD 82-4488",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488"
+                  },
+                  "sort": [
+                    "a*OFD 82-004488"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002297",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Firdawsī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "shelfMark": [
+            "*OMZ 84-1529"
+          ],
+          "creatorLiteral": [
+            "Dawlatābādī, Àlī Muḥammad."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1529"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202293"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Firdawsī, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10002297",
+            "urn:undefined:NNSZ00202345",
+            "urn:undefined:(WaOLN)nyp0202293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "uri": "b10002297",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10002297"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1529",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539872"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539872"
+                    ],
+                    "idBarcode": [
+                      "33433014539872"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001529"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001529"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002303",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "280 p. : facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century",
+            "Political prisoners",
+            "Political prisoners -- Iran",
+            "Political prisoners -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Haftah,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1538"
+          ],
+          "creatorLiteral": [
+            "Khāmahʼī, Anvar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1538"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002303"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202351"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202299"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636121044994,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Haftah, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002303",
+            "urn:undefined:NNSZ00202351",
+            "urn:undefined:(WaOLN)nyp0202299"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century.",
+            "Political prisoners -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad / khāṭirāt-i Anvar Khāmah'ī."
+          ],
+          "uri": "b10002303",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002303"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942130",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1538",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539880"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539880"
+                    ],
+                    "idBarcode": [
+                      "33433014539880"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001538"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001538"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003134",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "397 p. : ill., port., facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Statesmen",
+            "Statesmen -- Iran",
+            "Statesmen -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1427"
+          ],
+          "creatorLiteral": [
+            "Mumtaḥin al-Dawlah Shaqāqī, Mahdī Khān."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "seriesStatement": [
+            "Majmūʻah-ʼi guzashtah-ʼi Īrān dar nivishtah-ʼi pīshīnīyān, 1"
+          ],
+          "contributorLiteral": [
+            "Khānshaqāqī, Ḥusaynqulī."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1427"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003134"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303485"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203127"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003134",
+            "urn:undefined:NNSZ00303485",
+            "urn:undefined:(WaOLN)nyp0203127"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Statesmen -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī / bi-kūshish-i Ḥusaynqulī Khānshaqāqī."
+          ],
+          "uri": "b10003134",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10003134"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942159",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-1427",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539856"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539856"
+                    ],
+                    "idBarcode": [
+                      "33433014539856"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001427"
+                  },
+                  "sort": [
+                    "a*OMZ 84-001427"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003171",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "412 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āvāz-i kushtigān"
+          ],
+          "shelfMark": [
+            "*OMP 84-2030"
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2030"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003171"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303522"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203164"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636145267451,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003171",
+            "urn:undefined:NNSZ00303522",
+            "urn:undefined:(WaOLN)nyp0203164"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Āvāz-i kushtigān / Rizā Barāhinī."
+          ],
+          "uri": "b10003171",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10003171"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002196",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2030",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173038"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173038"
+                    ],
+                    "idBarcode": [
+                      "33433013173038"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002030"
+                  },
+                  "sort": [
+                    "a*OMP 84-002030"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003179",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "101 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chāh bih chāh"
+          ],
+          "shelfMark": [
+            "*OMP 84-2039"
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2039"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003179"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203172"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636081623272,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003179",
+            "urn:undefined:NNSZ00303530",
+            "urn:undefined:(WaOLN)nyp0203172"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Chāh bih chāh / Rizā Barāhinī."
+          ],
+          "uri": "b10003179",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003179"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2039",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173053"
+                    ],
+                    "idBarcode": [
+                      "33433013173053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002039"
+                  },
+                  "sort": [
+                    "a*OMP 84-002039"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003180",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "235 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam and state",
+            "Islam and state -- Iran",
+            "Khomeini, Ruhollah"
+          ],
+          "publisherLiteral": [
+            "Org. of Act. Constitutionalist Iranians,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qizāvat"
+          ],
+          "shelfMark": [
+            "*OMZ 84-965"
+          ],
+          "creatorLiteral": [
+            "ʻAbd al-Raḥmān."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-965"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003180"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203173"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1636124389229,
+          "publicationStatement": [
+            "Los Angeles : Org. of Act. Constitutionalist Iranians, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003180",
+            "urn:undefined:NNSZ00303531",
+            "urn:undefined:(WaOLN)nyp0203173"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam and state -- Iran.",
+            "Khomeini, Ruhollah."
+          ],
+          "titleDisplay": [
+            "Qizāvat / ʻAbd al-Raḥmān..."
+          ],
+          "uri": "b10003180",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Los Angeles :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10003180"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 84-965",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539666"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539666"
+                    ],
+                    "idBarcode": [
+                      "33433014539666"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-000965"
+                  },
+                  "sort": [
+                    "a*OMZ 84-000965"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002358",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGM 84-702",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702"
+                  },
+                  "sort": [
+                    "a*OGM 84-000702"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002360",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002361",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002363",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 1"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 84-641 v. 5 pt 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2"
+                  },
+                  "sort": [
+                    "a*OKOK 84-641 v. 000005 pt 2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002421",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*QYN 82-2046 Dala 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1."
+                  },
+                  "sort": [
+                    "a*QYN 82-2046 Dala 1."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002566",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931"
+                  },
+                  "sort": [
+                    "a*OFP 82-001931"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002601",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002602",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002603",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002604",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002605",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-35 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005"
+                  },
+                  "sort": [
+                    "a*OLC 83-35 v. 000005"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "39, 18, 83, 3 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Reprint of the 1910 ? ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1910"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn,"
+          ],
+          "shelfMark": [
+            "*OGL 83-2455"
+          ],
+          "creatorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "73960850"
+          ],
+          "contributorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGL 83-2455"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003958"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960850"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304319"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203950"
+            }
+          ],
+          "dateEndYear": [
+            1910
+          ],
+          "updatedAt": 1636072413178,
+          "publicationStatement": [
+            "Qum : Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī, 1405 [1984 or 1985]"
+          ],
+          "identifier": [
+            "urn:bnum:10003958",
+            "urn:lccn:73960850",
+            "urn:undefined:NNSZ00304319",
+            "urn:undefined:(WaOLN)nyp0203950"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn, taṣnīf Abī ʻAlī ibn Sīnā."
+          ],
+          "uri": "b10003958",
+          "lccClassification": [
+            "B751 .M4 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Qum :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10003958"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858216",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGL 83-2455",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058069919"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058069919"
+                    ],
+                    "idBarcode": [
+                      "33433058069919"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGL 83-002455"
+                  },
+                  "sort": [
+                    "a*OGL 83-002455"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858227",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-341 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003"
+                  },
+                  "sort": [
+                    "a*OLA 83-341 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003188",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  },
+                  "sort": [
+                    "a*OLA 83-3417 Library has: Vol. 1, 3."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004788",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "277 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Plon,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Le château du soleil couchant : roman"
+          ],
+          "shelfMark": [
+            "JFE 84-3450"
+          ],
+          "creatorLiteral": [
+            "Grey, Marina."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Grey, Marina. Saga de l'exil ; \\[3]",
+            "La saga de l'exil / Marina Grey ; [3]"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 84-3450"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004788"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2259011187 :"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405900"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204778"
+            }
+          ],
+          "updatedAt": 1636112113505,
+          "publicationStatement": [
+            "Paris : Plon, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10004788",
+            "urn:isbn:2259011187 :",
+            "urn:undefined:NNSZ00405900",
+            "urn:undefined:(WaOLN)nyp0204778"
+          ],
+          "idIsbn": [
+            "2259011187 :"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Le château du soleil couchant : roman / Marina Grey."
+          ],
+          "uri": "b10004788",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004788"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858280",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 84-3450"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 84-3450",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113944"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 84-3450"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113944"
+                    ],
+                    "idBarcode": [
+                      "33433046113944"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 84-003450"
+                  },
+                  "sort": [
+                    "aJFE 84-003450"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-291 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001"
+                  },
+                  "sort": [
+                    "aJFK 84-291 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-221 11 Azerbaijani monographs",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs"
+                  },
+                  "sort": [
+                    "a*ZO-221 11 Azerbaijani monographs"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30087469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-220 collection of 10 titles (monographs)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)"
+                  },
+                  "sort": [
+                    "a*ZO-220 collection of 10 titles (monographs)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005870",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"D'après le livre et le montage audiovisual 'L'Evolution de l'amour' por D. Sonet, légèrement adapté avec l'aimable autorisation de l'auteur.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sex instruction",
+            "Sex instruction -- Haiti",
+            "Sonet, D"
+          ],
+          "publisherLiteral": [
+            "Action familiale d'Haïti,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable"
+          ],
+          "shelfMark": [
+            "Sc D 84-595"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Action familiale d'Haïti."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-595"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205860"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636069688379,
+          "publicationStatement": [
+            "Port-au-Prince : Action familiale d'Haïti, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005870",
+            "urn:undefined:NNSZ00507084",
+            "urn:undefined:(WaOLN)nyp0205860"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sex instruction -- Haiti.",
+            "Sonet, D."
+          ],
+          "titleDisplay": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable / Action familiale d'Haïti."
+          ],
+          "uri": "b10005870",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10005870"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-595"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-595",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-595"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649329"
+                    ],
+                    "idBarcode": [
+                      "33433036649329"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000595"
+                  },
+                  "sort": [
+                    "aSc D 84-000595"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005876",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxvii, 751 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Unesco International Scientific Committee for the Drafting of a General History of Africa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 692-733.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- History",
+            "Africa -- History -- To 1884"
+          ],
+          "publisherLiteral": [
+            "Heinemann ; University of California Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Africa from the twelfth to the sixteenth century"
+          ],
+          "shelfMark": [
+            "Sc E 84-288"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84256508 //r86"
+          ],
+          "seriesStatement": [
+            "General history of Africa ; 4"
+          ],
+          "contributorLiteral": [
+            "Niane, Djibril Tamsir.",
+            "Unesco. International Scientific Committee for the Drafting of a General History of Africa."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005876"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0435948105"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0520039157 (University of California Press)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84256508 //r86"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205866"
+            }
+          ],
+          "updatedAt": 1636071226912,
+          "publicationStatement": [
+            "London : Heinemann ; Berkeley, Calif. : University of California Press, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005876",
+            "urn:isbn:0435948105",
+            "urn:isbn:0520039157 (University of California Press)",
+            "urn:lccn:84256508 //r86",
+            "urn:undefined:(WaOLN)nyp0205866"
+          ],
+          "idIsbn": [
+            "0435948105",
+            "0520039157 (University of California Press)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- History -- To 1884."
+          ],
+          "titleDisplay": [
+            "Africa from the twelfth to the sixteenth century / editor, D.T. Niane."
+          ],
+          "uri": "b10005876",
+          "lccClassification": [
+            "DT20 .G45 1981 vol. 4 DT25"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London : Berkeley, Calif. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10005876"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003889",
+                    "status": [
+                      {
+                        "id": "status:m",
+                        "label": "Missing"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:m||Missing"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "*R-BK 90-2407"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*R-BK 90-2407",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*R-BK 90-2407"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:-",
+                        "label": "No restrictions"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:-||No restrictions"
+                    ],
+                    "shelfMark_sort": "a*R-BK 90-002407"
+                  },
+                  "sort": [
+                    "a*R-BK 90-002407"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-288"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-288",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021813997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-288"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021813997"
+                    ],
+                    "idBarcode": [
+                      "33433021813997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000288"
+                  },
+                  "sort": [
+                    "aSc E 84-000288"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005902",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "76 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs, English",
+            "Sacred songs, English -- Caribbean Area",
+            "Sacred songs, English -- Caribbean Area -- Texts",
+            "Sacred songs, English -- Jamaica",
+            "Sacred songs, English -- Jamaica -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "shelfMark": [
+            "Sc D 84-602"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-602"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005902"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205892"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636116687148,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10005902",
+            "urn:undefined:NNSZ00507117",
+            "urn:undefined:(WaOLN)nyp0205892"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs, English -- Caribbean Area -- Texts.",
+            "Sacred songs, English -- Jamaica -- Texts."
+          ],
+          "titleDisplay": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "uri": "b10005902",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005902"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900490",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-602"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-602",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058825831"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-602"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058825831"
+                    ],
+                    "idBarcode": [
+                      "33433058825831"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000602"
+                  },
+                  "sort": [
+                    "aSc D 84-000602"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005905",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "52 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\"
+          ],
+          "shelfMark": [
+            "Sc C 85-2"
+          ],
+          "creatorLiteral": [
+            "Passavant, Camille."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc C 85-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005905"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507120"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205895"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636132396392,
+          "publicationStatement": [
+            "[Fort-de-France? Martinique : s.n., 19--] 52"
+          ],
+          "identifier": [
+            "urn:bnum:10005905",
+            "urn:undefined:NNSZ00507120",
+            "urn:undefined:(WaOLN)nyp0205895"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\ Camille Passavant."
+          ],
+          "uri": "b10005905",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Fort-de-France? Martinique :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10005905"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900493",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc C 85-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc C 85-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036604563"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc C 85-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036604563"
+                    ],
+                    "idBarcode": [
+                      "33433036604563"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc C 85-000002"
+                  },
+                  "sort": [
+                    "aSc C 85-000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    "aSc Ser.-L .V354 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005910",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 99 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 99.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Universities and colleges",
+            "Universities and colleges -- Africa",
+            "Universities and colleges -- Zambia"
+          ],
+          "publisherLiteral": [
+            "Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The African university : issues and perspectives : speeches"
+          ],
+          "shelfMark": [
+            "Sc D 84-502"
+          ],
+          "creatorLiteral": [
+            "Goma, L. K. H."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84980558"
+          ],
+          "seriesStatement": [
+            "Zambian papers ; no. 14"
+          ],
+          "contributorLiteral": [
+            "Tembo, L. P.",
+            "University of Zambia. Institute for African Studies."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-502"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005910"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84980558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205900"
+            }
+          ],
+          "updatedAt": 1636133189056,
+          "publicationStatement": [
+            "Lusaka, Zambia : Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005910",
+            "urn:lccn:84980558",
+            "urn:undefined:(WaOLN)nyp0205900"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Universities and colleges -- Africa.",
+            "Universities and colleges -- Zambia."
+          ],
+          "titleDisplay": [
+            "The African university : issues and perspectives : speeches / by L.H.K. [i.e. L.K.H.] Goma ; selected and edited by L.P. Tembo."
+          ],
+          "uri": "b10005910",
+          "lccClassification": [
+            "DT963.A3 Z3 no. 14 LA1503"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Lusaka, Zambia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005910"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 86-224 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 86-224 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003630815"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 86-224"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003630815"
+                    ],
+                    "idBarcode": [
+                      "33433003630815"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 86-224 v. 000014"
+                  },
+                  "sort": [
+                    "aJFK 86-224 v. 000014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-502"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-502",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021791029"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-502"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021791029"
+                    ],
+                    "idBarcode": [
+                      "33433021791029"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000502"
+                  },
+                  "sort": [
+                    "aSc D 84-000502"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 microfilm reels ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes biographical notes, scope and contents note and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm of Mss.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington, Fredi, 1903-1994",
+            "African American actresses",
+            "African American actresses -- Correspondence",
+            "African American women journalists",
+            "African American women journalists -- Correspondence",
+            "African Americans in the performing arts",
+            "African American actors",
+            "African American journalists"
+          ],
+          "publisherLiteral": [
+            "Amistad Research Center"
+          ],
+          "description": [
+            "Contains approximately one hundred pieces of correspondence, news clippings containing reviews of productions in which Fredi Washington appeared, and Washington's columns for The People's voice. Other groups in the collection are theatre programs, scripts, photographs and documentation of honors conferred on Fredi Washington."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "shelfMark": [
+            "Sc Micro R-4205"
+          ],
+          "creatorLiteral": [
+            "Washington, Fredi, 1903-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Amistad Research Center."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4205"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11780064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11780064"
+            }
+          ],
+          "idOclc": [
+            "11780064"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1651087265505,
+          "publicationStatement": [
+            "New Orleans, La. : Amistad Research Center, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10006007",
+            "urn:oclc:11780064",
+            "urn:undefined:(OCoLC)11780064"
+          ],
+          "genreForm": [
+            "Personal correspondence."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington, Fredi, 1903-1994.",
+            "African American actresses -- Correspondence.",
+            "African American women journalists -- Correspondence.",
+            "African Americans in the performing arts.",
+            "African American actors.",
+            "African American journalists."
+          ],
+          "titleDisplay": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "uri": "b10006007",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New Orleans, La."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm"
+          ]
+        },
+        "sort": [
+          "b10006007"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242492"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242492"
+                    ],
+                    "idBarcode": [
+                      "33433031242492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000001"
+                  },
+                  "sort": [
+                    "aSc Micro R-4205 r. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242500"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242500"
+                    ],
+                    "idBarcode": [
+                      "33433031242500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000002"
+                  },
+                  "sort": [
+                    "aSc Micro R-4205 r. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .T000425"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    "aSc F 84-000135"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "79 p. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- Portuguese",
+            "Cão, Diogo, active 15th century",
+            "Dias, Bartolomeu",
+            "Gama, Vasco da, 1469-1524",
+            "Portuguese",
+            "Portuguese -- India",
+            "Portuguese -- India -- History"
+          ],
+          "publisherLiteral": [
+            "Basler Afrika Bibliographien,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen"
+          ],
+          "shelfMark": [
+            "Sc D 84-477"
+          ],
+          "creatorLiteral": [
+            "Kalthammer, Wilhelm."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Beiträge zur Afrikakunde, 0171-1660; 5"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-477"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006034"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507257"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206027"
+            }
+          ],
+          "updatedAt": 1636088600902,
+          "publicationStatement": [
+            "Basel : Basler Afrika Bibliographien, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10006034",
+            "urn:undefined:NNSZ00507257",
+            "urn:undefined:(WaOLN)nyp0206027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- Portuguese.",
+            "Cão, Diogo, active 15th century.",
+            "Dias, Bartolomeu.",
+            "Gama, Vasco da, 1469-1524.",
+            "Portuguese -- India -- History."
+          ],
+          "titleDisplay": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen / Wilhelm Kalthammer."
+          ],
+          "uri": "b10006034",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Basel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006034"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900606",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-477"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-477",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-477"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649683"
+                    ],
+                    "idBarcode": [
+                      "33433036649683"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000477"
+                  },
+                  "sort": [
+                    "aSc D 84-000477"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "205 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa, Sub-Saharan",
+            "Africa, Sub-Saharan -- Relations",
+            "Africa, Sub-Saharan -- Relations -- Arab countries",
+            "Arab countries",
+            "Arab countries -- Relations",
+            "Arab countries -- Relations -- Africa, Sub-Saharan"
+          ],
+          "publisherLiteral": [
+            "Unesco,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "shelfMark": [
+            "Sc E 84-236"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "General history of Africa: studies and documents; 7"
+          ],
+          "contributorLiteral": [
+            "Unesco."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-236"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206036"
+            }
+          ],
+          "updatedAt": 1636103134727,
+          "publicationStatement": [
+            "Paris : Unesco, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10006043",
+            "urn:undefined:(WaOLN)nyp0206036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa, Sub-Saharan -- Relations -- Arab countries.",
+            "Arab countries -- Relations -- Africa, Sub-Saharan."
+          ],
+          "titleDisplay": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "uri": "b10006043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006043"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900614",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-236"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-236",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036807315"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-236"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036807315"
+                    ],
+                    "idBarcode": [
+                      "33433036807315"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000236"
+                  },
+                  "sort": [
+                    "aSc E 84-000236"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    "aSc Micro R-004202"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Black people",
+            "Black people -- Caribbean Area",
+            "Black people -- Caribbean Area -- Social conditions",
+            "Middle class",
+            "Middle class -- Caribbean Area"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The making of a middle class [microform]"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10459"
+          ],
+          "creatorLiteral": [
+            "Franks, W. Stanley."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10459"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206335"
+            }
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1646227218179,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006344",
+            "urn:undefined:NNSZ00507572",
+            "urn:undefined:(WaOLN)nyp0206335"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Black people -- Caribbean Area -- Social conditions.",
+            "Middle class -- Caribbean Area."
+          ],
+          "titleDisplay": [
+            "The making of a middle class [microform] / by W. S. Franks ; with a foreword by Lee Llewellyn Moore."
+          ],
+          "uri": "b10006344",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10006344"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10459",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058831748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058831748"
+                    ],
+                    "idBarcode": [
+                      "33433058831748"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010459"
+                  },
+                  "sort": [
+                    "aSc Micro F-010459"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 84-184 v. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2"
+                  },
+                  "sort": [
+                    "aJFK 84-184 v. 000001-2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636102841759,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "aHDK 84-1693 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006645",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "a, 257 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of: Algoritmy upravlen︠i︡a rabotami-manipul︠i︡atorami.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"JPRS 59717.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 245-252.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial"
+          ],
+          "publisherLiteral": [
+            "Joint Publications Research Service,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1973"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Robot-manipulator control algorithms"
+          ],
+          "shelfMark": [
+            "JSF 83-552"
+          ],
+          "creatorLiteral": [
+            "Ignatʹev, M. B. (Mikhail Borisovich)"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Kulakov, F. M. (Feliks Mikhaĭlovich)",
+            "Pokrovskiĭ, A. M."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 83-552"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006645"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206634"
+            }
+          ],
+          "uniformTitle": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami. English"
+          ],
+          "dateEndYear": [
+            1973
+          ],
+          "updatedAt": 1636073144930,
+          "publicationStatement": [
+            "Arlington, Va. : Joint Publications Research Service, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10006645",
+            "urn:undefined:(WaOLN)nyp0206634"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial."
+          ],
+          "titleDisplay": [
+            "Robot-manipulator control algorithms / by M.B. Ignatʹyev, F.M. Kulakov, A.M. Pokrovskiy."
+          ],
+          "uri": "b10006645",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Arlington, Va. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006645"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JSF 83-552"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JSF 83-552",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JSF 83-552"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693748"
+                    ],
+                    "idBarcode": [
+                      "33433037693748"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJSF 83-000552"
+                  },
+                  "sort": [
+                    "aJSF 83-000552"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003945",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003946",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-217 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-217 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003947",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 84-216 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002"
+                  },
+                  "sort": [
+                    "aJFL 84-216 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006699",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "483 p. : ill., ports ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 476-483.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dominican literature",
+            "Dominican literature -- Manuals, handbooks, etc",
+            "Latin American literature",
+            "Latin American literature -- Study and teaching",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media"
+          ],
+          "shelfMark": [
+            "JFF 84-820"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Gómez de Michel, Fiume."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 84-820"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006699"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507932"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206688"
+            }
+          ],
+          "updatedAt": 1636114816670,
+          "publicationStatement": [
+            "[Santo Domingo, R. D. : s.n.], 1984"
+          ],
+          "identifier": [
+            "urn:bnum:10006699",
+            "urn:undefined:NNSZ00507932",
+            "urn:undefined:(WaOLN)nyp0206688"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dominican literature -- Manuals, handbooks, etc.",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc."
+          ],
+          "titleDisplay": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media / [compilación] Fiumé Gómez de Michel."
+          ],
+          "uri": "b10006699",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Santo Domingo, R. D. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006699"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 84-820"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 84-820",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050352214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 84-820"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050352214"
+                    ],
+                    "idBarcode": [
+                      "33433050352214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 84-000820"
+                  },
+                  "sort": [
+                    "aJFF 84-000820"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-e2a00adae6112f3700a56a7d614a7654.json
+++ b/test/fixtures/query-e2a00adae6112f3700a56a7d614a7654.json
@@ -1,0 +1,17850 @@
+{
+  "took": 260,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 903197,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "577 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"The first printed book in Malayalam\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Facsimile reproduction of old Malayalam and transcription, paraphrase, and notes in modern Malayalam, on opposite pages.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Original t.p. reads: Nasṟāṇikaḷ okkakkuṃ aṟiyeṇṭunna saṅkṣepavedārtthaṃ=Compendiosa legis explanatio omnibus Christianis scitu necessaria. Malabarico idiomate. Romāyilninn Miśihā pirṟannīṭṭ 1772 śṟȧṣṭa melpaṭṭakkāraruṭe anuvādattāl=Romae An. A nativit. Christi 1772, praisidum facultate\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Catholic Church. Syro-Malabar rite",
+            "Christianity",
+            "Christianity -- Philosophy"
+          ],
+          "publisherLiteral": [
+            "Ḍi. Ṣi. Buks ; Kārmel Pabḷiṣiṅg Senṟar,"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "dateEndString": [
+            "1772"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp"
+          ],
+          "shelfMark": [
+            "*OLD 84-299"
+          ],
+          "creatorLiteral": [
+            "Piyāniyas, Kḷemanṟ, 1731-1782."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82904075"
+          ],
+          "contributorLiteral": [
+            "Choondal, Chummar, 1940-",
+            "Mathew, Ulakamthara."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-299"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82904075"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201079"
+            }
+          ],
+          "dateEndYear": [
+            1772
+          ],
+          "updatedAt": 1636128328325,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Ḍi. Ṣi. Buks ; Tiruvanantapuraṃ : Kārmel Pabḷiṣiṅg Senṟar, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10001080",
+            "urn:lccn:82904075",
+            "urn:undefined:NNSZ00201091",
+            "urn:undefined:(WaOLN)nyp0201079"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Catholic Church. Syro-Malabar rite.",
+            "Christianity -- Philosophy."
+          ],
+          "titleDisplay": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp / Kḷemanṟ Piyāniyas = Samkshepa vedartham / by Clement Pianius ; introduction by Chummar Choondel ; commentary by Mathew Ulakamthara."
+          ],
+          "uri": "b10001080",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ : Tiruvanantapuraṃ :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001080"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000682",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-299"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-299",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011099029"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-299"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011099029"
+                    ],
+                    "idBarcode": [
+                      "33433011099029"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000299"
+                  },
+                  "sort": [
+                    "a*OLD 84-000299"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003158",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "608 p. in various pagings ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Chinese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Chinese"
+          ],
+          "publisherLiteral": [
+            "Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si,"
+          ],
+          "language": [
+            {
+              "id": "lang:chi",
+              "label": "Chinese"
+            }
+          ],
+          "dateEndString": [
+            "1670"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zheng yin mo zhi : [4 juan]"
+          ],
+          "shelfMark": [
+            "*OVL 84-1330"
+          ],
+          "creatorLiteral": [
+            "Qin, Changyu, active 17th century."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "77839836"
+          ],
+          "seriesStatement": [
+            "zhongguo yi yao zong shu."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OVL 84-1330"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003158"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77839836"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303509"
+            }
+          ],
+          "dateEndYear": [
+            1670
+          ],
+          "updatedAt": 1641391919318,
+          "publicationStatement": [
+            "Taipei xian yonghe zhen : Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si, Min'Guo 61[1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10003158",
+            "urn:lccn:77839836",
+            "urn:undefined:NNSZ00303509"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Chinese."
+          ],
+          "titleDisplay": [
+            "Zheng yin mo zhi : [4 juan] / Qin Jingming [Changyu] zhu ; Qin Zhizheng ji ; [Cao Binzhang quan dian]."
+          ],
+          "uri": "b10003158",
+          "lccClassification": [
+            "R128.7 .C545"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Taipei xian yonghe zhen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003158"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002193",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OVL 84-1330",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001746852"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001746852"
+                    ],
+                    "idBarcode": [
+                      "33433001746852"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OVL 84-001330"
+                  },
+                  "sort": [
+                    "a*OVL 84-001330"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "606 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Basavapurāṇavu.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Kannaḍa sāhitya caritre.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Poetry",
+            "Lingayats",
+            "Lingayats -- Poetry"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavapurāṇavu"
+          ],
+          "shelfMark": [
+            "*OLA+ 82-1360"
+          ],
+          "creatorLiteral": [
+            "Palakuriki Somanatha, active 13th century."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Bhīmakavi, active 1369."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 82-1360"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003190"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303541"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203183"
+            }
+          ],
+          "uniformTitle": [
+            "Basavapurāṇamu. Kannada"
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636076831370,
+          "publicationStatement": [
+            "[S.1. : s.n., 18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003190",
+            "urn:undefined:NNSZ00303541",
+            "urn:undefined:(WaOLN)nyp0203183"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Poetry.",
+            "Lingayats -- Poetry."
+          ],
+          "titleDisplay": [
+            "Basavapurāṇavu / [Bhīmakavi viracita ; Sōmanātha kaviya Telugu Basavapurāṇamuvina Kannaḍa anuvāda]."
+          ],
+          "uri": "b10003190",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Basavapurāṇamu."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10003190"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784381",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069579674"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069579674"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433069579674"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 82-1360"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 82-001360"
+                  },
+                  "sort": [
+                    "a*OLA+ 82-001360"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003301",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map, facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kurds",
+            "Kurds -- Iran",
+            "Kurds -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Kūshish,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān"
+          ],
+          "shelfMark": [
+            "*OMR 84-1145"
+          ],
+          "creatorLiteral": [
+            "Tavaḥḥudī Awghāzī, Kalīm Allāh."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMR 84-1145"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303655"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000007"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636103985760,
+          "publicationStatement": [
+            "Mashhad : Chāpkhānah-ʼi Kūshish, 1359-  [1981-  ]"
+          ],
+          "identifier": [
+            "urn:bnum:10003301",
+            "urn:undefined:NNSZ00303655",
+            "urn:undefined:(WaOLN)nyp0000007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kurds -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān / taʼlīf-i Kalīm Allāh Tavaḥḥudī (Awghāzi)"
+          ],
+          "uri": "b10003301",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Mashhad :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003301"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013136530"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013136530"
+                    ],
+                    "idBarcode": [
+                      "33433013136530"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000001"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002282",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135847"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135847"
+                    ],
+                    "idBarcode": [
+                      "33433013135847"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000003"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002283",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMR 84-1145 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135854"
+                    ],
+                    "idBarcode": [
+                      "33433013135854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000004"
+                  },
+                  "sort": [
+                    "a*OMR 84-1145 v. 000004"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003857",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "319 p. : ill., plates, maps ;"
+          ],
+          "parallelDisplayField": [
+            {
+              "fieldName": "publicationStatement",
+              "index": 0,
+              "value": "‏بيروت : دار مكتبة الحياة, [196-؟]"
+            },
+            {
+              "fieldName": "placeOfPublication",
+              "index": 0,
+              "value": "‏بيروت :"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yemen (Republic)"
+          ],
+          "publisherLiteral": [
+            "Dār Maktabat al-Ḥayāh,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            196
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah /"
+          ],
+          "parallelTitle": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة /"
+          ],
+          "shelfMark": [
+            "*OFI 82-4419"
+          ],
+          "creatorLiteral": [
+            "Tarsīsī, ʻAdnān."
+          ],
+          "createdString": [
+            "196"
+          ],
+          "parallelPublisher": [
+            "‏دار مكتبة الحياة,"
+          ],
+          "idLccn": [
+            "ne 64003290"
+          ],
+          "dateStartYear": [
+            196
+          ],
+          "parallelCreatorLiteral": [
+            "‏ترسيسي, عدنان."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFI 82-4419"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003857"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 64003290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)221366702"
+            }
+          ],
+          "idOclc": [
+            "11272192"
+          ],
+          "updatedAt": 1649121307527,
+          "publicationStatement": [
+            "Bayrūt : Dār Maktabat al-Ḥayāh, [196-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003857",
+            "urn:lccn:ne 64003290",
+            "urn:oclc:11272192",
+            "urn:undefined:(OCoLC)11272192",
+            "urn:undefined:(OCoLC)221366702"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "196"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yemen (Republic)"
+          ],
+          "titleDisplay": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah / [taʼlīf] ʻAdnān Tarsīsī."
+          ],
+          "uri": "b10003857",
+          "lccClassification": [
+            "DS247.Y4 T3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة / [تاليف] عدنان ترسيسي."
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Includes musical score of national anthem of Yemen Arab Republic."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003857"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002714",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFI 82-4419",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002023293"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002023293"
+                    ],
+                    "idBarcode": [
+                      "33433002023293"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OFI 82-004419"
+                  },
+                  "sort": [
+                    "a*OFI 82-004419"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29202258",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101143836"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101143836"
+                    ],
+                    "idBarcode": [
+                      "33433101143836"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                  },
+                  "sort": [
+                    "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Esosiẏeṭeḍa Pābaliśārsa"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "dateEndString": [
+            "62"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Junāpura Sṭīla."
+          ],
+          "shelfMark": [
+            "*OKV 82-3891"
+          ],
+          "creatorLiteral": [
+            "Mānnā, Guṇamaẏa, 1925-2010."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "sa 63003864"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-3891"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63003864"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204072"
+            }
+          ],
+          "dateEndYear": [
+            62
+          ],
+          "updatedAt": 1636108800927,
+          "publicationStatement": [
+            "[Kalakātā] Esosiẏeṭeḍa Pābaliśārsa [1960-1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10004080",
+            "urn:lccn:sa 63003864",
+            "urn:undefined:NNSZ00304442",
+            "urn:undefined:(WaOLN)nyp0204072"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Junāpura Sṭīla. [Lekhaka] Guṇamaẏa Mānnā."
+          ],
+          "uri": "b10004080",
+          "lccClassification": [
+            "PK1718.M253 53"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Kalakātā]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004080"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-3891 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168394"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168394"
+                    ],
+                    "idBarcode": [
+                      "33433011168394"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000001"
+                  },
+                  "sort": [
+                    "a*OKV 82-3891 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002917",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-3891 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168402"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168402"
+                    ],
+                    "idBarcode": [
+                      "33433011168402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000002"
+                  },
+                  "sort": [
+                    "a*OKV 82-3891 v. 000002"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "34 p.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Pronunciation"
+          ],
+          "publisherLiteral": [
+            "Naṭarācaṉ,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            197
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum"
+          ],
+          "shelfMark": [
+            "*OLB 83-2757"
+          ],
+          "creatorLiteral": [
+            "Natarajan, Subbiah, 1911-"
+          ],
+          "createdString": [
+            "197"
+          ],
+          "idLccn": [
+            "75906338"
+          ],
+          "dateStartYear": [
+            197
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2757"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004504"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906338"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304869"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204496"
+            }
+          ],
+          "updatedAt": 1636132308475,
+          "publicationStatement": [
+            "[Tūttukkuṭi]: Naṭarācaṉ, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10004504",
+            "urn:lccn:75906338",
+            "urn:undefined:NNSZ00304869",
+            "urn:undefined:(WaOLN)nyp0204496"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "197"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Pronunciation."
+          ],
+          "titleDisplay": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum/ Cu. Naṭarājaṉ."
+          ],
+          "uri": "b10004504",
+          "lccClassification": [
+            "PL4754 .N33 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tūttukkuṭi]:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10004504"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784546",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-2757",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296681"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296681"
+                    ],
+                    "idBarcode": [
+                      "33433061296681"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002757"
+                  },
+                  "sort": [
+                    "a*OLB 83-002757"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004672",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "106 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "P. Vaillant,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1775
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "All in the wrong [microform] : a comedy, as it is acted at the Theatre-Royal in Drury-Lane"
+          ],
+          "shelfMark": [
+            "*ZC-177"
+          ],
+          "creatorLiteral": [
+            "Murphy, Arthur, 1727-1805."
+          ],
+          "createdString": [
+            "1775"
+          ],
+          "dateStartYear": [
+            1775
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZC-177"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004672"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405783"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204664"
+            }
+          ],
+          "updatedAt": 1636073146019,
+          "publicationStatement": [
+            "London : P. Vaillant, 1775."
+          ],
+          "identifier": [
+            "urn:bnum:10004672",
+            "urn:undefined:NNSZ00405783",
+            "urn:undefined:(WaOLN)nyp0204664"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1775"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "All in the wrong [microform] : a comedy, as it is acted at the Theatre-Royal in Drury-Lane / by Mr. Murphy."
+          ],
+          "uri": "b10004672",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12⁰."
+          ]
+        },
+        "sort": [
+          "b10004672"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004849",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[8], 48 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Samaritans"
+          ],
+          "publisherLiteral": [
+            "Sumtu Io. Bielckii,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1688
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Christophori Cellarii Collectanea historiae Samaritanae : quibus praeter res geographicas, tam politia huius gentis, quam religio et res litteraria explicantur."
+          ],
+          "shelfMark": [
+            "**P 07-283"
+          ],
+          "creatorLiteral": [
+            "Cellarius, Christoph, 1638-1707."
+          ],
+          "createdString": [
+            "1688"
+          ],
+          "dateStartYear": [
+            1688
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "**P 07-283"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004849"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405962"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204839"
+            }
+          ],
+          "updatedAt": 1636081486226,
+          "publicationStatement": [
+            "Cizae : Sumtu Io. Bielckii, 1688."
+          ],
+          "identifier": [
+            "urn:bnum:10004849",
+            "urn:undefined:NNSZ00405962",
+            "urn:undefined:(WaOLN)nyp0204839"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1688"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Samaritans."
+          ],
+          "titleDisplay": [
+            "Christophori Cellarii Collectanea historiae Samaritanae : quibus praeter res geographicas, tam politia huius gentis, quam religio et res litteraria explicantur."
+          ],
+          "uri": "b10004849",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Cizae :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Collectanea historiae Samaritanae."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10004849"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746564",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf88",
+                        "label": "Schwarzman Building - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf88||Schwarzman Building - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "**P 07-283"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "**P 07-283",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075470579"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "**P 07-283"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075470579"
+                    ],
+                    "idBarcode": [
+                      "33433075470579"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "shelfMark_sort": "a**P 07-000283"
+                  },
+                  "sort": [
+                    "a**P 07-000283"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005935",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[12] leaves : col. ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "J. Vlieger,"
+          ],
+          "language": [
+            {
+              "id": "lang:dut",
+              "label": "Dutch"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "De 10 kleine nikkertjes."
+          ],
+          "shelfMark": [
+            "Sc Rare F 83-57"
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 83-57"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005935"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205924"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636086421285,
+          "publicationStatement": [
+            "Amsterdam : J. Vlieger, [18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005935",
+            "urn:undefined:NNSZ00507149",
+            "urn:undefined:(WaOLN)nyp0205924"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "De 10 kleine nikkertjes."
+          ],
+          "uri": "b10005935",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Tien Kleine nikkertjes."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10005935"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900518",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 83-57"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 83-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926669"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 83-57"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926669"
+                    ],
+                    "idBarcode": [
+                      "33433036926669"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+10+kleine+nikkertjes.&Site=SCHRB&CallNumber=Sc+Rare+F+83-57&ItemPlace=Amsterdam+:&ItemPublisher=J.+Vlieger,&Date=[18--?]&ItemInfo3=https://catalog.nypl.org/record=b10005935&ReferenceNumber=b100059351&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926669&ItemISxN=i119005189&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 83-000057"
+                  },
+                  "sort": [
+                    "aSc Rare F 83-000057"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005935-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+10+kleine+nikkertjes.&Site=SCHRB&CallNumber=Sc+Rare+F+83-57&ItemPlace=Amsterdam+:&ItemPublisher=J.+Vlieger,&Date=[18--?]&ItemInfo3=https://catalog.nypl.org/record=b10005935&ReferenceNumber=b100059351&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926669&ItemISxN=i119005189&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005935-e"
+                  },
+                  "sort": [
+                    "bi10005935-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005945",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[4], iv, 5-62 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Sabin",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "of Sidney Lapidus; ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Copy in Sc Rare E 16-46 (Lapidus Collection) disbound.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Slave-trade",
+            "Slave-trade -- West Indies, British.",
+            "Slave-trade -- West Indies, British. -- Early works to 1800",
+            "Slavery",
+            "Slavery -- Law and legislation",
+            "Slavery -- Law and legislation -- Jamaica",
+            "Slavery -- Law and legislation -- Jamaica -- Early works to 1800",
+            "Slavery -- West Indies, British.",
+            "Slavery -- West Indies, British. -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Printed and sold by James Philips,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1789
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Notes on the two reports from the Committee of the Honourable House of Assembly of Jamaica: appointed to examine into, and to report to the House, the allegations and charges contained in the several petitions which have been presented to the British House of Commons, on the subject of the slave-trade, and the treatment of the Negroes,&c.&c.&c."
+          ],
+          "shelfMark": [
+            "Sc Rare F 83-78"
+          ],
+          "creatorLiteral": [
+            "Fuller, Stephen, 1716-1808."
+          ],
+          "createdString": [
+            "1789"
+          ],
+          "contributorLiteral": [
+            "Jamaica. Assembly."
+          ],
+          "dateStartYear": [
+            1789
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 83-78"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005945"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205933"
+            }
+          ],
+          "updatedAt": 1647839859610,
+          "publicationStatement": [
+            "London : Printed and sold by James Philips, 1789."
+          ],
+          "identifier": [
+            "urn:bnum:10005945",
+            "urn:undefined:NNSZ00507159",
+            "urn:undefined:(WaOLN)nyp0205933"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1789"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Slave-trade -- West Indies, British. -- Early works to 1800.",
+            "Slavery -- Law and legislation -- Jamaica -- Early works to 1800.",
+            "Slavery -- West Indies, British. -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Notes on the two reports from the Committee of the Honourable House of Assembly of Jamaica: appointed to examine into, and to report to the House, the allegations and charges contained in the several petitions which have been presented to the British House of Commons, on the subject of the slave-trade, and the treatment of the Negroes,&c.&c.&c. / by a Jamaica planter."
+          ],
+          "uri": "b10005945",
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            4
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10005945"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003914",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*KF 1789 (Notes on the two reports)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*KF 1789 (Notes on the two reports)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*KF 1789 (Notes on the two reports)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a*KF 1789 (Notes on the two reports)"
+                  },
+                  "sort": [
+                    "a*KF 1789 (Notes on the two reports)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "8-*KF 1789 (Notes on the two reports)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "8-*KF 1789 (Notes on the two reports)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "8-*KF 1789 (Notes on the two reports)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a8-*KF 1789 (Notes on the two reports)"
+                  },
+                  "sort": [
+                    "a8-*KF 1789 (Notes on the two reports)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34051315",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare E 16-46 (Lapidus Collection)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare E 16-46 (Lapidus Collection)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117263263"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare E 16-46 (Lapidus Collection)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117263263"
+                    ],
+                    "idBarcode": [
+                      "33433117263263"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "aSc Rare E 16-46 (Lapidus Collection)"
+                  },
+                  "sort": [
+                    "aSc Rare E 16-46 (Lapidus Collection)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003913",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 83-78"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 83-78",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076159494"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 83-78"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076159494"
+                    ],
+                    "idBarcode": [
+                      "33433076159494"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 83-000078"
+                  },
+                  "sort": [
+                    "aSc Rare F 83-000078"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005945-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      },
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SCHRB&CallNumber=Sc+Rare+F+83-78&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005945-e"
+                  },
+                  "sort": [
+                    "bi10005945-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005951",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "150, [10] p. : folded col. map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Bound in leather.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Almanacs, Jamaican",
+            "Jamaica",
+            "Jamaica -- Registers"
+          ],
+          "publisherLiteral": [
+            "Printed by David Dickson for Thomas Stevenson,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1794
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Jamaica almanack, and register ... for the year of Our Lord 1795 ... ."
+          ],
+          "shelfMark": [
+            "Sc Rare B 83-2"
+          ],
+          "createdString": [
+            "1794"
+          ],
+          "dateStartYear": [
+            1794
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare B 83-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005951"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507166"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205940"
+            }
+          ],
+          "updatedAt": 1636136675426,
+          "publicationStatement": [
+            "Kingston : Printed by David Dickson for Thomas Stevenson, [1794?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005951",
+            "urn:undefined:NNSZ00507166",
+            "urn:undefined:(WaOLN)nyp0205940"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1794"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Almanacs, Jamaican.",
+            "Jamaica -- Registers."
+          ],
+          "titleDisplay": [
+            "The New Jamaica almanack, and register ... for the year of Our Lord 1795 ... ."
+          ],
+          "uri": "b10005951",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kingston :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10005951"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare B 83-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare B 83-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926776"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare B 83-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926776"
+                    ],
+                    "idBarcode": [
+                      "33433036926776"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+New+Jamaica+almanack,+and+register+...+for+the+year+of+Our+Lord+1795+...+.&Site=SCHRB&CallNumber=Sc+Rare+B+83-2&ItemPlace=Kingston+:&ItemPublisher=Printed+by+David+Dickson+for+Thomas+Stevenson,&Date=[1794?]&ItemInfo3=https://catalog.nypl.org/record=b10005951&ReferenceNumber=b10005951x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926776&ItemISxN=i119005281&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare B 83-000002"
+                  },
+                  "sort": [
+                    "aSc Rare B 83-000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005951-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+New+Jamaica+almanack,+and+register+...+for+the+year+of+Our+Lord+1795+...+.&Site=SCHRB&CallNumber=Sc+Rare+B+83-2&ItemPlace=Kingston+:&ItemPublisher=Printed+by+David+Dickson+for+Thomas+Stevenson,&Date=[1794?]&ItemInfo3=https://catalog.nypl.org/record=b10005951&ReferenceNumber=b10005951x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926776&ItemISxN=i119005281&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005951-e"
+                  },
+                  "sort": [
+                    "bi10005951-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "66 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Sabin",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Garran de Coulon, Jean Philippe, 1748-1816",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804"
+          ],
+          "publisherLiteral": [
+            "Se vend chez Maret, Desenne, et chez tous les marchands de nouveautés,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1797
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Lettre de Michel-Pascal Creuzé à Jean-Philippe Garan sur son rapport des troubles de St-Domingue : distribué au Corps législatif en ventôse, an V, dix-huit mois apres la clôture des débats."
+          ],
+          "shelfMark": [
+            "*KF 1797 (Creuzé-Dufresne, M. P. Lettre de Michel Pascal Creuzé)"
+          ],
+          "creatorLiteral": [
+            "Creuzé-Dufresne, Michel Pascal."
+          ],
+          "createdString": [
+            "1797"
+          ],
+          "dateStartYear": [
+            1797
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*KF 1797 (Creuzé-Dufresne, M. P. Lettre de Michel Pascal Creuzé)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005958"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507175"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205949"
+            }
+          ],
+          "updatedAt": 1647835450218,
+          "publicationStatement": [
+            "Paris : Se vend chez Maret, Desenne, et chez tous les marchands de nouveautés, an 5 [1797]"
+          ],
+          "identifier": [
+            "urn:bnum:10005958",
+            "urn:undefined:NNSZ00507175",
+            "urn:undefined:(WaOLN)nyp0205949"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1797"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Garran de Coulon, Jean Philippe, 1748-1816.",
+            "Haiti -- History -- Revolution, 1791-1804."
+          ],
+          "titleDisplay": [
+            "Lettre de Michel-Pascal Creuzé à Jean-Philippe Garan sur son rapport des troubles de St-Domingue : distribué au Corps législatif en ventôse, an V, dix-huit mois apres la clôture des débats."
+          ],
+          "uri": "b10005958",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10005958"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003918",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Lettre+de+Michel-Pascal+Creuzé+à+Jean-Philippe+Garan+sur+son+rapport+des+troubles+de+St-Domingue+:+distribué+au+Corps+législatif+en+ventôse,+an+V,+dix-huit+mois+apres+la+clôture+des+débats.&Site=SASRB&CallNumber=*KF+1797+(Creuzé,+M.+P.+Lettre+de+Michel+Pascal+Creuzé)&Author=Creuzé-Dufresne,+Michel+Pascal.&ItemPlace=Paris+:&ItemPublisher=Se+vend+chez+Maret,+Desenne,+et+chez+tous+les+marchands+de+nouveautés,&Date=an+5+[1797]&ItemInfo3=https://catalog.nypl.org/record=b10005958&ReferenceNumber=b100059582&ItemISxN=i100039182&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                  },
+                  "sort": [
+                    "a*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005958-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Lettre+de+Michel-Pascal+Creuzé+à+Jean-Philippe+Garan+sur+son+rapport+des+troubles+de+St-Domingue+:+distribué+au+Corps+législatif+en+ventôse,+an+V,+dix-huit+mois+apres+la+clôture+des+débats.&Site=SASRB&CallNumber=*KF+1797+(Creuzé,+M.+P.+Lettre+de+Michel+Pascal+Creuzé)&Author=Creuzé-Dufresne,+Michel+Pascal.&ItemPlace=Paris+:&ItemPublisher=Se+vend+chez+Maret,+Desenne,+et+chez+tous+les+marchands+de+nouveautés,&Date=an+5+[1797]&ItemInfo3=https://catalog.nypl.org/record=b10005958&ReferenceNumber=b100059582&ItemISxN=i100039182&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005958-e"
+                  },
+                  "sort": [
+                    "bi10005958-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[12] p. of plates : all col. ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ethiopia",
+            "Ethiopia -- Pictorial works",
+            "Ethiopia -- Social life and customs"
+          ],
+          "publisherLiteral": [
+            "A. Vallardi,"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Usi e costumi dell' Abissinia e dei dintorni di Massaua"
+          ],
+          "shelfMark": [
+            "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Pasini, Lazzaro."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006047"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507270"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206040"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636141457793,
+          "publicationStatement": [
+            "Milano : A. Vallardi, [18--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006047",
+            "urn:undefined:NNSZ00507270",
+            "urn:undefined:(WaOLN)nyp0206040"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ethiopia -- Pictorial works.",
+            "Ethiopia -- Social life and customs."
+          ],
+          "titleDisplay": [
+            "Usi e costumi dell' Abissinia e dei dintorni di Massaua / da originali acquarelli di un indigeno, riprodotti da Laz. Pasini."
+          ],
+          "uri": "b10006047",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Milano :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10006047"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003926",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019684897"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019684897"
+                    ],
+                    "idBarcode": [
+                      "33433019684897"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                  },
+                  "sort": [
+                    "aSc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003925",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 84-8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 84-8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137185"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 84-8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137185"
+                    ],
+                    "idBarcode": [
+                      "33433076137185"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Usi+e+costumi+dell'+Abissinia+e+dei+dintorni+di+Massaua+/&Site=SCHRB&CallNumber=Sc+Rare+C+84-8&ItemPlace=Milano+:&ItemPublisher=A.+Vallardi,&Date=[18--]&ItemInfo3=https://catalog.nypl.org/record=b10006047&ReferenceNumber=b10006047x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433076137185&ItemISxN=i10003925x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 84-000008"
+                  },
+                  "sort": [
+                    "aSc Rare C 84-000008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006047-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Usi+e+costumi+dell'+Abissinia+e+dei+dintorni+di+Massaua+/&Site=SCHRB&CallNumber=Sc+Rare+C+84-8&ItemPlace=Milano+:&ItemPublisher=A.+Vallardi,&Date=[18--]&ItemInfo3=https://catalog.nypl.org/record=b10006047&ReferenceNumber=b10006047x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433076137185&ItemISxN=i10003925x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10006047-e"
+                  },
+                  "sort": [
+                    "bi10006047-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[11], 144 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nella stamperia di Gennaro Muzio,"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "createdYear": [
+            1725
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La somiglianza [microform] : commedia"
+          ],
+          "shelfMark": [
+            "*Z-3500"
+          ],
+          "creatorLiteral": [
+            "Amenta, Niccolò, 1659-1719."
+          ],
+          "createdString": [
+            "1725"
+          ],
+          "dateStartYear": [
+            1725
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3500"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006816"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508052"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206802"
+            }
+          ],
+          "updatedAt": 1636111583127,
+          "publicationStatement": [
+            "In Napoli : Nella stamperia di Gennaro Muzio, 1725."
+          ],
+          "identifier": [
+            "urn:bnum:10006816",
+            "urn:undefined:NNSZ00508052",
+            "urn:undefined:(WaOLN)nyp0206802"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1725"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "La somiglianza [microform] : commedia / del dottor ... Niccolò Amenta ..."
+          ],
+          "uri": "b10006816",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "In Napoli :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          "b10006816"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003967",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3500"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3500",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107660718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3500"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107660718"
+                    ],
+                    "idBarcode": [
+                      "33433107660718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-003500"
+                  },
+                  "sort": [
+                    "a*Z-003500"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007423",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "184 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Muʼassisah-ʼi Khāvar,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1334"
+          ],
+          "createdYear": [
+            1333
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻĀlam va Ādam"
+          ],
+          "shelfMark": [
+            "*OMO 84-2676"
+          ],
+          "creatorLiteral": [
+            "Vafā ʻAlī Shāh."
+          ],
+          "createdString": [
+            "1333"
+          ],
+          "dateStartYear": [
+            1333
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-2676"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007423"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508668"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207407"
+            }
+          ],
+          "dateEndYear": [
+            1334
+          ],
+          "updatedAt": 1636145488993,
+          "publicationStatement": [
+            "Tihrān : Muʼassisah-ʼi Khāvar, 1312 [1933 or 1934]"
+          ],
+          "identifier": [
+            "urn:bnum:10007423",
+            "urn:undefined:NNSZ00508668",
+            "urn:undefined:(WaOLN)nyp0207407"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1333"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "ʻĀlam va Ādam / a̲sar-i khāmah-ʼi Mīrzā Hādī Mawlavī Rash̄tī ; bi-himmat-i Muḥammad Ramazānī."
+          ],
+          "uri": "b10007423",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10007423"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004294",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMO 84-2676"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMO 84-2676",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898570"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-2676"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898570"
+                    ],
+                    "idBarcode": [
+                      "33433001898570"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-002676"
+                  },
+                  "sort": [
+                    "a*OMO 84-002676"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007812",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "176 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "French wit and humor",
+            "French wit and humor -- France"
+          ],
+          "publisherLiteral": [
+            "A. Pierret,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sac à juifs [microform] : recueil de scènes et récits satiriques et humoristiques"
+          ],
+          "shelfMark": [
+            "*ZP-687 no. 9"
+          ],
+          "creatorLiteral": [
+            "La Badine, C. de."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZP-687 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007812"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609209"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207795"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1637634877781,
+          "publicationStatement": [
+            "Paris : A. Pierret, [18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10007812",
+            "urn:undefined:NNSZ00609209",
+            "urn:undefined:(WaOLN)nyp0207795"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "French wit and humor -- France."
+          ],
+          "titleDisplay": [
+            "Sac à juifs [microform] : recueil de scènes et récits satiriques et humoristiques / par C. de La Badine ; illus. de Bocardho."
+          ],
+          "uri": "b10007812",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12⁰."
+          ]
+        },
+        "sort": [
+          "b10007812"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008934",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "536 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Aristotle",
+            "Porphyry, approximately 234-approximately 305"
+          ],
+          "publisherLiteral": [
+            "G. Olms,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "dateEndString": [
+            "1597"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "In Porphyrii Isagogen et Aristotelis Organum : commentarius analyticus"
+          ],
+          "shelfMark": [
+            "JFD 85-2807"
+          ],
+          "creatorLiteral": [
+            "Pace, Giulio, 1550-1635."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 85-2807"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008934"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810450"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208909"
+            }
+          ],
+          "dateEndYear": [
+            1597
+          ],
+          "updatedAt": 1636105378000,
+          "publicationStatement": [
+            "Hildesheim : G. Olms, 1966."
+          ],
+          "identifier": [
+            "urn:bnum:10008934",
+            "urn:undefined:NNSZ00810450",
+            "urn:undefined:(WaOLN)nyp0208909"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Aristotle.",
+            "Porphyry, approximately 234-approximately 305."
+          ],
+          "titleDisplay": [
+            "In Porphyrii Isagogen et Aristotelis Organum : commentarius analyticus / Julius Pacius."
+          ],
+          "uri": "b10008934",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Hildesheim :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10008934"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858678",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFD 85-2807"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 85-2807",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433038876987"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFD 85-2807"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433038876987"
+                    ],
+                    "idBarcode": [
+                      "33433038876987"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFD 85-002807"
+                  },
+                  "sort": [
+                    "aJFD 85-002807"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "84 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "God (Islam)",
+            "God (Islam) -- Attributes"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1268"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Fatwá al-Ḥamawīyah al-kubrá,"
+          ],
+          "shelfMark": [
+            "*OGM 85-1727"
+          ],
+          "creatorLiteral": [
+            "Ibn Taymīyah, Aḥmad ibn ʻAbd al-Ḥalīm, 1263-1328."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "76961126"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 85-1727"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009127"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76961126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810649"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209102"
+            }
+          ],
+          "dateEndYear": [
+            1268
+          ],
+          "updatedAt": 1636072369613,
+          "publicationStatement": [
+            "[al-Qāhirah, al-Maṭbaʻah al-Salafīyah wa-Maktabatuhā, 1967 or 8]"
+          ],
+          "identifier": [
+            "urn:bnum:10009127",
+            "urn:lccn:76961126",
+            "urn:undefined:NNSZ00810649",
+            "urn:undefined:(WaOLN)nyp0209102"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "God (Islam) -- Attributes."
+          ],
+          "titleDisplay": [
+            "al-Fatwá al-Ḥamawīyah al-kubrá, taʼlīf Taqī al-Dīn Aḥmad ibn Taymīyah. Nasharahā Quṣay Muḥibb al-Dīn al-Khaṭīb."
+          ],
+          "uri": "b10009127",
+          "lccClassification": [
+            "BP166.2 .I24 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah, al-Maṭbaʻah al-Salafīyah wa-Maktabatuhā, 1967 or 8]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10009127"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004965",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGM 85-1727"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGM 85-1727",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001945694"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGM 85-1727"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001945694"
+                    ],
+                    "idBarcode": [
+                      "33433001945694"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OGM 85-001727"
+                  },
+                  "sort": [
+                    "a*OGM 85-001727"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009912",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[4] p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Alva, Juan de"
+          ],
+          "publisherLiteral": [
+            "Imprenta de Alonso del Riego,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "1799"
+          ],
+          "createdYear": [
+            1700
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Romance famoso : en que se refieren las grandes hazañas del valiente negro en Flandes, llamado Juan de Alva, y la mucho que el Rey nuestro Señor premio sus hechos."
+          ],
+          "shelfMark": [
+            "Sc Rare+ F 82-61"
+          ],
+          "createdString": [
+            "1700"
+          ],
+          "dateStartYear": [
+            1700
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ F 82-61"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009912"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911389"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209888"
+            }
+          ],
+          "dateEndYear": [
+            1799
+          ],
+          "updatedAt": 1636127128020,
+          "publicationStatement": [
+            "Valladolid : Imprenta de Alonso del Riego, [17--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10009912",
+            "urn:undefined:NNSZ00911389",
+            "urn:undefined:(WaOLN)nyp0209888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1700"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Alva, Juan de."
+          ],
+          "titleDisplay": [
+            "Romance famoso : en que se refieren las grandes hazañas del valiente negro en Flandes, llamado Juan de Alva, y la mucho que el Rey nuestro Señor premio sus hechos."
+          ],
+          "uri": "b10009912",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Valladolid :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10009912"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-61"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-61",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926867"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-61"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926867"
+                    ],
+                    "idBarcode": [
+                      "33433036926867"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Romance+famoso+:+en+que+se+refieren+las+grandes+hazañas+del+valiente+negro+en+Flandes,+llamado+Juan+de+Alva,+y+la+mucho+que+el+Rey+nuestro+Señor+premio+sus+hechos.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-61&ItemPlace=Valladolid+:&ItemPublisher=Imprenta+de+Alonso+del+Riego,&Date=[17--?]&ItemInfo3=https://catalog.nypl.org/record=b10009912&ReferenceNumber=b100099129&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926867&ItemISxN=i11901001x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000061"
+                  },
+                  "sort": [
+                    "aSc Rare+ F 82-000061"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10009912-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Romance+famoso+:+en+que+se+refieren+las+grandes+hazañas+del+valiente+negro+en+Flandes,+llamado+Juan+de+Alva,+y+la+mucho+que+el+Rey+nuestro+Señor+premio+sus+hechos.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-61&ItemPlace=Valladolid+:&ItemPublisher=Imprenta+de+Alonso+del+Riego,&Date=[17--?]&ItemInfo3=https://catalog.nypl.org/record=b10009912&ReferenceNumber=b100099129&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926867&ItemISxN=i11901001x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10009912-e"
+                  },
+                  "sort": [
+                    "bi10009912-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009988",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Coutilien Coutard, Philippe-Jérome",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- 1804-1844",
+            "Haiti -- History -- Revolution, 1791-1804"
+          ],
+          "publisherLiteral": [
+            "Impr. du gouvernement,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Discours aux Haïtiens, ou, Hommage au dévouement patriotique de Coutillien [microform]"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10834"
+          ],
+          "creatorLiteral": [
+            "Marion, Ignace Despontreaux."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10834"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009988"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209965"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1643680852554,
+          "publicationStatement": [
+            "Aux Cayes : Impr. du gouvernement, [185-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10009988",
+            "urn:undefined:(WaOLN)nyp0209965"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Coutilien Coutard, Philippe-Jérome.",
+            "Haiti -- History -- 1804-1844.",
+            "Haiti -- History -- Revolution, 1791-1804."
+          ],
+          "titleDisplay": [
+            "Discours aux Haïtiens, ou, Hommage au dévouement patriotique de Coutillien [microform] / par A.J. Despontreau Marion."
+          ],
+          "uri": "b10009988",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Aux Cayes :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Hommage au dévouement patriotique de Coutillien"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10009988"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785539",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10834"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10834",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058299276"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10834"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058299276"
+                    ],
+                    "idBarcode": [
+                      "33433058299276"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010834"
+                  },
+                  "sort": [
+                    "aSc Micro F-010834"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13965122",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058298906"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058298906"
+                    ],
+                    "idBarcode": [
+                      "33433058298906"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-10900 Library has: Vol. 3, no. 000005-v. 3, no. 7 (June-Aug. 1919)"
+                  },
+                  "sort": [
+                    "aSc Micro F-10900 Library has: Vol. 3, no. 000005-v. 3, no. 7 (June-Aug. 1919)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010385",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 microfilm reel ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "On reel with: Jamaica 1871-1943 (except 1934), Panama Canal Zone 1912",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "United States Virgin Islands",
+            "United States Virgin Islands -- Census"
+          ],
+          "publisherLiteral": [
+            "Research Publications,"
+          ],
+          "language": [
+            {
+              "id": "lang:und",
+              "label": "Undetermined"
+            }
+          ],
+          "createdYear": [
+            198
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "U.S. Virgin Islands--Census 1901, pt. 1, 1911, pt. 1 [microform]."
+          ],
+          "shelfMark": [
+            "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+          ],
+          "createdString": [
+            "198"
+          ],
+          "seriesStatement": [
+            "International population census publications [pre-1945]. Latin America"
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010385"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01012026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210361"
+            }
+          ],
+          "updatedAt": 1636140635056,
+          "publicationStatement": [
+            "Woodbridge, Conn. : Research Publications, [1983]"
+          ],
+          "identifier": [
+            "urn:bnum:10010385",
+            "urn:undefined:NNSZ01012026",
+            "urn:undefined:(WaOLN)nyp0210361"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "United States Virgin Islands -- Census."
+          ],
+          "titleDisplay": [
+            "U.S. Virgin Islands--Census 1901, pt. 1, 1911, pt. 1 [microform]."
+          ],
+          "uri": "b10010385",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Woodbridge, Conn. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm."
+          ]
+        },
+        "sort": [
+          "b10010385"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27849993",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433094813171"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433094813171"
+                    ],
+                    "idBarcode": [
+                      "33433094813171"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                  },
+                  "sort": [
+                    "a*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010607",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 broadside ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Facsimile reproduction (photoreproduction).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Alembert, Jean Le Rond d', 1717-1783",
+            "Diderot, Denis, 1713-1784",
+            "Encyclopédie"
+          ],
+          "publisherLiteral": [
+            "Ex Typographia Reverendae Camerae Apostolicae,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1759
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Damnatio, et prohibitio operis in plures tomos distributi, cujus est titulus Encyclopedie, ou Dictionaire raisonné des sciences, des arts, & des metiers, par une société de gens de lettres, mis en ordre, & publié par Mr. Diderot de l'Academie royale des sciences, & des belles lettres de Prusse, & quant a la partie mathematique, par Mr. d'Alembert de l'Academie royale de Sciences de Paris, de celle de Prusse, & de la Société royale de Londres [microform]"
+          ],
+          "shelfMark": [
+            "*Z-3852 no. 26"
+          ],
+          "creatorLiteral": [
+            "Catholic Church. Pope (1758-1769 : Clement XIII)"
+          ],
+          "createdString": [
+            "1759"
+          ],
+          "dateStartYear": [
+            1759
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3852 no. 26"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010607"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)13888170"
+            }
+          ],
+          "updatedAt": 1636086132775,
+          "publicationStatement": [
+            "Romae : Ex Typographia Reverendae Camerae Apostolicae, 1759."
+          ],
+          "identifier": [
+            "urn:bnum:10010607",
+            "urn:undefined:(OCoLC)13888170"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1759"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Alembert, Jean Le Rond d', 1717-1783.",
+            "Diderot, Denis, 1713-1784.",
+            "Encyclopédie."
+          ],
+          "titleDisplay": [
+            "Damnatio, et prohibitio operis in plures tomos distributi, cujus est titulus Encyclopedie, ou Dictionaire raisonné des sciences, des arts, & des metiers, par une société de gens de lettres, mis en ordre, & publié par Mr. Diderot de l'Academie royale des sciences, & des belles lettres de Prusse, & quant a la partie mathematique, par Mr. d'Alembert de l'Academie royale de Sciences de Paris, de celle de Prusse, & de la Société royale de Londres [microform] / Clemens Papa XIII ad futuram rei memoriam."
+          ],
+          "uri": "b10010607",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Romae :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm"
+          ]
+        },
+        "sort": [
+          "b10010607"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30458802",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3852 no. 1-27"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3852 no. 1-27",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107973277"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*Z-3852"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-27"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107973277"
+                    ],
+                    "idBarcode": [
+                      "33433107973277"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*Z-3852 no. 000001-27"
+                  },
+                  "sort": [
+                    "a*Z-3852 no. 000001-27"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010675",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: No. 2 (1975).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English or Spanish.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "American literature",
+            "American literature -- Mexican American authors",
+            "American literature -- Mexican American authors -- Periodicals",
+            "American poetry",
+            "American poetry -- Mexican American authors",
+            "American poetry -- Mexican American authors -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Pajarito Publications."
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            19
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Flor y canto."
+          ],
+          "shelfMark": [
+            "JFL 81-111"
+          ],
+          "createdString": [
+            "19"
+          ],
+          "dateStartYear": [
+            19
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 81-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010675"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210651"
+            }
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1636096259890,
+          "publicationStatement": [
+            "Albuquerque : Pajarito Publications."
+          ],
+          "identifier": [
+            "urn:bnum:10010675",
+            "urn:undefined:(WaOLN)nyp0210651"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "American literature -- Mexican American authors -- Periodicals.",
+            "American poetry -- Mexican American authors -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Flor y canto."
+          ],
+          "uri": "b10010675",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Albuquerque :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10010675"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005340",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 81-111 v. 2-5 1975-78"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 81-111 v. 2-5 1975-78",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005304187"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFL 81-111"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-5 1975-78"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005304187"
+                    ],
+                    "idBarcode": [
+                      "33433005304187"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFL 81-111 v. 000002-5 1975-78"
+                  },
+                  "sort": [
+                    "aJFL 81-111 v. 000002-5 1975-78"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "State universities and colleges",
+            "State universities and colleges -- United States",
+            "State universities and colleges -- United States -- Periodicals"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "AASCU studies."
+          ],
+          "shelfMark": [
+            "JLM 81-389"
+          ],
+          "creatorLiteral": [
+            "American Association of State Colleges and Universities."
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "72621307"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-389"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011031"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72621307"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211007"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070448706,
+          "publicationStatement": [
+            "[Washington]"
+          ],
+          "identifier": [
+            "urn:bnum:10011031",
+            "urn:lccn:72621307",
+            "urn:undefined:(WaOLN)nyp0211007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "State universities and colleges -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "AASCU studies."
+          ],
+          "uri": "b10011031",
+          "lccClassification": [
+            "LB2329.5.A43"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Washington]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "A. A. S. C. U. studies."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10011031"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540542",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-389 1970-1974"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-389 1970-1974",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017529995"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-389"
+                    ],
+                    "enumerationChronology": [
+                      "1970-1974"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017529995"
+                    ],
+                    "idBarcode": [
+                      "33433017529995"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-389 1970-001974"
+                  },
+                  "sort": [
+                    "aJLM 81-389 1970-001974"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Numbering",
+              "label": "Vols. for 1980-   called 1st-   annual supplement.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Continues: Equal employment opportunity court cases, ISSN 0272-278x, issued by: United States. Civil Service Commission. Bureau of Intergovernmental Personnel Programs. (Earlier title cataloged as monograph. See entry under: United States. Civil Service Commission. Bureau of Intergovernmental Personnel Programs).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Discrimination in employment",
+            "Discrimination in employment -- Digests",
+            "Discrimination in employment -- Digests -- United States",
+            "Discrimination in employment -- Digests -- United States -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "U.S. Office of Personnel Management, Office of Intergovernmental Programs : For sale by the Supt. of Docs., U.S. G.P.O."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Equal employment opportunity court cases."
+          ],
+          "shelfMark": [
+            "JLM 81-385"
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "80647817"
+          ],
+          "seriesStatement": [
+            "OIPP"
+          ],
+          "contributorLiteral": [
+            "United States. Office of Intergovernmental Personnel Programs."
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-385"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80647817"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0011050"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000038"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-EPA"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093707190,
+          "publicationStatement": [
+            "Washington : U.S. Office of Personnel Management, Office of Intergovernmental Programs : For sale by the Supt. of Docs., U.S. G.P.O."
+          ],
+          "identifier": [
+            "urn:bnum:10011036",
+            "urn:lccn:80647817",
+            "urn:undefined:(WaOLN)nyp0011050",
+            "urn:undefined:(WaOLN)nyp0000038",
+            "urn:undefined:RCON-EPA"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Discrimination in employment -- Digests -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Equal employment opportunity court cases."
+          ],
+          "uri": "b10011036",
+          "lccClassification": [
+            "PAR"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Equal employment opportunity court cases"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10011036"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540547",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-385 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-385 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017529912"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-385"
+                    ],
+                    "enumerationChronology": [
+                      "1980"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017529912"
+                    ],
+                    "idBarcode": [
+                      "33433017529912"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-385 001980"
+                  },
+                  "sort": [
+                    "aJLM 81-385 001980"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill., ports."
+          ],
+          "note": [
+            {
+              "noteType": "Supplement",
+              "label": "Supplement accompany some issues.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Journalism",
+            "Journalism -- Periodicals"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bulletin."
+          ],
+          "shelfMark": [
+            "M-10 3102"
+          ],
+          "creatorLiteral": [
+            "American Society of Newspaper Editors."
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "59037860 //r82"
+          ],
+          "idIssn": [
+            "0003-1178"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "M-10 3102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011041"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0003-1178"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "59037860 //r82"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0011055"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000039"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079653370,
+          "publicationStatement": [
+            "Easton, Pa. [etc.]"
+          ],
+          "identifier": [
+            "urn:bnum:10011041",
+            "urn:issn:0003-1178",
+            "urn:lccn:59037860 //r82",
+            "urn:undefined:(WaOLN)nyp0011055",
+            "urn:undefined:(WaOLN)nyp0000039"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Journalism -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Bulletin."
+          ],
+          "uri": "b10011041",
+          "lccClassification": [
+            "PN4700 .A58"
+          ],
+          "numItems": [
+            9
+          ],
+          "numAvailable": [
+            9
+          ],
+          "placeOfPublication": [
+            "Easton, Pa. [etc.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "The Bulletin of the American Society of Newspaper Editors"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10011041"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 9,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 383-415 1956-58"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 383-415 1956-58",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676801"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 383-415 1956-58"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676801"
+                    ],
+                    "idBarcode": [
+                      "33433010676801"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 383-415 1956-000058"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 383-415 1956-000058"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901110",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 416-437 1959-60"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 416-437 1959-60",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676819"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 416-437 1959-60"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676819"
+                    ],
+                    "idBarcode": [
+                      "33433010676819"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 416-437 1959-000060"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 416-437 1959-000060"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901111",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 438-459 1961-62"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 438-459 1961-62",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676827"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 438-459 1961-62"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676827"
+                    ],
+                    "idBarcode": [
+                      "33433010676827"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 438-459 1961-000062"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 438-459 1961-000062"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901112",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 460-481 1963-64"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 460-481 1963-64",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676835"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 460-481 1963-64"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676835"
+                    ],
+                    "idBarcode": [
+                      "33433010676835"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 460-481 1963-000064"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 460-481 1963-000064"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901113",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 482-514 1965-67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 482-514 1965-67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676843"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 482-514 1965-67"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676843"
+                    ],
+                    "idBarcode": [
+                      "33433010676843"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 482-514 1965-000067"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 482-514 1965-000067"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901114",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 515-546 1968-70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 515-546 1968-70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676850"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 515-546 1968-70"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676850"
+                    ],
+                    "idBarcode": [
+                      "33433010676850"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 515-546 1968-000070"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 515-546 1968-000070"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 547-57 1971-73"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 547-57 1971-73",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676868"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 547-57 1971-73"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676868"
+                    ],
+                    "idBarcode": [
+                      "33433010676868"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 547-57 1971-000073"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 547-57 1971-000073"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901116",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 574-600 1974-76"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 574-600 1974-76",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676876"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 574-600 1974-76"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676876"
+                    ],
+                    "idBarcode": [
+                      "33433010676876"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 574-600 1974-000076"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 574-600 1974-000076"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901117",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 601-629 Jan. 1977-Jan. 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 601-629 Jan. 1977-Jan. 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676884"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "enumerationChronology": [
+                      "nos. 601-629 Jan. 1977-Jan. 1980"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676884"
+                    ],
+                    "idBarcode": [
+                      "33433010676884"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 601-629 Jan. 1977-Jan. 001980"
+                  },
+                  "sort": [
+                    "aM-10 3102 nos. 601-629 Jan. 1977-Jan. 001980"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011321",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[6], 72 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "German and Hebrew.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Aramaic language",
+            "Aramaic language -- Grammar",
+            "Hebrew language",
+            "Hebrew language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Wittwe Vandenhöck,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1770
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Johann Ernst Fabers Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "shelfMark": [
+            "*PCQ 85-1669"
+          ],
+          "creatorLiteral": [
+            "Faber, Johann Ernst, 1746-1774."
+          ],
+          "createdString": [
+            "1770"
+          ],
+          "dateStartYear": [
+            1770
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*PCQ 85-1669"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011321"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213287"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211293"
+            }
+          ],
+          "updatedAt": 1636107911712,
+          "publicationStatement": [
+            "Göttingen : Wittwe Vandenhöck, 1770."
+          ],
+          "identifier": [
+            "urn:bnum:10011321",
+            "urn:undefined:NNSZ01213287",
+            "urn:undefined:(WaOLN)nyp0211293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1770"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Aramaic language -- Grammar.",
+            "Hebrew language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Johann Ernst Fabers Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "uri": "b10011321",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Göttingen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "dimensions": [
+            "19cm."
+          ]
+        },
+        "sort": [
+          "b10011321"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747226",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf98",
+                        "label": "Schwarzman Building M2 - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf98||Schwarzman Building M2 - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "**P- *PCQ 85-1669"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "**P- *PCQ 85-1669",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089858876"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "**P- *PCQ 85-1669"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089858876"
+                    ],
+                    "idBarcode": [
+                      "33433089858876"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "a**P- *PCQ 85-001669"
+                  },
+                  "sort": [
+                    "a**P- *PCQ 85-001669"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011751",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Results of a survey of RMA member banks.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "-1987."
+          ],
+          "subjectLiteral_exploded": [
+            "Bank loans",
+            "Bank loans -- United States",
+            "Bank loans -- United States -- Periodicals",
+            "Robert Morris Associates",
+            "Robert Morris Associates -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Robert Morris Associates."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1987"
+          ],
+          "createdYear": [
+            198
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Report on domestic and international loan charge-offs."
+          ],
+          "shelfMark": [
+            "JLM 81-449"
+          ],
+          "creatorLiteral": [
+            "Robert Morris Associates."
+          ],
+          "createdString": [
+            "198"
+          ],
+          "idLccn": [
+            "80640293"
+          ],
+          "idIssn": [
+            "0196-724X"
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-449"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011751"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0196-724X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80640293"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211718"
+            }
+          ],
+          "dateEndYear": [
+            1987
+          ],
+          "updatedAt": 1636126055000,
+          "publicationStatement": [
+            "Philadelphia, Robert Morris Associates."
+          ],
+          "identifier": [
+            "urn:bnum:10011751",
+            "urn:issn:0196-724X",
+            "urn:lccn:80640293",
+            "urn:undefined:(WaOLN)nyp0211718"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bank loans -- United States -- Periodicals.",
+            "Robert Morris Associates -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Report on domestic and international loan charge-offs."
+          ],
+          "uri": "b10011751",
+          "lccClassification": [
+            "HG1642.U5 R58a"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Report on domestic and international loan charge-offs"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10011751"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540558",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-449 1978-1983, 1987."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-449 1978-1983, 1987.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019908379"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-449"
+                    ],
+                    "enumerationChronology": [
+                      "1978-1983, 1987."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019908379"
+                    ],
+                    "idBarcode": [
+                      "33433019908379"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-449 1978-1983, 1987."
+                  },
+                  "sort": [
+                    "aJLM 81-449 1978-1983, 1987."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012379",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "712 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A service book of the Armenian church.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In classical Armenian (Grabar)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Armenian Church",
+            "Armenian Church -- Liturgy"
+          ],
+          "publisherLiteral": [
+            "Tpeal hramanaw Teaṛn Zakʻariay azgasēr ev barekarg Patriargi,"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "createdYear": [
+            1795
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Kargavorutʻyun Hasarakatsʻ Aghotʻitsʻ Hayastaneaytsʻ Ekeghetsʻwoy."
+          ],
+          "shelfMark": [
+            "*ONN 86-1887"
+          ],
+          "creatorLiteral": [
+            "Armenian Church."
+          ],
+          "createdString": [
+            "1795"
+          ],
+          "dateStartYear": [
+            1795
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONN 86-1887"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012379"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314364"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212344"
+            }
+          ],
+          "updatedAt": 1647838731409,
+          "publicationStatement": [
+            "Kostandnupolis : Tpeal hramanaw Teaṛn Zakʻariay azgasēr ev barekarg Patriargi, 1795."
+          ],
+          "identifier": [
+            "urn:bnum:10012379",
+            "urn:undefined:NNSZ01314364",
+            "urn:undefined:(WaOLN)nyp0212344"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1795"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenian Church -- Liturgy."
+          ],
+          "titleDisplay": [
+            "Kargavorutʻyun Hasarakatsʻ Aghotʻitsʻ Hayastaneaytsʻ Ekeghetsʻwoy."
+          ],
+          "uri": "b10012379",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "Kostandnupolis :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10012379"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540597",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*ONN 86-1887"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONN 86-1887",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057787578"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONN 86-1887"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057787578"
+                    ],
+                    "idBarcode": [
+                      "33433057787578"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Kargavorutʻyun+Hasarakatsʻ+Aghotʻitsʻ+Hayastaneaytsʻ+Ekeghetsʻwoy.&Site=SASRB&CallNumber=*ONN+86-1887+(Locked+cage)&Author=Armenian+Church.&ItemPlace=Kostandnupolis+:&ItemPublisher=Tpeal+hramanaw+Teaṛn+Zakʻariay+azgas&#x113;r+ev+barekarg+Patriargi,&Date=1795.&ItemInfo3=https://catalog.nypl.org/record=b10012379&ReferenceNumber=b10012379x&ItemNumber=33433057787578&ItemISxN=i125405972&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a*ONN 86-001887"
+                  },
+                  "sort": [
+                    "a*ONN 86-001887"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10012379-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Kargavorutʻyun+Hasarakatsʻ+Aghotʻitsʻ+Hayastaneaytsʻ+Ekeghetsʻwoy.&Site=SASRB&CallNumber=*ONN+86-1887+(Locked+cage)&Author=Armenian+Church.&ItemPlace=Kostandnupolis+:&ItemPublisher=Tpeal+hramanaw+Teaṛn+Zakʻariay+azgas&#x113;r+ev+barekarg+Patriargi,&Date=1795.&ItemInfo3=https://catalog.nypl.org/record=b10012379&ReferenceNumber=b10012379x&ItemNumber=33433057787578&ItemISxN=i125405972&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10012379-e"
+                  },
+                  "sort": [
+                    "bi10012379-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: Sept. 1, 1933.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Issues for 1933-1957 called v. <16-39>.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began in 1918"
+          ],
+          "subjectLiteral_exploded": [
+            "Labor unions",
+            "Labor unions -- Miners",
+            "Labor unions -- Miners -- United States",
+            "Labor unions -- Miners -- United States -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Districts No. 1, 7, and 9, United Mine Workers of America,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Anthracite tri-district news : official organ for Districts No. 1, 7, and 9, United Mine Workers of America."
+          ],
+          "shelfMark": [
+            "TDRA+++ (Anthracite tri-district news)"
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "contributorLiteral": [
+            "United Mine Workers of America. District No. 1.",
+            "United Mine Workers of America. District No. 7.",
+            "United Mine Workers of America. District No. 9."
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "TDRA+++ (Anthracite tri-district news)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012504"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212468"
+            }
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1636074531396,
+          "publicationStatement": [
+            "Hazelton, Pa. : Districts No. 1, 7, and 9, United Mine Workers of America,"
+          ],
+          "identifier": [
+            "urn:bnum:10012504",
+            "urn:undefined:(WaOLN)nyp0212468"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Labor unions -- Miners -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Anthracite tri-district news : official organ for Districts No. 1, 7, and 9, United Mine Workers of America."
+          ],
+          "uri": "b10012504",
+          "numItems": [
+            16
+          ],
+          "numAvailable": [
+            16
+          ],
+          "placeOfPublication": [
+            "Hazelton, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "57 cm."
+          ]
+        },
+        "sort": [
+          "b10012504"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 16,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859066",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 17 (Jan. 5-Dec. 28, 1934)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 17 (Jan. 5-Dec. 28, 1934)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100251"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17 (Jan. 5-Dec. 28, 1934)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100251"
+                    ],
+                    "idBarcode": [
+                      "33433057100251"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000017 (Jan. 5-Dec. 28, 1934)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000017 (Jan. 5-Dec. 28, 1934)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859067",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 18 (1935)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 18 (1935)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100269"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 18 (1935)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100269"
+                    ],
+                    "idBarcode": [
+                      "33433057100269"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000018 (1935)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000018 (1935)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859068",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 19 (1936)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 19 (1936)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100277"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 19 (1936)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100277"
+                    ],
+                    "idBarcode": [
+                      "33433057100277"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000019 (1936)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000019 (1936)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 20 (1937)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 20 (1937)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100285"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 20 (1937)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100285"
+                    ],
+                    "idBarcode": [
+                      "33433057100285"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000020 (1937)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000020 (1937)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859070",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 21 (1938)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 21 (1938)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100293"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 21 (1938)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100293"
+                    ],
+                    "idBarcode": [
+                      "33433057100293"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000021 (1938)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000021 (1938)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859071",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 22 (1939)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 22 (1939)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100301"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 22 (1939)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100301"
+                    ],
+                    "idBarcode": [
+                      "33433057100301"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000022 (1939)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000022 (1939)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859072",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 23 (1940)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 23 (1940)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102141"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23 (1940)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102141"
+                    ],
+                    "idBarcode": [
+                      "33433057102141"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000023 (1940)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000023 (1940)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859073",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 24 (1941)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 24 (1941)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102158"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 24 (1941)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102158"
+                    ],
+                    "idBarcode": [
+                      "33433057102158"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000024 (1941)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000024 (1941)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859074",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 25 (1942)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 25 (1942)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102166"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25 (1942)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102166"
+                    ],
+                    "idBarcode": [
+                      "33433057102166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000025 (1942)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000025 (1942)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859075",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 26 (1943)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 26 (1943)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102174"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 26 (1943)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102174"
+                    ],
+                    "idBarcode": [
+                      "33433057102174"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000026 (1943)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000026 (1943)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859076",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 27 (1944)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 27 (1944)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102182"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27 (1944)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102182"
+                    ],
+                    "idBarcode": [
+                      "33433057102182"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000027 (1944)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000027 (1944)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859077",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 28 (1945)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 28 (1945)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102190"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 28 (1945)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102190"
+                    ],
+                    "idBarcode": [
+                      "33433057102190"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000028 (1945)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000028 (1945)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859078",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 29 (1946)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 29 (1946)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102208"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 29 (1946)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102208"
+                    ],
+                    "idBarcode": [
+                      "33433057102208"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000029 (1946)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000029 (1946)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859079",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 30 (1947)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 30 (1947)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102216"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30 (1947)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102216"
+                    ],
+                    "idBarcode": [
+                      "33433057102216"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000030 (1947)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000030 (1947)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 32 (1949)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 32 (1949)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102224"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 32 (1949)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102224"
+                    ],
+                    "idBarcode": [
+                      "33433057102224"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000032 (1949)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000032 (1949)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859081",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 33 (1950)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 33 (1950)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102232"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "enumerationChronology": [
+                      "v. 33 (1950)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102232"
+                    ],
+                    "idBarcode": [
+                      "33433057102232"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000033 (1950)"
+                  },
+                  "sort": [
+                    "aTDRA+++ (Anthracite tri-district news) v. 000033 (1950)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012514",
+        "_score": null,
+        "_source": {
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Clark County (Wash.)",
+            "Clark County (Wash.) -- Genealogy",
+            "Clark County (Wash.) -- Genealogy -- Periodicals",
+            "Genealogy",
+            "United States, Washington",
+            "United States, Washington -- Periodicals",
+            "Washington (State)",
+            "Washington (State) -- Clark County"
+          ],
+          "publisherLiteral": [
+            "Clark County Genealogical Society."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Trail breakers."
+          ],
+          "shelfMark": [
+            "APR (Clark Co., Wash.) 81-297"
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "   76641407"
+          ],
+          "idIssn": [
+            "0362-0344"
+          ],
+          "contributorLiteral": [
+            "Clark County Genealogical Society (Clark County, Wash.)"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APR (Clark Co., Wash.) 81-297"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012514"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0362-0344"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   76641407"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)2441280"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "2:1(Sep 1975)-33(Jun. 2006-Jun. 2007).",
+                "Directory (of society's officers and other sources)  1984/1985 bound with v.10 & v.11"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 27 No. 1 (Fall 2000)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 2 (Winter 2001)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 3 (Spring 2001)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 4 (Summer 2001)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 28 No. 1-3 (Fall 2001)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 1 (Fall 2002)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 2 (Winter 2003)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 3/4 (Spring 2003)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 30 No. 1 (Fall 2003)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Unavailable"
+                },
+                {
+                  "coverage": "Vol. 30 No. 2 (Winter 2004)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 30 No. 3/4 (Spring 2004)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 31-32 No. 1 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Out of Print"
+                },
+                {
+                  "coverage": "No. 33 (Jul. 2006 - Jun. 2007)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "APR (Clark Co., Wash.) 81-297"
+                }
+              ],
+              "notes": [
+                "\"Directory\" of same society collected and bound separately under : APR (Clark Co., Wash.) 83-333.",
+                "ISSN number: 0362-0344",
+                "QUARTERLY"
+              ],
+              "physicalLocation": [
+                "APR (Clark Co., Wash.) 81-297"
+              ],
+              "format": [
+                "CURRENT IN U.S. HISTORY & GENEALOGY + HOLDINGS"
+              ],
+              "location": [
+                {
+                  "code": "loc:mag",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "uri": "h1031662",
+              "shelfMark": [
+                "APR (Clark Co., Wash.) 81-297"
+              ]
+            }
+          ],
+          "updatedAt": 1636140123404,
+          "publicationStatement": [
+            "Vancouver, Wash., Clark County Genealogical Society."
+          ],
+          "identifier": [
+            "urn:bnum:10012514",
+            "urn:issn:0362-0344",
+            "urn:lccn:   76641407",
+            "urn:undefined:(OCoLC)2441280"
+          ],
+          "genreForm": [
+            "Periodicals."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Clark County (Wash.) -- Genealogy -- Periodicals.",
+            "Genealogy.",
+            "United States, Washington -- Periodicals.",
+            "Washington (State) -- Clark County."
+          ],
+          "titleDisplay": [
+            "Trail breakers."
+          ],
+          "uri": "b10012514",
+          "lccClassification": [
+            "F897.C6 T7"
+          ],
+          "numItems": [
+            12
+          ],
+          "numAvailable": [
+            12
+          ],
+          "placeOfPublication": [
+            "Vancouver, Wash.,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Trail breakers"
+          ],
+          "dimensions": [
+            "28 cm"
+          ]
+        },
+        "sort": [
+          "b10012514"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 12,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747349",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 2-4 (1975-1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 2-4 (1975-1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480094"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-4 (1975-1978)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480094"
+                    ],
+                    "idBarcode": [
+                      "33433062480094"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000002-4 (1975-1978)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000002-4 (1975-1978)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747350",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 5-7 (Sep. 1978-Sum. 1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 5-7 (Sep. 1978-Sum. 1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480102"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-7 (Sep. 1978-Sum. 1981)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480102"
+                    ],
+                    "idBarcode": [
+                      "33433062480102"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000005-7 (Sep. 1978-Sum. 1981)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000005-7 (Sep. 1978-Sum. 1981)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747351",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 8-9 (1981-1983)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 8-9 (1981-1983)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9 (1981-1983)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480110"
+                    ],
+                    "idBarcode": [
+                      "33433062480110"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000008-9 (1981-1983)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000008-9 (1981-1983)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747352",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 10-11 (1983-1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 10-11 (1983-1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10-11 (1983-1985)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480128"
+                    ],
+                    "idBarcode": [
+                      "33433062480128"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000010-11 (1983-1985)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000010-11 (1983-1985)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747353",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 12-13 (Fall. 1985-Sum. 1987)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 12-13 (Fall. 1985-Sum. 1987)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480136"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12-13 (Fall. 1985-Sum. 1987)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480136"
+                    ],
+                    "idBarcode": [
+                      "33433062480136"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000012-13 (Fall. 1985-Sum. 1987)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000012-13 (Fall. 1985-Sum. 1987)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747354",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 14-15 (1987-1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 14-15 (1987-1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480144"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14-15 (1987-1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480144"
+                    ],
+                    "idBarcode": [
+                      "33433062480144"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000014-15 (1987-1989)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000014-15 (1987-1989)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747355",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 16-17 (1989-1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 16-17 (1989-1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480151"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-17 (1989-1991)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480151"
+                    ],
+                    "idBarcode": [
+                      "33433062480151"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000016-17 (1989-1991)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000016-17 (1989-1991)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747356",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 18-20 (Fall. 1991-Sum. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 18-20 (Fall. 1991-Sum. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480169"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 18-20 (Fall. 1991-Sum. 1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480169"
+                    ],
+                    "idBarcode": [
+                      "33433062480169"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000018-20 (Fall. 1991-Sum. 1994)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000018-20 (Fall. 1991-Sum. 1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747357",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 21-22 (Fall. 1994-Sum. 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 21-22 (Fall. 1994-Sum. 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480177"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 21-22 (Fall. 1994-Sum. 1996)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480177"
+                    ],
+                    "idBarcode": [
+                      "33433062480177"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000021-22 (Fall. 1994-Sum. 1996)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000021-22 (Fall. 1994-Sum. 1996)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901143",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 23-24 (Fall. 1996-Sum. 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 23-24 (Fall. 1996-Sum. 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031851219"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-24 (Fall. 1996-Sum. 1998)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031851219"
+                    ],
+                    "idBarcode": [
+                      "33433031851219"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000023-24 (Fall. 1996-Sum. 1998)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000023-24 (Fall. 1996-Sum. 1998)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901144",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 25-26 (Fall. 1998-Sum. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 25-26 (Fall. 1998-Sum. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031851227"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-26 (Fall. 1998-Sum. 2000)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031851227"
+                    ],
+                    "idBarcode": [
+                      "33433031851227"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000025-26 (Fall. 1998-Sum. 2000)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000025-26 (Fall. 1998-Sum. 2000)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34246372",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 27-33, inc. (Fall 2000 - July 2006-June 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 27-33, inc. (Fall 2000 - July 2006-June 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089464600"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27-33, inc. (Fall 2000 - July 2006-June 2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089464600"
+                    ],
+                    "idBarcode": [
+                      "33433089464600"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000027-33, inc. (Fall 2000 - July 2006-June 2007)"
+                  },
+                  "sort": [
+                    "aAPR (Clark Co., Wash.) 81-297 v. 000027-33, inc. (Fall 2000 - July 2006-June 2007)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012515",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Numbering",
+              "label": "Feb.-June 1928 also called year 3.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "no.   -123;   -June 22, 1928"
+          ],
+          "subjectLiteral_exploded": [
+            "Jews",
+            "Jews -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Jewish Graphic, Ltd."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1928"
+          ],
+          "createdYear": [
+            192
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The Jewish graphic."
+          ],
+          "shelfMark": [
+            "*ZAN-*P519"
+          ],
+          "createdString": [
+            "192"
+          ],
+          "dateStartYear": [
+            192
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-*P519"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012515"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212479"
+            }
+          ],
+          "dateEndYear": [
+            1928
+          ],
+          "updatedAt": 1636135799008,
+          "publicationStatement": [
+            "London : Jewish Graphic, Ltd."
+          ],
+          "identifier": [
+            "urn:bnum:10012515",
+            "urn:undefined:(WaOLN)nyp0212479"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "192"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jews -- Periodicals."
+          ],
+          "titleDisplay": [
+            "The Jewish graphic."
+          ],
+          "uri": "b10012515",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "42 cm."
+          ]
+        },
+        "sort": [
+          "b10012515"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006287",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf82",
+                        "label": "Schwarzman Building - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf82||Schwarzman Building - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433092672512"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-*P519"
+                    ],
+                    "enumerationChronology": [
+                      "Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433092672512"
+                    ],
+                    "idBarcode": [
+                      "33433092672512"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                  },
+                  "sort": [
+                    "a*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013199",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Volume 1 only. No more published.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Administrative agencies",
+            "Administrative agencies -- Argentina",
+            "Argentina",
+            "Argentina -- Politics and government",
+            "Argentina -- Politics and government -- 1983-"
+          ],
+          "publisherLiteral": [
+            "Asociación Argentina de Egresados en Ciencias Políticas,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Estructura y organización de los ministerios de poder ejecutivo nacional : [aportes para el estudio de la estructura del poder durante el gobierno del Dr. Alfonsín]"
+          ],
+          "shelfMark": [
+            "JLK 86-206"
+          ],
+          "creatorLiteral": [
+            "Fardeso, José Horacio."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLK 86-206"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013199"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415604"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213163"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636094229907,
+          "publicationStatement": [
+            "Buenos Aires : Asociación Argentina de Egresados en Ciencias Políticas, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10013199",
+            "urn:undefined:NNSZ01415604",
+            "urn:undefined:(WaOLN)nyp0213163"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Administrative agencies -- Argentina.",
+            "Argentina -- Politics and government -- 1983-"
+          ],
+          "titleDisplay": [
+            "Estructura y organización de los ministerios de poder ejecutivo nacional : [aportes para el estudio de la estructura del poder durante el gobierno del Dr. Alfonsín] / José Horacio Fardeso."
+          ],
+          "uri": "b10013199",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Buenos Aires :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10013199"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747397",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLK 86-206 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLK 86-206 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433063254944"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLK 86-206"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433063254944"
+                    ],
+                    "idBarcode": [
+                      "33433063254944"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLK 86-206 v. 000001"
+                  },
+                  "sort": [
+                    "aJLK 86-206 v. 000001"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013321",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5 v. in 1."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Minerva,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "dateEndString": [
+            "1597"
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Problemata logica. Marburg 1597."
+          ],
+          "shelfMark": [
+            "JFB 86-112"
+          ],
+          "creatorLiteral": [
+            "Goclenius, Rudolph, 1547-1628."
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "68110653"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 86-112"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013321"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "68110653"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415735"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213284"
+            }
+          ],
+          "dateEndYear": [
+            1597
+          ],
+          "updatedAt": 1636123523500,
+          "publicationStatement": [
+            "Frankfurt, Minerva, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10013321",
+            "urn:lccn:68110653",
+            "urn:undefined:NNSZ01415735",
+            "urn:undefined:(WaOLN)nyp0213284"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Problemata logica. Marburg 1597."
+          ],
+          "uri": "b10013321",
+          "lccClassification": [
+            "BC60 .G62"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Frankfurt,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10013321"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006744",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFB 86-112"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFB 86-112",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005151620"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFB 86-112"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005151620"
+                    ],
+                    "idBarcode": [
+                      "33433005151620"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFB 86-000112"
+                  },
+                  "sort": [
+                    "aJFB 86-000112"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013473",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "155 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Perspective"
+          ],
+          "publisherLiteral": [
+            "M. Tavernier,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1643
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La perspective speculative, et pratique [microform] : ou sont demonstrez les fondemens de cet art, & de tout ce qui en a esté enseigné jusqu'ā present ..."
+          ],
+          "shelfMark": [
+            "*ZM-189"
+          ],
+          "creatorLiteral": [
+            "Aleaume, Jacques, -approximately 1627."
+          ],
+          "createdString": [
+            "1643"
+          ],
+          "dateStartYear": [
+            1643
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZM-189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013473"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415893"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213436"
+            }
+          ],
+          "updatedAt": 1644357878029,
+          "publicationStatement": [
+            "Paris : M. Tavernier, 1643."
+          ],
+          "identifier": [
+            "urn:bnum:10013473",
+            "urn:undefined:NNSZ01415893",
+            "urn:undefined:(WaOLN)nyp0213436"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1643"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Perspective."
+          ],
+          "titleDisplay": [
+            "La perspective speculative, et pratique [microform] : ou sont demonstrez les fondemens de cet art, & de tout ce qui en a esté enseigné jusqu'ā present ... / de l'invention du feu sieur Aleaume ..."
+          ],
+          "uri": "b10013473",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10013473"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006750",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZM-189"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZM-189",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110386137"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZM-189"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110386137"
+                    ],
+                    "idBarcode": [
+                      "33433110386137"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZM-000189"
+                  },
+                  "sort": [
+                    "a*ZM-000189"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006752",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MBF (Aleaume, J. Perspective speculative, et pratique)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090700216"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090700216"
+                    ],
+                    "idBarcode": [
+                      "33433090700216"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "a3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                  },
+                  "sort": [
+                    "a3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013537",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Colonies. No. 10.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: A⁶.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Bibliothèque nationale (France). Catalogue de l’histoire de la Révolution française",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- Early works to 1800",
+            "Racially mixed people",
+            "Racially mixed people -- Haiti",
+            "Racially mixed people -- Haiti -- Early works to 1800",
+            "Slavery",
+            "Slavery -- Haiti",
+            "Slavery -- Haiti -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "De l'Imprimerie nationale,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1791
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Opinion de Jean-François Ducos sur l'exécution provisoire du concordat, & des arrêtés de l'Assemblée coloniale confirmatifs de cet accord : imprimée par ordre de l'Assemblée nationale."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-7"
+          ],
+          "creatorLiteral": [
+            "Ducos, Jean François, 1765-1793."
+          ],
+          "createdString": [
+            "1791"
+          ],
+          "contributorLiteral": [
+            "France. Assemblée nationale constituante (1789-1791)",
+            "Imprimerie nationale (France), publisher."
+          ],
+          "dateStartYear": [
+            1791
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-7"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013537"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415958"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213499"
+            }
+          ],
+          "updatedAt": 1637598155096,
+          "publicationStatement": [
+            "A Paris : De l'Imprimerie nationale, 1791."
+          ],
+          "identifier": [
+            "urn:bnum:10013537",
+            "urn:undefined:NNSZ01415958",
+            "urn:undefined:(WaOLN)nyp0213499"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1791"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "France -- Administration -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800.",
+            "Haiti -- Politics and government -- Early works to 1800.",
+            "Racially mixed people -- Haiti -- Early works to 1800.",
+            "Slavery -- Haiti -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Opinion de Jean-François Ducos sur l'exécution provisoire du concordat, & des arrêtés de l'Assemblée coloniale confirmatifs de cet accord : imprimée par ordre de l'Assemblée nationale."
+          ],
+          "uri": "b10013537",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013537"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901189",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927121"
+                    ],
+                    "idBarcode": [
+                      "33433036927121"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Opinion+de+Jean-François+Ducos+sur+l'exécution+provisoire+du+concordat,+and+des+arrêtés+de+l'Assemblée+coloniale+confirmatifs+de+cet+accord+:+imprimée+par+ordre+de+l'Assemblée+nationale.&Site=SCHRB&CallNumber=Sc+Rare+C+86-7&Author=Ducos,+Jean+François,&ItemPlace=A+Paris+:&ItemPublisher=De+l'Imprimerie+nationale,&Date=1791.&ItemInfo3=https://catalog.nypl.org/record=b10013537&ReferenceNumber=b100135377&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927121&ItemISxN=i11901189x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000007"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-000007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013537-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Opinion+de+Jean-François+Ducos+sur+l'exécution+provisoire+du+concordat,+and+des+arrêtés+de+l'Assemblée+coloniale+confirmatifs+de+cet+accord+:+imprimée+par+ordre+de+l'Assemblée+nationale.&Site=SCHRB&CallNumber=Sc+Rare+C+86-7&Author=Ducos,+Jean+François,&ItemPlace=A+Paris+:&ItemPublisher=De+l'Imprimerie+nationale,&Date=1791.&ItemInfo3=https://catalog.nypl.org/record=b10013537&ReferenceNumber=b100135377&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927121&ItemISxN=i11901189x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013537-e"
+                  },
+                  "sort": [
+                    "bi10013537-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013539",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "48 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "With a half-title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Avertissement. Quoique le titre de cet ouvrage semble announcer qu'on présentera la situation actuelle de toutes les colonies, je dois cependant prévenir le lecteur que, n'ayant en que des matériaux incomplets, j'ai été forcé pour le moment, de ne parler que de Saint-Domingue.\"--p. [2] (verso of half-title page). ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: A-C⁸.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Bibliothèque nationale (France). Catalogue de l’histoire de la Révolution française",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "France. Marine",
+            "France. Marine -- Early works to 1800",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- Early works to 1800",
+            "Racially mixed people",
+            "Racially mixed people -- Haiti",
+            "Racially mixed people -- Haiti -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "de le Imprimerie de L.-P. Couret, rue Christine, no. 2,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "De l'état actuel de la marine et des colonies"
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-4"
+          ],
+          "creatorLiteral": [
+            "Brasseur."
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "contributorLiteral": [
+            "Couret de Villeneuve, Louis-Pierre, 1749-1806,"
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013539"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415960"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213501"
+            }
+          ],
+          "updatedAt": 1637598155148,
+          "publicationStatement": [
+            "A Paris : de le Imprimerie de L.-P. Couret, rue Christine, no. 2, 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013539",
+            "urn:undefined:NNSZ01415960",
+            "urn:undefined:(WaOLN)nyp0213501"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "France. Marine -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800.",
+            "Haiti -- Politics and government -- Early works to 1800.",
+            "Racially mixed people -- Haiti -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "De l'état actuel de la marine et des colonies / par M. Le Brasseur, ci-devant intendant-général de la Marine."
+          ],
+          "uri": "b10013539",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013539"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901191",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927147"
+                    ],
+                    "idBarcode": [
+                      "33433036927147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+l'état+actuel+de+la+marine+et+des+colonies+/&Site=SCHRB&CallNumber=Sc+Rare+C+86-4&Author=Brasseur.&ItemPlace=A+Paris+:&ItemPublisher=de+le+Imprimerie+de+L.-P.+Couret,+rue+Christine,+no.+2,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013539&ReferenceNumber=b100135390&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927147&ItemISxN=i119011918&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000004"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-000004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013539-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+l'état+actuel+de+la+marine+et+des+colonies+/&Site=SCHRB&CallNumber=Sc+Rare+C+86-4&Author=Brasseur.&ItemPlace=A+Paris+:&ItemPublisher=de+le+Imprimerie+de+L.-P.+Couret,+rue+Christine,+no.+2,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013539&ReferenceNumber=b100135390&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927147&ItemISxN=i119011918&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013539-e"
+                  },
+                  "sort": [
+                    "bi10013539-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "7 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources"
+          ],
+          "publisherLiteral": [
+            "De l'Impr. de P.F. Didot le jeune,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1791
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pétition faite à l'Assemblée nationale par MM. les Commissaires de l'Assemblée générale de la partie française de St.-Domingue : le 2 décembre 1791, et lue le 3."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-3"
+          ],
+          "creatorLiteral": [
+            "Saint-Domingue. Assemblée générale Commissaires."
+          ],
+          "createdString": [
+            "1791"
+          ],
+          "contributorLiteral": [
+            "France. Assemblée nationale législative (1791-1792)"
+          ],
+          "dateStartYear": [
+            1791
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415961"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213502"
+            }
+          ],
+          "updatedAt": 1636124323776,
+          "publicationStatement": [
+            "[Paris?] : De l'Impr. de P.F. Didot le jeune, [1791?]"
+          ],
+          "identifier": [
+            "urn:bnum:10013540",
+            "urn:undefined:NNSZ01415961",
+            "urn:undefined:(WaOLN)nyp0213502"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1791"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources."
+          ],
+          "titleDisplay": [
+            "Pétition faite à l'Assemblée nationale par MM. les Commissaires de l'Assemblée générale de la partie française de St.-Domingue : le 2 décembre 1791, et lue le 3."
+          ],
+          "uri": "b10013540",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Paris?] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013540"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901192",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927154"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927154"
+                    ],
+                    "idBarcode": [
+                      "33433036927154"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Pétition+faite+à+l'Assemblée+nationale+par+MM.+les+Commissaires+de+l'Assemblée+générale+de+la+partie+française+de+St.-Domingue+:+le+2+décembre+1791,+et+lue+le+3.&Site=SCHRB&CallNumber=Sc+Rare+C+86-3&Author=Saint-Domingue.&ItemPlace=[Paris?]+:&ItemPublisher=De+l'Impr.+de+P.F.+Didot+le+jeune,&Date=[1791?]&ItemInfo3=https://catalog.nypl.org/record=b10013540&ReferenceNumber=b100135407&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927154&ItemISxN=i11901192x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000003"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-000003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013540-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Pétition+faite+à+l'Assemblée+nationale+par+MM.+les+Commissaires+de+l'Assemblée+générale+de+la+partie+française+de+St.-Domingue+:+le+2+décembre+1791,+et+lue+le+3.&Site=SCHRB&CallNumber=Sc+Rare+C+86-3&Author=Saint-Domingue.&ItemPlace=[Paris?]+:&ItemPublisher=De+l'Impr.+de+P.F.+Didot+le+jeune,&Date=[1791?]&ItemInfo3=https://catalog.nypl.org/record=b10013540&ReferenceNumber=b100135407&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927154&ItemISxN=i11901192x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013540-e"
+                  },
+                  "sort": [
+                    "bi10013540-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013541",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "6, [2] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Imprint from colophon.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"No. 1606\" printed to right of head-piece above caption title. ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Decree of the National Assembly.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signed on p. 6: Louis. Et plus bas, Roland.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Last [2] p. blank.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: [A]⁴ ([A]4 blank)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Black people",
+            "Black people -- Civil rights",
+            "Black people -- Civil rights -- Haiti",
+            "Black people -- Civil rights -- Haiti -- Early works to 1800",
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800",
+            "France -- Politics and government",
+            "France -- Politics and government -- 1789-1799",
+            "France -- Politics and government -- 1789-1799 -- Early works to 1800",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- 1791-1804",
+            "Haiti -- Politics and government -- 1791-1804 -- Early works to 1800",
+            "Racially mixed people",
+            "Racially mixed people -- Civil rights",
+            "Racially mixed people -- Civil rights -- Haiti",
+            "Racially mixed people -- Civil rights -- Haiti -- Early works to 1800",
+            "Suffrage",
+            "Suffrage -- Haiti",
+            "Suffrage -- Haiti -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Chez Jean-Baptiste Lefranc-Elies, imprimeur de Dép. des Deux Sèvres,"
+          ],
+          "description": [
+            "Concerns suffrage rights given to men of color and free Blacks in all parish assemblies in all of the French West Indian colonies, specifically Saint-Domingue."
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Loi relative aux colonies, & aux moyens d'y appaiser les troubles : Donnée à Paris, le 4 avril 1792. "
+          ],
+          "shelfMark": [
+            "Sc Rare+  F 82-68"
+          ],
+          "creatorLiteral": [
+            "France."
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "contributorLiteral": [
+            "France. Assemblée nationale législative (1791-1792)",
+            "France. Sovereign (1774-1792 : Louis XVI)",
+            "Lefranc-Elies, Jean-Baptiste, 1764-",
+            "Roland de La Platière, Jean-Marie, 1734-1793"
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+  F 82-68"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013541"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415962"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213503"
+            }
+          ],
+          "updatedAt": 1643270734646,
+          "publicationStatement": [
+            "A Niort : Chez Jean-Baptiste Lefranc-Elies, imprimeur de Dép. des Deux Sèvres, 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013541",
+            "urn:undefined:NNSZ01415962",
+            "urn:undefined:(WaOLN)nyp0213503"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Black people -- Civil rights -- Haiti -- Early works to 1800.",
+            "France -- Administration -- Early works to 1800.",
+            "France -- Politics and government -- 1789-1799 -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources.",
+            "Haiti -- Politics and government -- 1791-1804 -- Early works to 1800.",
+            "Racially mixed people -- Civil rights -- Haiti -- Early works to 1800.",
+            "Suffrage -- Haiti -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Loi relative aux colonies, & aux moyens d'y appaiser les troubles : Donnée à Paris, le 4 avril 1792. "
+          ],
+          "uri": "b10013541",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Niort :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Loi relative aux colonies, et aux moyens d'y appaiser les troubles"
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10013541"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901193",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-68"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-68",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927162"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-68"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927162"
+                    ],
+                    "idBarcode": [
+                      "33433036927162"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Loi+relative+aux+colonies,+and+aux+moyens+d'y+appaiser+les+troubles+:+Donnée+à+Paris,+le+4+avril+1792.+&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-68&Author=France.&ItemPlace=A+Niort+:&ItemPublisher=Chez+Jean-Baptiste+Lefranc-Elies,+imprimeur+de+Dép.+des+Deux+Sèvres,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013541&ReferenceNumber=b100135419&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927162&ItemISxN=i119011931&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000068"
+                  },
+                  "sort": [
+                    "aSc Rare+ F 82-000068"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013541-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Loi+relative+aux+colonies,+and+aux+moyens+d'y+appaiser+les+troubles+:+Donnée+à+Paris,+le+4+avril+1792.+&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-68&Author=France.&ItemPlace=A+Niort+:&ItemPublisher=Chez+Jean-Baptiste+Lefranc-Elies,+imprimeur+de+Dép.+des+Deux+Sèvres,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013541&ReferenceNumber=b100135419&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927162&ItemISxN=i119011931&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013541-e"
+                  },
+                  "sort": [
+                    "bi10013541-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013542",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3, [1] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signed at end: Fait à Laon, le 6 Floréal, seconde année républicaine. Signé Lefevre, Président; Lelarge, Regnault, Partis, Caignart, Tranchant, Duchateau, Clouard, administrateurs. Contresigné M. J. J. P. Leleu, Secrétaire-Général du Département.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Pour copie conforme à l'Exemplaire qui nous a été adressé, certifié par l'Administration du Département de l'Aisne.\"--p. [3].",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Imprint from colophon.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At side of title: No. 3443.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Last page blank.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: [A]²",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800",
+            "France -- Politics and government",
+            "France -- Politics and government -- Early works to 1800",
+            "Slavery",
+            "Slavery -- France",
+            "Slavery -- France -- Colonies",
+            "Slavery -- France -- Colonies -- Early works to 1800",
+            "Slaves",
+            "Slaves -- Colonies",
+            "Slaves -- Colonies -- France",
+            "Slaves -- Colonies -- France -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "De l'Imprimerie de Veuve Melleville & fils, imprimeurs du Dép. de l'Aisne,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1795"
+          ],
+          "createdYear": [
+            1794
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Decret de la Convention nationale, du 16.e jour de pluviôse, an 2.e de la République françoise, une & indivisible, qui abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "shelfMark": [
+            "Sc Rare+ F 82-67"
+          ],
+          "creatorLiteral": [
+            "France. Convention nationale."
+          ],
+          "createdString": [
+            "1794"
+          ],
+          "contributorLiteral": [
+            "Veuve Melleville & fils, printer."
+          ],
+          "dateStartYear": [
+            1794
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ F 82-67"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013542"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415963"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213504"
+            }
+          ],
+          "dateEndYear": [
+            1795
+          ],
+          "updatedAt": 1637598155096,
+          "publicationStatement": [
+            "A Laon : De l'Imprimerie de Veuve Melleville & fils, imprimeurs du Dép. de l'Aisne, An 3 de la Républ. [1794 or 1795]"
+          ],
+          "identifier": [
+            "urn:bnum:10013542",
+            "urn:undefined:NNSZ01415963",
+            "urn:undefined:(WaOLN)nyp0213504"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1794"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "France -- Administration -- Early works to 1800.",
+            "France -- Politics and government -- Early works to 1800.",
+            "Slavery -- France -- Colonies -- Early works to 1800.",
+            "Slaves -- Colonies -- France -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Decret de la Convention nationale, du 16.e jour de pluviôse, an 2.e de la République françoise, une & indivisible, qui abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "uri": "b10013542",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Laon :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10013542"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901194",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927170"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-67"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927170"
+                    ],
+                    "idBarcode": [
+                      "33433036927170"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Decret+de+la+Convention+nationale,+du+16.e+jour+de+pluviôse,+an+2.e+de+la+République+françoise,+une+and+indivisible,+qui+abolit+l'esclavage+des+Nègres+dans+les+colonies.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-67&Author=France.&ItemPlace=A+Laon+:&ItemPublisher=De+l'Imprimerie+de+Veuve+Melleville+and+fils,+imprimeurs+du+Dép.+de+l'Aisne,&Date=An+3+de+la+Républ.+[1794+or+1795]&ItemInfo3=https://catalog.nypl.org/record=b10013542&ReferenceNumber=b100135420&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927170&ItemISxN=i119011943&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000067"
+                  },
+                  "sort": [
+                    "aSc Rare+ F 82-000067"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013542-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Decret+de+la+Convention+nationale,+du+16.e+jour+de+pluviôse,+an+2.e+de+la+République+françoise,+une+and+indivisible,+qui+abolit+l'esclavage+des+Nègres+dans+les+colonies.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-67&Author=France.&ItemPlace=A+Laon+:&ItemPublisher=De+l'Imprimerie+de+Veuve+Melleville+and+fils,+imprimeurs+du+Dép.+de+l'Aisne,&Date=An+3+de+la+Républ.+[1794+or+1795]&ItemInfo3=https://catalog.nypl.org/record=b10013542&ReferenceNumber=b100135420&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927170&ItemISxN=i119011943&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013542-e"
+                  },
+                  "sort": [
+                    "bi10013542-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013544",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[23], 334 p., 81 leaves ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Suma del privilegio\" refers to the book under title: De instauranda aethiopum salute. Running title: Tract[atus] de inst[auranda] ethiop[um] sal[ute]",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- Social life and customs",
+            "Black people",
+            "Black people -- Missions",
+            "Black people -- South America",
+            "Catholic Church",
+            "Catholic Church -- Missions",
+            "Jesuits",
+            "Jesuits -- Missions",
+            "Slave-trade",
+            "Slave-trade -- Africa"
+          ],
+          "publisherLiteral": [
+            "Por Francisco de Lira, impresor,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1627
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Naturaleza, policia sagrada i profana, costumbres i ritos, disciplina i catechismo evangelico de todos etiopes"
+          ],
+          "shelfMark": [
+            "Sc Rare F 82-70"
+          ],
+          "creatorLiteral": [
+            "Sandoval, Alonso de, 1576-1652."
+          ],
+          "createdString": [
+            "1627"
+          ],
+          "dateStartYear": [
+            1627
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 82-70"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013544"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415965"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213506"
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "En Sevilla : Por Francisco de Lira, impresor, 1627."
+          ],
+          "identifier": [
+            "urn:bnum:10013544",
+            "urn:undefined:NNSZ01415965",
+            "urn:undefined:(WaOLN)nyp0213506"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1627"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- Social life and customs.",
+            "Black people -- Missions.",
+            "Black people -- South America.",
+            "Catholic Church -- Missions.",
+            "Jesuits -- Missions.",
+            "Slave-trade -- Africa."
+          ],
+          "titleDisplay": [
+            "Naturaleza, policia sagrada i profana, costumbres i ritos, disciplina i catechismo evangelico de todos etiopes / por el p. Alonso, de Sandoval ..."
+          ],
+          "uri": "b10013544",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "En Sevilla :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "De instauranda aethiopum salute.",
+            "Tractatus de instauranda ethiopum salute."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10013544"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901195",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 82-70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 82-70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 82-70"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927188"
+                    ],
+                    "idBarcode": [
+                      "33433036927188"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Naturaleza,+policia+sagrada+i+profana,+costumbres+i+ritos,+disciplina+i+catechismo+evangelico+de+todos+etiopes+/&Site=SCHRB&CallNumber=Sc+Rare+F+82-70&Author=Sandoval,+Alonso+de,&ItemPlace=En+Sevilla+:&ItemPublisher=Por+Francisco+de+Lira,+impresor,&Date=1627.&ItemInfo3=https://catalog.nypl.org/record=b10013544&ReferenceNumber=b100135444&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927188&ItemISxN=i119011955&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 82-000070"
+                  },
+                  "sort": [
+                    "aSc Rare F 82-000070"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013544-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Naturaleza,+policia+sagrada+i+profana,+costumbres+i+ritos,+disciplina+i+catechismo+evangelico+de+todos+etiopes+/&Site=SCHRB&CallNumber=Sc+Rare+F+82-70&Author=Sandoval,+Alonso+de,&ItemPlace=En+Sevilla+:&ItemPublisher=Por+Francisco+de+Lira,+impresor,&Date=1627.&ItemInfo3=https://catalog.nypl.org/record=b10013544&ReferenceNumber=b100135444&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927188&ItemISxN=i119011955&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013544-e"
+                  },
+                  "sort": [
+                    "bi10013544-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013584",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "6 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Seventeen \"books\" in six vols.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "America",
+            "America -- Discovery and exploration",
+            "Colonization",
+            "Colonization -- History",
+            "Commerce",
+            "Commerce -- History",
+            "East Indies"
+          ],
+          "publisherLiteral": [
+            "[s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1770
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Histoire philosophique et politique des établissemens & du commerce des Européens dans les deux Indes."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-2"
+          ],
+          "creatorLiteral": [
+            "Raynal, abbé (Guillaume-Thomas-François), 1713-1796."
+          ],
+          "createdString": [
+            "1770"
+          ],
+          "dateStartYear": [
+            1770
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013584"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01416007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213546"
+            }
+          ],
+          "updatedAt": 1636102690344,
+          "publicationStatement": [
+            "A Amsterdam : [s.n.], 1770."
+          ],
+          "identifier": [
+            "urn:bnum:10013584",
+            "urn:undefined:NNSZ01416007",
+            "urn:undefined:(WaOLN)nyp0213546"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1770"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "America -- Discovery and exploration.",
+            "Colonization -- History.",
+            "Commerce -- History.",
+            "East Indies."
+          ],
+          "titleDisplay": [
+            "Histoire philosophique et politique des établissemens & du commerce des Européens dans les deux Indes."
+          ],
+          "uri": "b10013584",
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "A Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013584"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927279"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927279"
+                    ],
+                    "idBarcode": [
+                      "33433036927279"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000001"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-2 v. 000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32196083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137235"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137235"
+                    ],
+                    "idBarcode": [
+                      "33433076137235"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000002"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-2 v. 000002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32196084",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137243"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137243"
+                    ],
+                    "idBarcode": [
+                      "33433076137243"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000006"
+                  },
+                  "sort": [
+                    "aSc Rare C 86-2 v. 000006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013584-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013584-e"
+                  },
+                  "sort": [
+                    "bi10013584-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013594",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Slavery",
+            "Slavery -- West Indies, British",
+            "Sugar trade",
+            "Sugar trade -- West Indies, British"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "An Address to Her Royal Highness the Dutchess of York, against the use of sugar."
+          ],
+          "shelfMark": [
+            "Sc Rare+ G 86-31"
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "contributorLiteral": [
+            "Frederica Charlotte Ulrica Catherina, Duchess of York, 1767-1820."
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ G 86-31"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01416017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213556"
+            }
+          ],
+          "updatedAt": 1636073709891,
+          "publicationStatement": [
+            "[London? : s.n.], 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013594",
+            "urn:undefined:NNSZ01416017",
+            "urn:undefined:(WaOLN)nyp0213556"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Slavery -- West Indies, British.",
+            "Sugar trade -- West Indies, British."
+          ],
+          "titleDisplay": [
+            "An Address to Her Royal Highness the Dutchess of York, against the use of sugar."
+          ],
+          "uri": "b10013594",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[London? :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10013594"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901476",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ G 86-31"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ G 86-31",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927360"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ G 86-31"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927360"
+                    ],
+                    "idBarcode": [
+                      "33433036927360"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=An+Address+to+Her+Royal+Highness+the+Dutchess+of+York,+against+the+use+of+sugar.&Site=SCHRB&CallNumber=Sc+Rare%2b+G+86-31&ItemPlace=[London?+:&ItemPublisher=s.n.],&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013594&ReferenceNumber=b100135948&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927360&ItemISxN=i119014762&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ G 86-000031"
+                  },
+                  "sort": [
+                    "aSc Rare+ G 86-000031"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10013594-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=An+Address+to+Her+Royal+Highness+the+Dutchess+of+York,+against+the+use+of+sugar.&Site=SCHRB&CallNumber=Sc+Rare%2b+G+86-31&ItemPlace=[London?+:&ItemPublisher=s.n.],&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013594&ReferenceNumber=b100135948&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927360&ItemISxN=i119014762&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013594-e"
+                  },
+                  "sort": [
+                    "bi10013594-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013625",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Magazine for Filipinos.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Vol. 8, no. 1 (Oct. 1978)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Filipino Americans",
+            "Filipino Americans -- Periodicals",
+            "Philippines",
+            "Philippines -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Ningas Corp.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ningas."
+          ],
+          "shelfMark": [
+            "JFM 85-295"
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idIssn": [
+            "0164-6966"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFM 85-295"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013625"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0164-6966"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213587"
+            }
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1636118902540,
+          "publicationStatement": [
+            "New York : Ningas Corp., 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10013625",
+            "urn:issn:0164-6966",
+            "urn:undefined:(WaOLN)nyp0213587"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Filipino Americans -- Periodicals.",
+            "Philippines -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Ningas."
+          ],
+          "uri": "b10013625",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10013625"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006769",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFM 85-295 v. 8  oct 1978- ma y1979"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFM 85-295 v. 8  oct 1978- ma y1979",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005091180"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFM 85-295"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8  oct 1978- ma y1979"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005091180"
+                    ],
+                    "idBarcode": [
+                      "33433005091180"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFM 85-295 v. 000008 oct 1978- ma y1979"
+                  },
+                  "sort": [
+                    "aJFM 85-295 v. 000008 oct 1978- ma y1979"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013626",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., plans ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Edited by M. Bontempelli and P.M. Bardi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "3 (luglio [1933])-"
+          ],
+          "subjectLiteral_exploded": [
+            "Architecture",
+            "Architecture -- Italy",
+            "Architecture -- Italy -- Periodicals",
+            "Fascism and architecture",
+            "Fascism and architecture -- Italy",
+            "Fascism and architecture -- Italy -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "[s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            1933
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadrante [microform]."
+          ],
+          "shelfMark": [
+            "*ZAN-M114"
+          ],
+          "createdString": [
+            "1933"
+          ],
+          "contributorLiteral": [
+            "Bardi, P. M. (Pietro Maria), 1900-",
+            "Bontempelli, Massimo, 1878-1960."
+          ],
+          "dateStartYear": [
+            1933
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-M114"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013626"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213588"
+            }
+          ],
+          "uniformTitle": [
+            "Quadrante (Milan, Italy)"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1644368856194,
+          "publicationStatement": [
+            "Milano : [s.n.], 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10013626",
+            "urn:undefined:(WaOLN)nyp0213588"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1933"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Architecture -- Italy -- Periodicals.",
+            "Fascism and architecture -- Italy -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Quadrante [microform]."
+          ],
+          "uri": "b10013626",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Milano :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10013626"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30719650",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-M114 July 1933-July/Aug. 1935, inc."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-M114 July 1933-July/Aug. 1935, inc.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110459025"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-M114"
+                    ],
+                    "enumerationChronology": [
+                      "July 1933-July/Aug. 1935, inc."
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110459025"
+                    ],
+                    "idBarcode": [
+                      "33433110459025"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-M114 July 1933-July/Aug. 1935, inc."
+                  },
+                  "sort": [
+                    "a*ZAN-M114 July 1933-July/Aug. 1935, inc."
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013628",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13 v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: Vol. 1, no. 22 (July 21, 1977).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 4, no. 24 repeated in numbering.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "-v. 13, no. 27 (May 22, 1989)."
+          ],
+          "subjectLiteral_exploded": [
+            "Savings and loan associations",
+            "Savings and loan associations -- United States",
+            "Savings and loan associations -- United States -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "National Thrift News,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "createdYear": [
+            198
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "National thrift news [microform]."
+          ],
+          "shelfMark": [
+            "*ZAN-T5363"
+          ],
+          "createdString": [
+            "198"
+          ],
+          "idLccn": [
+            "79005118 /sn"
+          ],
+          "idIssn": [
+            "0193-287X"
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-T5363"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013628"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0193-287X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79005118 /sn"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213589"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1643724139051,
+          "publicationStatement": [
+            "New York : National Thrift News, -1989."
+          ],
+          "identifier": [
+            "urn:bnum:10013628",
+            "urn:issn:0193-287X",
+            "urn:lccn:79005118 /sn",
+            "urn:undefined:(WaOLN)nyp0213589"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Savings and loan associations -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "National thrift news [microform]."
+          ],
+          "uri": "b10013628",
+          "numItems": [
+            17
+          ],
+          "numAvailable": [
+            17
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "National thrift news"
+          ],
+          "dimensions": [
+            "43 cm."
+          ]
+        },
+        "sort": [
+          "b10013628"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 17,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646732",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588691"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "Oct. 3 (1988) - May 22 (1989) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588691"
+                    ],
+                    "idBarcode": [
+                      "33433093588691"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646689",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588923"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588923"
+                    ],
+                    "idBarcode": [
+                      "33433093588923"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646662",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 1-3, July 21 (1977) - June 21 (1979)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 1-3, July 21 (1977) - June 21 (1979)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588949"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3, July 21 (1977) - June 21 (1979)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588949"
+                    ],
+                    "idBarcode": [
+                      "33433093588949"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000001-3, July 21 (1977) - June 21 (1979)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000001-3, July 21 (1977) - June 21 (1979)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646682",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 3-4, July 5 (1979) - Sep. 22 (1980)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 3-4, July 5 (1979) - Sep. 22 (1980)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588931"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3-4, July 5 (1979) - Sep. 22 (1980)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588931"
+                    ],
+                    "idBarcode": [
+                      "33433093588931"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000003-4, July 5 (1979) - Sep. 22 (1980)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000003-4, July 5 (1979) - Sep. 22 (1980)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646643",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588824"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588824"
+                    ],
+                    "idBarcode": [
+                      "33433093588824"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000005-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000005-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646653",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 6, Feb. 1 - Sep. 20 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 6, Feb. 1 - Sep. 20 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588956"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6, Feb. 1 - Sep. 20 (1982)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588956"
+                    ],
+                    "idBarcode": [
+                      "33433093588956"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000006, Feb. 1 - Sep. 20 (1982)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000006, Feb. 1 - Sep. 20 (1982)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646705",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588915"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588915"
+                    ],
+                    "idBarcode": [
+                      "33433093588915"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000008, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000008, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646735",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588683"
+                    ],
+                    "idBarcode": [
+                      "33433093588683"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000008-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000008-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 9-10, Mar. 4 - Dec. 9 (1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 9-10, Mar. 4 - Dec. 9 (1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588675"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-10, Mar. 4 - Dec. 9 (1985)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588675"
+                    ],
+                    "idBarcode": [
+                      "33433093588675"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000009-10, Mar. 4 - Dec. 9 (1985)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000009-10, Mar. 4 - Dec. 9 (1985)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646742",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588667"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588667"
+                    ],
+                    "idBarcode": [
+                      "33433093588667"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000010, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000010, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747443",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614072"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614072"
+                    ],
+                    "idBarcode": [
+                      "33433062614072"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000011-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000011-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646717",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588717"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588717"
+                    ],
+                    "idBarcode": [
+                      "33433093588717"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000011-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000011-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747444",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614080"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614080"
+                    ],
+                    "idBarcode": [
+                      "33433062614080"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000012 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000012 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646727",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588709"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588709"
+                    ],
+                    "idBarcode": [
+                      "33433093588709"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000012 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000012 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747445",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13 (Oct. 3, 1988-May 22, 1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13 (Oct. 3, 1988-May 22, 1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614098"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13 (Oct. 3, 1988-May 22, 1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614098"
+                    ],
+                    "idBarcode": [
+                      "33433062614098"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013 (Oct. 3, 1988-May 22, 1989)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000013 (Oct. 3, 1988-May 22, 1989)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588832"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588832"
+                    ],
+                    "idBarcode": [
+                      "33433093588832"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000013, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747442",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13, no. 1-27 (Oct. 1988-May 22, 1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13, no. 1-27 (Oct. 1988-May 22, 1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614056"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13, no. 1-27 (Oct. 1988-May 22, 1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614056"
+                    ],
+                    "idBarcode": [
+                      "33433062614056"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013, no. 1-27 (Oct. 1988-May 22, 1989)"
+                  },
+                  "sort": [
+                    "a*ZAN-T5363 v. 000013, no. 1-27 (Oct. 1988-May 22, 1989)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013630",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Music",
+            "Music -- Periodicals",
+            "Music, Latvian",
+            "Music, Latvian -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Latvijas muziku biedrība,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            19
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Latvijas muzikis [microform]."
+          ],
+          "shelfMark": [
+            "*ZAN-*Q1241"
+          ],
+          "createdString": [
+            "19"
+          ],
+          "contributorLiteral": [
+            "Latvijas muziku biedrība."
+          ],
+          "dateStartYear": [
+            19
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-*Q1241"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013630"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213591"
+            }
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1636111916525,
+          "publicationStatement": [
+            "Riga : Latvijas muziku biedrība,"
+          ],
+          "identifier": [
+            "urn:bnum:10013630",
+            "urn:undefined:(WaOLN)nyp0213591"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music -- Periodicals.",
+            "Music, Latvian -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Latvijas muzikis [microform]."
+          ],
+          "uri": "b10013630",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10013630"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30780148",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-*Q1241 1929-May 1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-*Q1241 1929-May 1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110389370"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-*Q1241"
+                    ],
+                    "enumerationChronology": [
+                      "1929-May 1934"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110389370"
+                    ],
+                    "idBarcode": [
+                      "33433110389370"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZAN-*Q1241 1929-May 001934"
+                  },
+                  "sort": [
+                    "a*ZAN-*Q1241 1929-May 001934"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013632",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1-"
+          ],
+          "subjectLiteral_exploded": [
+            "American poetry",
+            "American poetry -- Women authors",
+            "American poetry -- Women authors -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Brainchild Collective,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brainchild."
+          ],
+          "shelfMark": [
+            "JFK 81-88"
+          ],
+          "createdString": [
+            "999"
+          ],
+          "contributorLiteral": [
+            "Brainchild Collective (Springfield, Ill.)"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 81-88"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013632"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213593"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "[Springfield, Ill. : Brainchild Collective, 197?-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10013632",
+            "urn:undefined:(WaOLN)nyp0213593"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "American poetry -- Women authors -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Brainchild."
+          ],
+          "uri": "b10013632",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Springfield, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10013632"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006770",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 81-88 v. 2-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 81-88 v. 2-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005347897"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFK 81-88"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005347897"
+                    ],
+                    "idBarcode": [
+                      "33433005347897"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJFK 81-88 v. 000002-4"
+                  },
+                  "sort": [
+                    "aJFK 81-88 v. 000002-4"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013633",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1981-"
+          ],
+          "subjectLiteral_exploded": [
+            "International agencies",
+            "International agencies -- Directories",
+            "Statesmen",
+            "Statesmen -- Directories"
+          ],
+          "publisherLiteral": [
+            "Lambert Publications,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "198"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lambert's worldwide government directory with inter-governmental organizations."
+          ],
+          "shelfMark": [
+            "JLM 81-504"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-504"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013633"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-EPA"
+            }
+          ],
+          "dateEndYear": [
+            198
+          ],
+          "updatedAt": 1636111698966,
+          "publicationStatement": [
+            "Washington : Lambert Publications, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10013633",
+            "urn:undefined:(WaOLN)nyp0213594",
+            "urn:undefined:RCON-EPA"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "International agencies -- Directories.",
+            "Statesmen -- Directories."
+          ],
+          "titleDisplay": [
+            "Lambert's worldwide government directory with inter-governmental organizations."
+          ],
+          "uri": "b10013633",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Worldwide government directory with inter-governmental organizations"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10013633"
+        ],
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540643",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "enumerationChronology": [
+                      "1981"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909591"
+                    ],
+                    "idBarcode": [
+                      "33433019909591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001981"
+                  },
+                  "sort": [
+                    "aJLM 81-504 001981"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540644",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1982",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909609"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "enumerationChronology": [
+                      "1982"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909609"
+                    ],
+                    "idBarcode": [
+                      "33433019909609"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001982"
+                  },
+                  "sort": [
+                    "aJLM 81-504 001982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540645",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "enumerationChronology": [
+                      "1984"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909617"
+                    ],
+                    "idBarcode": [
+                      "33433019909617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001984"
+                  },
+                  "sort": [
+                    "aJLM 81-504 001984"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-fd3a57ed07785c153a1c725f238ab56f.json
+++ b/test/fixtures/query-fd3a57ed07785c153a1c725f238ab56f.json
@@ -1,0 +1,905 @@
+{
+  "took": 21,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015295,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015295,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/scsb-by-barcode-341c9faa67093fb0225d3123a0e4df34.json
+++ b/test/fixtures/scsb-by-barcode-341c9faa67093fb0225d3123a0e4df34.json
@@ -1,0 +1,232 @@
+[
+  {
+    "itemBarcode": "33433116929518",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433116929526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539161",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059840763",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107825220",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107825220",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107825220",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673077",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673168",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673168",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673309",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011242603",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673531",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011099029",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058659826",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433098135548",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105672749",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433098135548",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001892276",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005146166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005146166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005146166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001997497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417965",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002896748",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013217298",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058659842",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058568993",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001746852",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069579674",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013136530",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013135847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013135854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013144385",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011955378",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002023293",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101143836",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013144377",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011168394",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011168402",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019817224",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296681",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673085",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107964664",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110498031",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107663993",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-37495bda1aef0fd44ec2a62edb4ce16c.json
+++ b/test/fixtures/scsb-by-barcode-37495bda1aef0fd44ec2a62edb4ce16c.json
@@ -1,0 +1,757 @@
+[
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013119130",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068848849",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999656",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999664",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013000082",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068817299",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013001767",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013001759",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013002005",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128214",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128164",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128149",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128156",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058620984",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126648",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128081",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126325",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013271295",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001543184",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575934",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575942",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575959",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575975",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575967",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575983",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575991",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576007",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576015",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576023",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576031",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576049",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576411",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576429",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576437",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576445",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576452",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576494",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576486",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576460",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576478",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576528",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576502",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576510",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433111366286",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575900",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575918",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015942182",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013574946",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074631197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085541104",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085539777",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117980106",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117979967",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121642221",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842191",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842209",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842217",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842225",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842233",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842241",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842258",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842266",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842274",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842282",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069710790",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069710808",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546589",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546597",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546605",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546613",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546621",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546639",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546647",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842290",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545185",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545193",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545201",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544733",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544741",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544758",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545128",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545136",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545144",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545151",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545169",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545177",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576221",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118744",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118751",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118769",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122498",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122274",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122282",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122290",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812019",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812027",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812035",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013124239",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013117753",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126176",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126093",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126085",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013123785",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013123777",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126036",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013119056",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071260776",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071260552",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061320531",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997635",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997627",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997643",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068805302",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997601",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996918",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998187",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998195",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998203",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998286",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997973",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997981",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997999",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998641",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618822",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618830",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618764",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618772",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618798",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618749",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618806",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618731",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618814",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999102",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999292",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999284",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999318",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999300",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060421959",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060421967",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998591",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013120682",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013120096",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-4f5053c8abbf2f90220a80c7fda5e176.json
+++ b/test/fixtures/scsb-by-barcode-4f5053c8abbf2f90220a80c7fda5e176.json
@@ -1,0 +1,387 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050409147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061318089",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084847221",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001898497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089337251",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030771",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030789",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030797",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030805",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030813",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030821",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030839",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030870",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058617816",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001997497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539872",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539880",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539856",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173038",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539666",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944960",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221381",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221399",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221407",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013501782",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937121",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197435",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197443",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197476",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058069919",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433046113944",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003418559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673499",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105674059",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030859007",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219797",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219805",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036649329",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433021813997",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017863220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058825831",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036604563",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030890481",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017895651",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003630815",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433021791029",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031242492",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031242500",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076233265",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036872368",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061038323",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036649683",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036807315",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059035760",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058831748",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003841073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433097665214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433037693748",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069567",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069534",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069542",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050352214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-537f4c5f9301802420e7152e8eaa0f96.json
+++ b/test/fixtures/scsb-by-barcode-537f4c5f9301802420e7152e8eaa0f96.json
@@ -1,0 +1,672 @@
+[
+  {
+    "itemBarcode": "33433078272113",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272121",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272139",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272147",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272154",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272162",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272170",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272188",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272196",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272204",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272212",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272220",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272253",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272261",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272279",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272287",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272295",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272303",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272311",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101083917",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078272329",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433102440389",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433102440397",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084525736",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433088832484",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101072555",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101084204",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101062549",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433112607373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069825366",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433086720046",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433083531677",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076528763",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076529019",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072299997",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083159",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083175",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083225",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083209",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083217",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083191",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083142",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074083183",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105255586",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433115147914",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433116522354",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857576",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857584",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857592",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857600",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857618",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857626",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857634",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060930082",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101055220",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433112611961",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117979173",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117119341",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121729853",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857535",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857543",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857550",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019857568",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846041",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846058",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846066",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846074",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846082",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846090",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846108",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846116",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846124",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846132",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846140",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846157",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846165",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846173",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846181",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846199",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846207",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846215",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019846223",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105255578",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071526143",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071526218",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071526226",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071526234",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071526242",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099608188",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099608063",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099607917",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099608055",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099608048",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124984265",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124930839",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938352",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938360",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938378",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938386",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938394",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938402",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938410",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938428",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938436",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938444",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938451",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124930854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938469",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938477",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938485",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938568",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938550",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938543",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938535",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938493",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938501",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938519",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938527",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124930862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938592",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938584",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433124938576",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121700144",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121696201",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433122611381",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433122611373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121711620",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121962835",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128509571",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433132313184",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128589565",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433132312749",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-6ff8ef004ccd0cd426da66b60db4e420.json
+++ b/test/fixtures/scsb-by-barcode-6ff8ef004ccd0cd426da66b60db4e420.json
@@ -1,0 +1,547 @@
+[
+  {
+    "itemBarcode": "33433011099029",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001746852",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069579674",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013136530",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013135847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013135854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002023293",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433101143836",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011168394",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011168402",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296681",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433075470579",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036926669",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117263263",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076159494",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036926776",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019684897",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076137185",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107660718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001898570",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433038876987",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001945694",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036926867",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058299276",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058298906",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433094813171",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433107973277",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005304187",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017529995",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017529912",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676801",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676819",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676827",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676835",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676843",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676850",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676868",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676876",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010676884",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089858876",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019908379",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057787578",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100251",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100269",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100277",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100285",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100293",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057100301",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102141",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102158",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102174",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102182",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102190",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102208",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102216",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102224",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057102232",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480094",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480102",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480110",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480128",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480136",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480144",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480151",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480169",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062480177",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031851219",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031851227",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089464600",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433092672512",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433063254944",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005151620",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110386137",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090700216",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927121",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927154",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927162",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927170",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927188",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927279",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076137235",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076137243",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036927360",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005091180",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110459025",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588691",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588923",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588949",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588931",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588824",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588956",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588915",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588683",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588675",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588667",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062614072",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588717",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062614080",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588709",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062614098",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093588832",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433062614056",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110389370",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005347897",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019909591",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019909609",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433019909617",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-83d062bda10204a0c2d252f92e91daf2.json
+++ b/test/fixtures/scsb-by-barcode-83d062bda10204a0c2d252f92e91daf2.json
@@ -1,0 +1,897 @@
+[
+  {
+    "itemBarcode": "33433061318089",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084847221",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433089337251",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030771",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030789",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030797",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030805",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030813",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030821",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030839",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030870",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058617816",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944960",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221381",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221399",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221407",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013501782",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937121",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197435",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197443",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197476",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003418559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673499",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105674059",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030859007",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219797",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219805",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017863220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030890481",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017895651",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076233265",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036872368",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061038323",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059035760",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003841073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433097665214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069567",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069534",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069542",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160620",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160638",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160646",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160653",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160661",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160679",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090390752",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061303693",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061354662",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005566207",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005566215",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005566223",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005566231",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005566249",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433034815294",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013119130",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005577105",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036872814",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057875217",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057875050",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057875068",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057875258",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433021653690",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433033482716",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079237792",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079237784",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079237776",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079237768",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433037693862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059486500",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059486757",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433037693870",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059486450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059486724",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061304857",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061304865",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585319",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585327",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585335",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585343",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585350",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585368",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059585376",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105667400",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093160137",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093160145",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093160152",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433070348341",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017526942",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017526959",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433091335046",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433091335053",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433091335061",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032068110",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085274375",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064479813",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064479805",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064479821",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654198",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654073",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654560",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654446",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022582096",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654313",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654099",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654461",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654222",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654594",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654354",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654115",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654487",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654248",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654123",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654339",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654586",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654347",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654107",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654479",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654230",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654602",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654362",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654321",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654206",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654081",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654578",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433018654453",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022619146",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022621456",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022621332",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064452513",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064452521",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064470549",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064470556",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064470564",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064471521",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064471539",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433075624639",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433075624647",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073125134",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073125142",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060824939",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060824947",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060824954",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073091153",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073091161",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073091179",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073091187",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433073091195",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064468618",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064468626",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064468634",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433064468642",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433104416361",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433104416379",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433104416387",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108987532",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108987540",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108987557",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108987565",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108987573",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022619021",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433106577558",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433106577871",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-e7dfdf96a2be9ba3159a5ec0c3a54d7b.json
+++ b/test/fixtures/scsb-by-barcode-e7dfdf96a2be9ba3159a5ec0c3a54d7b.json
@@ -1,0 +1,412 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001898497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030771",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030789",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030797",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030805",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030813",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030821",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030839",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030870",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058617816",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001997497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539872",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539880",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539856",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173038",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539666",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944960",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221381",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221399",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221407",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013501782",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937121",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197435",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197443",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197476",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058069919",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433046113944",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003418559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673499",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105674059",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030859007",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219797",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219805",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036649329",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433021813997",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017863220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058825831",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036604563",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030890481",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017895651",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003630815",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433021791029",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031242492",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433031242500",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076233265",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036872368",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061038323",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036649683",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036807315",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059035760",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058831748",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003841073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433097665214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433037693748",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069567",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069534",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069542",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050352214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160620",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160638",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160646",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160653",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160661",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160679",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090390752",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032723599",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -526,12 +526,16 @@ describe('Test Resources responses', function () {
           assert.equal(200, response.statusCode)
 
           const results = JSON.parse(body)
+          // const fs = require('fs')
+          // fs.writeFileSync(`./${num}-body.json`, JSON.stringify(results, null, 2))
           expect(results.totalResults).to.be.at.least(1)
           expect(results.itemListElement).to.be.a('array')
           expect(results.itemListElement[0]).to.be.a('object')
           expect(results.itemListElement[0].result).to.be.a('object')
           expect(results.itemListElement[0].result['@type']).to.include('nypl:Item')
-          expect(results.itemListElement[0].result['@id']).to.equal('res:b22144813')
+          // expect(results.itemListElement[0].result['@id']).to.equal('res:b22144813')
+          console.log('results: ', results.itemListElement.map((item) => item.result['@id']))
+          expect(results.itemListElement.map((item) => item.result['@id'])).to.include('res:b22144813')
 
           done()
         })

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -526,15 +526,11 @@ describe('Test Resources responses', function () {
           assert.equal(200, response.statusCode)
 
           const results = JSON.parse(body)
-          // const fs = require('fs')
-          // fs.writeFileSync(`./${num}-body.json`, JSON.stringify(results, null, 2))
           expect(results.totalResults).to.be.at.least(1)
           expect(results.itemListElement).to.be.a('array')
           expect(results.itemListElement[0]).to.be.a('object')
           expect(results.itemListElement[0].result).to.be.a('object')
           expect(results.itemListElement[0].result['@type']).to.include('nypl:Item')
-          // expect(results.itemListElement[0].result['@id']).to.equal('res:b22144813')
-          console.log('results: ', results.itemListElement.map((item) => item.result['@id']))
           expect(results.itemListElement.map((item) => item.result['@id'])).to.include('res:b22144813')
 
           done()
@@ -543,7 +539,7 @@ describe('Test Resources responses', function () {
     })
 
     ; [
-      'b22193421',
+      'b22144813',
       '"Q-TAG (852 8b q tag.  Staff call in bib.)"', // Should match `identifierV2[@type=bf:ShelfMark].value`
       '"ISSN -- 022"', // Should match `identifierV2[@type=bf:Issn].value`
       '"LCCN -- 010"', // Should match `identifierV2[@type=bf:Lccn].value`
@@ -567,7 +563,7 @@ describe('Test Resources responses', function () {
           expect(results.itemListElement[0]).to.be.a('object')
           expect(results.itemListElement[0].result).to.be.a('object')
           expect(results.itemListElement[0].result['@type']).to.include('nypl:Item')
-          expect(results.itemListElement.some((el) => el.result['@id'] === 'res:b12082323'))
+          expect(results.itemListElement.map((el) => el.result['@id'])).to.include('res:b22144813')
 
           done()
         })

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -220,7 +220,8 @@ describe('Resources query', function () {
             should: [
               { term: { idIsbn: '0689844921' } },
               { term: { idIsbn_clean: '0689844921' } }
-            ]
+            ],
+            minimum_should_match: 1
           }
         }
       })


### PR DESCRIPTION
- Add `idIsbn_clean` to standard number search scopes
- Add `minimum_should_match: 1` to isbn search
- Fix tests