### PR TITLE
Add extra should clause for standard number search

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -750,6 +750,16 @@ const buildElasticQueryForKeywords = function (params) {
     }
   })
 
+  if (params.search_scope === 'standard_number') {
+    should.push({
+      'query_string': {
+        'fields': fieldMap._root,
+        'query': `"${escapeQuery(params.q)}"`,
+        'default_operator': 'AND'
+      }
+    })
+  }
+
   // Add nested queries (if any) to things that *should* match:
   Object.keys(fieldMap)
     .filter((nestedName) => nestedName !== '_root')

--- a/test/fixtures/query-051dba442f346e10c5385430073e7786.json
+++ b/test/fixtures/query-051dba442f346e10c5385430073e7786.json
@@ -1,0 +1,215 @@
+{
+  "took": 263,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 117.01943,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12423567",
+        "_score": 117.01943,
+        "_source": {
+          "extent": [
+            "202 p."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Campanella, Tommaso, 1568-1639"
+          ],
+          "publisherLiteral": [
+            "S. Neaulme,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1741
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vita Th. Campanellae."
+          ],
+          "shelfMark": [
+            "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+          ],
+          "creatorLiteral": [
+            "Cyprian, Ernst Salomon, 1673-1745."
+          ],
+          "createdString": [
+            "1741"
+          ],
+          "dateStartYear": [
+            1741
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12423567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2408048"
+            }
+          ],
+          "updatedAt": 1636321232714,
+          "publicationStatement": [
+            "Trajecti ad Rhenum, S. Neaulme, 1741."
+          ],
+          "identifier": [
+            "urn:bnum:12423567",
+            "urn:undefined:(WaOLN)nyp2408048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1741"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Campanella, Tommaso, 1568-1639."
+          ],
+          "titleDisplay": [
+            "Vita Th. Campanellae. Autore Ern. Sal. Cypriano. Accedunt hac secunda editione appendices IV. doctorum virorum de Campanellae vita, philosophia & libris schediasmata complectentes."
+          ],
+          "uri": "b12423567",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Trajecti ad Rhenum,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16020288",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104031624"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104031624"
+                    ],
+                    "idBarcode": [
+                      "33433104031624"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aAN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                  },
+                  "sort": [
+                    "aAN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-1c7304b835bf44d8c47957dd9b6d799d.json
+++ b/test/fixtures/query-1c7304b835bf44d8c47957dd9b6d799d.json
@@ -1,0 +1,905 @@
+{
+  "took": 41,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.383479,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.383479,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-2abf3152ca659f5af6f7defba7a71e9f.json
+++ b/test/fixtures/query-2abf3152ca659f5af6f7defba7a71e9f.json
@@ -1,0 +1,13306 @@
+{
+  "took": 211,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5,
+    "max_score": 52.30332,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11826883",
+        "_score": 52.30332,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Applied science & technology index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "R]pertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art and archaeology technical abstracts",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Artbibliographies modern",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Vols. 1 (1965)-10 (1974). 1 v.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Vol. 1 (1965)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Furniture",
+            "Furniture -- England",
+            "Furniture -- England -- History",
+            "Furniture -- England -- History -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "The Society,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "shelfMark": [
+            "JQL 08-18"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "66053650 //r89"
+          ],
+          "idIssn": [
+            "0016-3058"
+          ],
+          "contributorLiteral": [
+            "Furniture History Society (London, England)"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-18"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11826883"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0016-3058"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "66053650 //r89"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0280126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1832956"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1965)-44(2008)-",
+                "v. 3636 (2000) - v. 45 (2000); v. 44 (2008); v. 45 (2009); v. 46 (2010); v. 47 (2011); v. 48 (2012); v. 49 (2013); v. 50 (2014); v. 55 (2019)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 30 (1994)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 31 (1995)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 32 (1996)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (1997)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 34 (1998)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 35 (1999)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26-35 (1990 - 1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 37 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 38 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 39 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 40 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 41 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 42 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 43 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 44 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 45 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 46 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 47 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 48 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36-45 (2000 - 2009)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 49 (2013)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 50 (2014)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 51 (2015)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 52 (2016)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 53 (2017)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 54 (2018)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 55 (2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 56 (2020)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 57 (2021)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 58 (2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-18"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-18"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1066822",
+              "shelfMark": [
+                "JQL 08-18"
+              ]
+            }
+          ],
+          "updatedAt": 1649888604293,
+          "publicationStatement": [
+            "[London] : The Society,"
+          ],
+          "identifier": [
+            "urn:bnum:11826883",
+            "urn:issn:0016-3058",
+            "urn:lccn:66053650 //r89",
+            "urn:undefined:0280126",
+            "urn:undefined:(WaOLN)nyp1832956"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Furniture -- England -- History -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "uri": "b11826883",
+          "lccClassification": [
+            "NK2528 .F8"
+          ],
+          "numItems": [
+            37
+          ],
+          "numAvailable": [
+            37
+          ],
+          "placeOfPublication": [
+            "[London] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Furnit. hist.",
+            "Furniture history"
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 37,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 1-4 (1965-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 1-4 (1965-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272113"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1965-1968)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272113"
+                    ],
+                    "idBarcode": [
+                      "33433078272113"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000001-4 (1965-1968)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000001-4 (1965-1968)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 5-6 (1969-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 5-6 (1969-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-6 (1969-1970)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272121"
+                    ],
+                    "idBarcode": [
+                      "33433078272121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000005-6 (1969-1970)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000005-6 (1969-1970)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753886",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 7 (1971)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 7 (1971)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272139"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7 (1971)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272139"
+                    ],
+                    "idBarcode": [
+                      "33433078272139"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000007 (1971)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000007 (1971)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 8-9 (1972-1973)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 8-9 (1972-1973)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9 (1972-1973)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272147"
+                    ],
+                    "idBarcode": [
+                      "33433078272147"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000008-9 (1972-1973)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000008-9 (1972-1973)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 10 (1974) + Index v. 1-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272154"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272154"
+                    ],
+                    "idBarcode": [
+                      "33433078272154"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000010 (1974) + Index v. 1-10"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000010 (1974) + Index v. 1-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 11-12 (1975-1976)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 11-12 (1975-1976)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272162"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12 (1975-1976)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272162"
+                    ],
+                    "idBarcode": [
+                      "33433078272162"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000011-12 (1975-1976)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000011-12 (1975-1976)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 13 (1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 13 (1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272170"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13 (1977)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272170"
+                    ],
+                    "idBarcode": [
+                      "33433078272170"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000013 (1977)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000013 (1977)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 14-15 (1978-1979)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 14-15 (1978-1979)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14-15 (1978-1979)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272188"
+                    ],
+                    "idBarcode": [
+                      "33433078272188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000014-15 (1978-1979)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000014-15 (1978-1979)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 16-17 (1980-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 16-17 (1980-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272196"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-17 (1980-1981)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272196"
+                    ],
+                    "idBarcode": [
+                      "33433078272196"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000016-17 (1980-1981)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000016-17 (1980-1981)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 18 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 18 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 18 (1982)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272204"
+                    ],
+                    "idBarcode": [
+                      "33433078272204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000018 (1982)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000018 (1982)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 19-20 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 19-20 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272212"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-20 (1983-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272212"
+                    ],
+                    "idBarcode": [
+                      "33433078272212"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000019-20 (1983-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000019-20 (1983-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 21-22 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 21-22 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 21-22 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272220"
+                    ],
+                    "idBarcode": [
+                      "33433078272220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000021-22 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000021-22 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 23-24 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 23-24 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-24 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272238"
+                    ],
+                    "idBarcode": [
+                      "33433078272238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000023-24 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000023-24 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272246"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272246"
+                    ],
+                    "idBarcode": [
+                      "33433078272246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000025-26 (1989-90) + Index v. 16-25 (1980-90)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000025-26 (1989-90) + Index v. 16-25 (1980-90)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 27 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 27 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272253"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27 (1991)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272253"
+                    ],
+                    "idBarcode": [
+                      "33433078272253"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000027 (1991)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000027 (1991)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 28 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 28 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272261"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 28 (1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272261"
+                    ],
+                    "idBarcode": [
+                      "33433078272261"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000028 (1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000028 (1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 29 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 29 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272279"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 29 (1993)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272279"
+                    ],
+                    "idBarcode": [
+                      "33433078272279"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000029 (1993)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000029 (1993)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 30 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 30 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272287"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30 (1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272287"
+                    ],
+                    "idBarcode": [
+                      "33433078272287"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000030 (1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000030 (1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 31 (1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 31 (1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272295"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 31 (1995)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272295"
+                    ],
+                    "idBarcode": [
+                      "33433078272295"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000031 (1995)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000031 (1995)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 32-34 (1996-1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 32-34 (1996-1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272303"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 32-34 (1996-1998)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272303"
+                    ],
+                    "idBarcode": [
+                      "33433078272303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000032-34 (1996-1998)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000032-34 (1996-1998)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 35-37 (1999-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 35-37 (1999-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272311"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-37 (1999-2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272311"
+                    ],
+                    "idBarcode": [
+                      "33433078272311"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000035-37 (1999-2001)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000035-37 (1999-2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 36-45 (2000-2009) + index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 36-45 (2000-2009) + index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101083917"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 36-45 (2000-2009) + index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101083917"
+                    ],
+                    "idBarcode": [
+                      "33433101083917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000036-45 (2000-2009) + index"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000036-45 (2000-2009) + index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 38-39 (2002-2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 38-39 (2002-2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38-39 (2002-2003)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272329"
+                    ],
+                    "idBarcode": [
+                      "33433078272329"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000038-39 (2002-2003)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000038-39 (2002-2003)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627525",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 40-41 (2004-2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 40-41 (2004-2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440389"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40-41 (2004-2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440389"
+                    ],
+                    "idBarcode": [
+                      "33433102440389"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000040-41 (2004-2005)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000040-41 (2004-2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 42-43 (2006-2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 42-43 (2006-2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440397"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 42-43 (2006-2007)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440397"
+                    ],
+                    "idBarcode": [
+                      "33433102440397"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000042-43 (2006-2007)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000042-43 (2006-2007)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627803",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 44-45 (2008-2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 44-45 (2008-2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084525736"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 44-45 (2008-2009)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084525736"
+                    ],
+                    "idBarcode": [
+                      "33433084525736"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000044-45 (2008-2009)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000044-45 (2008-2009)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26216680",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 46 (2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 46 (2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088832484"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46 (2010)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088832484"
+                    ],
+                    "idBarcode": [
+                      "33433088832484"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000046 (2010)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000046 (2010)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878768",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 47 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 47 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101072555"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 47 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101072555"
+                    ],
+                    "idBarcode": [
+                      "33433101072555"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000047 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000047 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011841",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 48 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 48 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101084204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101084204"
+                    ],
+                    "idBarcode": [
+                      "33433101084204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000048 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000048 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31146937",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 49 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 49 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101062549"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101062549"
+                    ],
+                    "idBarcode": [
+                      "33433101062549"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000049 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000049 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32204255",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 50 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 50 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112607373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112607373"
+                    ],
+                    "idBarcode": [
+                      "33433112607373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000050 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000050 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33587281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 51 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 51 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069825366"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069825366"
+                    ],
+                    "idBarcode": [
+                      "33433069825366"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000051 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000051 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36041027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 53 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 53 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433086720046"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433086720046"
+                    ],
+                    "idBarcode": [
+                      "33433086720046"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000053 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000053 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 54 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 54 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433083531677"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433083531677"
+                    ],
+                    "idBarcode": [
+                      "33433083531677"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000054 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000054 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 55 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 55 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076528763"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076528763"
+                    ],
+                    "idBarcode": [
+                      "33433076528763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000055 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000055 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 56 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 56 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076529019"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076529019"
+                    ],
+                    "idBarcode": [
+                      "33433076529019"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000056 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000056 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39175596",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 57 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 57 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072299997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2021)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072299997"
+                    ],
+                    "idBarcode": [
+                      "33433072299997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000057 (2021)"
+                  },
+                  "sort": [
+                    "aJQL 08-18 v. 000057 (2021)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b16775643",
+        "_score": 15.62849,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from cover.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "No. 16 (fall 1982)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Research",
+            "Art -- Research -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "University of Illinois Press,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Visual arts research."
+          ],
+          "shelfMark": [
+            "JQL 08-3"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83644328 "
+          ],
+          "idIssn": [
+            "0736-0770"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16775643"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0736-0770"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83644328 "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)9069635"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S240000007"
+            },
+            {
+              "type": "bf:Issn",
+              "identifierStatus": "incorrect",
+              "value": "0160-3221"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "9(1983)-27(2001)-"
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-3"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-3"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab82",
+                  "label": "Schwarzman Building M1 - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1090282",
+              "shelfMark": [
+                "JQL 08-3"
+              ]
+            }
+          ],
+          "updatedAt": 1636752116421,
+          "publicationStatement": [
+            "[Champaign, Ill.] : University of Illinois Press, c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:16775643",
+            "urn:issn:0736-0770",
+            "urn:lccn:83644328 ",
+            "urn:undefined:(OCoLC)9069635",
+            "urn:undefined:(WaOLN)S240000007",
+            "b16775643#1.0001",
+            "urn:issn:0160-3221"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Research -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Visual arts research."
+          ],
+          "uri": "b16775643",
+          "lccClassification": [
+            "N81 .R49"
+          ],
+          "numItems": [
+            10
+          ],
+          "numAvailable": [
+            10
+          ],
+          "placeOfPublication": [
+            "[Champaign, Ill.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Vis. arts res.",
+            "Visual arts research"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 10,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 11-12 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 11-12 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083159"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "11-12 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083159"
+                    ],
+                    "idBarcode": [
+                      "33433074083159"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 11-12 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 11-12 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 13-14 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 13-14 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083175"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "13-14 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083175"
+                    ],
+                    "idBarcode": [
+                      "33433074083175"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 13-14 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 13-14 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 17-18 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 17-18 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083225"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "17-18 (1991-1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083225"
+                    ],
+                    "idBarcode": [
+                      "33433074083225"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 17-18 (1991-1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 17-18 (1991-1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 19-20 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 19-20 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083209"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "19-20 (1993-1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083209"
+                    ],
+                    "idBarcode": [
+                      "33433074083209"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 19-20 (1993-1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 19-20 (1993-1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 21-23 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 21-23 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083217"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "21-23 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083217"
+                    ],
+                    "idBarcode": [
+                      "33433074083217"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 21-23 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 21-23 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662015",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 24-25 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 24-25 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "24-25 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083191"
+                    ],
+                    "idBarcode": [
+                      "33433074083191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 24-25 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 24-25 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 26-27 (2000-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 26-27 (2000-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083142"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "26-27 (2000-2001)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083142"
+                    ],
+                    "idBarcode": [
+                      "33433074083142"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 26-27 (2000-2001)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 26-27 (2000-2001)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 9-10 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 9-10 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083183"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "9-10 (1983-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083183"
+                    ],
+                    "idBarcode": [
+                      "33433074083183"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 9-10 (1983-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 9-10 (1983-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627807",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 15-16 (1989-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 15-16 (1989-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255586"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15-16 (1989-90)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255586"
+                    ],
+                    "idBarcode": [
+                      "33433105255586"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000015-16 (1989-90)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 v. 000015-16 (1989-90)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29405160",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433115147914"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433115147914"
+                    ],
+                    "idBarcode": [
+                      "33433115147914"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000038, no. 1, Issue 74 (Sum. 2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-3 v. 000038, no. 1, Issue 74 (Sum. 2012)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b21506221",
+        "_score": 15.549061,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A magazine of art, design and architecture.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on: Issue 01 (2007/08); title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: Issue 01 (2007/08)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Issue 01 (2007-08)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Faculty of Art, Design and Architecture, Kingston University,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kiosk."
+          ],
+          "shelfMark": [
+            "JQL 18-4"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "idIssn": [
+            "1755-9626"
+          ],
+          "contributorLiteral": [
+            "Kingston University (London, England). Faculty of Art, Design and Architecture."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 18-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21506221"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "1755-9626"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)190792176"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636807100803,
+          "publicationStatement": [
+            "London : Faculty of Art, Design and Architecture, Kingston University, 2007-"
+          ],
+          "identifier": [
+            "urn:bnum:21506221",
+            "urn:issn:1755-9626",
+            "urn:undefined:(OCoLC)190792176"
+          ],
+          "genreForm": [
+            "Periodicals."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Periodicals.",
+            "Art."
+          ],
+          "titleDisplay": [
+            "Kiosk."
+          ],
+          "uri": "b21506221",
+          "lccClassification": [
+            "N1 .K56"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i35913145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab82",
+                        "label": "Schwarzman Building M1 - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab82||Schwarzman Building M1 - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 18-4 issue 1 (2007/08)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 18-4 issue 1 (2007/08)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116522354"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 18-4"
+                    ],
+                    "enumerationChronology": [
+                      "issue 1 (2007/08)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116522354"
+                    ],
+                    "idBarcode": [
+                      "33433116522354"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 18-4 issue 1 (2007/08)"
+                  },
+                  "sort": [
+                    "aJQL 18-4 issue 1 (2007/08)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12525718",
+        "_score": 12.840677,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published: Fratelli Palombi Editori, 1954-1984; L'Erma di Bretschneider, 1985- .",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Anno 25 (1978)-27 (1980) combined.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Anno 1, n. 1-2 (1954)-anno 32 (1985) ; nuova serie, 1 (1987)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Rome (Italy)",
+            "Rome (Italy) -- Galleries and museums"
+          ],
+          "publisherLiteral": [
+            "Gli Amici,"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1954
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "shelfMark": [
+            "JQL 08-17"
+          ],
+          "createdString": [
+            "1954"
+          ],
+          "idLccn": [
+            "64036787 //r882"
+          ],
+          "idIssn": [
+            "0523-9346"
+          ],
+          "contributorLiteral": [
+            "Amici dei musei di Roma (Italy)"
+          ],
+          "dateStartYear": [
+            1954
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12525718"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0523-9346"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "64036787 //r882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S010000043"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1954)-6(1959),8(1961)-32(1985) [N.S] 1(1987)-18(2004),25(2011)28(2014),32(2018)-",
+                "v. 25 (2011) - v. 28 (2014); v. 32 (2020)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 7 (1993)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 8 (1994)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 9 (1995)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 10 (1996)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 11 (1997)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 12 (1998)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 13 (1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 14 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 15 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 16 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 17 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 18 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 19 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 20 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 21 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 22 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 23 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 24 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 25 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 27 (2013)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 28 (2014)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 29 (2015)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 30 (2018)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 31 (2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 32 (2018)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (2021)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 34 (2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-17"
+                }
+              ],
+              "notes": [
+                "Order transferred from GRD to ART per CCK/ART 7/29/04 ?EP"
+              ],
+              "physicalLocation": [
+                "JQL 08-17"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1069076",
+              "shelfMark": [
+                "JQL 08-17"
+              ]
+            }
+          ],
+          "updatedAt": 1644388628630,
+          "publicationStatement": [
+            "[Roma] : Gli Amici, [1954]-"
+          ],
+          "identifier": [
+            "urn:bnum:12525718",
+            "urn:issn:0523-9346",
+            "urn:lccn:64036787 //r882",
+            "urn:undefined:(WaOLN)S010000043"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1954"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rome (Italy) -- Galleries and museums."
+          ],
+          "titleDisplay": [
+            "Bollettino dei Musei comunali di Roma / a cura degli Amici dei musei di Roma."
+          ],
+          "uri": "b12525718",
+          "lccClassification": [
+            "AM55.R6 B6"
+          ],
+          "numItems": [
+            17
+          ],
+          "numAvailable": [
+            17
+          ],
+          "placeOfPublication": [
+            "[Roma] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Boll. Mus. comunali Roma",
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 17,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757466",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 1-2 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857576"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857576"
+                    ],
+                    "idBarcode": [
+                      "33433019857576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000001-2 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000001-2 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 3-4 (1989-1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857584"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857584"
+                    ],
+                    "idBarcode": [
+                      "33433019857584"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000003-4 (1989-1990)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000003-4 (1989-1990)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757468",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 5-6 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857592"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857592"
+                    ],
+                    "idBarcode": [
+                      "33433019857592"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000005-6 (1991-1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000005-6 (1991-1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 7-8 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857600"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857600"
+                    ],
+                    "idBarcode": [
+                      "33433019857600"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000007-8 (1993-1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000007-8 (1993-1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757470",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 9-11 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857618"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857618"
+                    ],
+                    "idBarcode": [
+                      "33433019857618"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000009-11 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000009-11 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757471",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 12-13 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857626"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857626"
+                    ],
+                    "idBarcode": [
+                      "33433019857626"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000012-13 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000012-13 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 14-16 (2000-2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857634"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857634"
+                    ],
+                    "idBarcode": [
+                      "33433019857634"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000014-16 (2000-2002)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000014-16 (2000-2002)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14288461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 17-18 (2003-2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060930082"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060930082"
+                    ],
+                    "idBarcode": [
+                      "33433060930082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000017-18 (2003-2004)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000017-18 (2003-2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30890910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 25  (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 25  (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101055220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 25  (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101055220"
+                    ],
+                    "idBarcode": [
+                      "33433101055220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000025 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000025 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32391069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 26 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 26 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112611961"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 26 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112611961"
+                    ],
+                    "idBarcode": [
+                      "33433112611961"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000026 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000026 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33682199",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 27 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 27 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117979173"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 27 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117979173"
+                    ],
+                    "idBarcode": [
+                      "33433117979173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000027 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000027 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33860628",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 28 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 28 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117119341"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 28 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117119341"
+                    ],
+                    "idBarcode": [
+                      "33433117119341"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000028 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000028 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37359040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 32 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 32 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121729853"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 32 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121729853"
+                    ],
+                    "idBarcode": [
+                      "33433121729853"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000032 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 N.S. v. 000032 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757462",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 1-6 (1954-1959)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 1-6 (1954-1959)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857535"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-6 (1954-1959)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857535"
+                    ],
+                    "idBarcode": [
+                      "33433019857535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000001-6 (1954-1959)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000001-6 (1954-1959)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757463",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 8-15 (1961-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 8-15 (1961-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857543"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-15 (1961-1968)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857543"
+                    ],
+                    "idBarcode": [
+                      "33433019857543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000008-15 (1961-1968)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000008-15 (1961-1968)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757464",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 16-24 (1969-1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 16-24 (1969-1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857550"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-24 (1969-1977)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857550"
+                    ],
+                    "idBarcode": [
+                      "33433019857550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000016-24 (1969-1977)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000016-24 (1969-1977)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757465",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 25-32 (1978-1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 25-32 (1978-1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-32 (1978-1985)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857568"
+                    ],
+                    "idBarcode": [
+                      "33433019857568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000025-32 (1978-1985)"
+                  },
+                  "sort": [
+                    "aJQL 08-17 v. 000025-32 (1978-1985)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11560439",
+        "_score": 12.762962,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals. Second edition. Revised and enlarged. Supplement",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Summaries in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1. jaarg., nr. 1/2 (1953)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Amsterdam",
+            "Art -- Amsterdam -- Periodicals",
+            "Art -- Periodicals",
+            "Rijksmuseum (Netherlands)",
+            "Rijksmuseum (Netherlands) -- Periodicals"
+          ],
+          "publisherLiteral": [
+            "Rijks-Museum,"
+          ],
+          "language": [
+            {
+              "id": "lang:dut",
+              "label": "Dutch"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1953
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            " "
+          ],
+          "title": [
+            "Bulletin."
+          ],
+          "shelfMark": [
+            "JQL 08-19"
+          ],
+          "createdString": [
+            "1953"
+          ],
+          "idLccn": [
+            "sn 86000271"
+          ],
+          "idIssn": [
+            "0165-9510"
+          ],
+          "dateStartYear": [
+            1953
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-19"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11560439"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0165-9510"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sn 86000271"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4272788"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1568914"
+            }
+          ],
+          "idOclc": [
+            "4272788"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1953)-65(2017), 66:2(2018)-67:3(2019),68:1(2020)-68:2(2020)-",
+                "v. 66, no. 1 (2018); v. 66, no. 4 (2018) - v. 67, no. 3 (2019); v. 68, no. 1 (2020) - no. 3 (2020); v. 69, no. 3 (2021)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 66 No. 1 (2018)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 2 (2018)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 3 (2018)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 4 (2018)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 1 (2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 2 (2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 3 (2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 4 (2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 68 No. 1 (2020)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 2 (2020)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 3 (2020)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 4 (2020)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 1 (2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 2 (2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 3 (2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 4 (2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 70 No. 1 (2022)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-19"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-19"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:rcmb2",
+                  "label": "Offsite"
+                }
+              ],
+              "uri": "h1059577",
+              "shelfMark": [
+                "JQL 08-19"
+              ]
+            }
+          ],
+          "updatedAt": 1647266949911,
+          "publicationStatement": [
+            "Amsterdam : Rijks-Museum, 1953-"
+          ],
+          "identifier": [
+            "urn:bnum:11560439",
+            "urn:issn:0165-9510",
+            "urn:lccn:sn 86000271",
+            "urn:oclc:4272788",
+            "urn:undefined:(WaOLN)nyp1568914"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1953"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Amsterdam -- Periodicals.",
+            "Art -- Periodicals.",
+            "Rijksmuseum (Netherlands) -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Bulletin."
+          ],
+          "uri": "b11560439",
+          "lccClassification": [
+            "N2460 .A3"
+          ],
+          "numItems": [
+            69
+          ],
+          "numAvailable": [
+            67
+          ],
+          "parallelTitleDisplay": [
+            " "
+          ],
+          "placeOfPublication": [
+            "Amsterdam :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Bull. Rÿksmus.",
+            "Bulletin Mauritshuis",
+            "Bulletin van het Rijksmuseum"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 69,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 1-4 (1953-1956)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 1-4 (1953-1956)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846041"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1953-1956)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846041"
+                    ],
+                    "idBarcode": [
+                      "33433019846041"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000001-4 (1953-1956)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000001-4 (1953-1956)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 5-8 (1957-1960)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 5-8 (1957-1960)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846058"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-8 (1957-1960)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846058"
+                    ],
+                    "idBarcode": [
+                      "33433019846058"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000005-8 (1957-1960)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000005-8 (1957-1960)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693366",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 9-12 (1961-1964)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 9-12 (1961-1964)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846066"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-12 (1961-1964)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846066"
+                    ],
+                    "idBarcode": [
+                      "33433019846066"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000009-12 (1961-1964)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000009-12 (1961-1964)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693367",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 13-15 (1965-1967)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 13-15 (1965-1967)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846074"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13-15 (1965-1967)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846074"
+                    ],
+                    "idBarcode": [
+                      "33433019846074"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000013-15 (1965-1967)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000013-15 (1965-1967)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693368",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 16-18 (1968-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 16-18 (1968-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846082"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-18 (1968-1970)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846082"
+                    ],
+                    "idBarcode": [
+                      "33433019846082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000016-18 (1968-1970)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000016-18 (1968-1970)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693369",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 19-22 (1971-1974)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 19-22 (1971-1974)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846090"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-22 (1971-1974)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846090"
+                    ],
+                    "idBarcode": [
+                      "33433019846090"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000019-22 (1971-1974)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000019-22 (1971-1974)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693370",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 23-26 (1975-1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 23-26 (1975-1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846108"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-26 (1975-1978)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846108"
+                    ],
+                    "idBarcode": [
+                      "33433019846108"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000023-26 (1975-1978)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000023-26 (1975-1978)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693371",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 27-29 (1979-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 27-29 (1979-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846116"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 27-29 (1979-1981)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846116"
+                    ],
+                    "idBarcode": [
+                      "33433019846116"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000027-29 (1979-1981)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000027-29 (1979-1981)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693372",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 30-32 (1982-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 30-32 (1982-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846124"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 30-32 (1982-1984)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846124"
+                    ],
+                    "idBarcode": [
+                      "33433019846124"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000030-32 (1982-1984)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000030-32 (1982-1984)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693373",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 33-34 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 33-34 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846132"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 33-34 (1985-1986)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846132"
+                    ],
+                    "idBarcode": [
+                      "33433019846132"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000033-34 (1985-1986)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000033-34 (1985-1986)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693374",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 35-36 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 35-36 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846140"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-36 (1987-1988)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846140"
+                    ],
+                    "idBarcode": [
+                      "33433019846140"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000035-36 (1987-1988)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000035-36 (1987-1988)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693375",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 37 (1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 37 (1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846157"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 37 (1989)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846157"
+                    ],
+                    "idBarcode": [
+                      "33433019846157"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000037 (1989)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000037 (1989)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693376",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 38 (1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 38 (1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846165"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 38 (1990)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846165"
+                    ],
+                    "idBarcode": [
+                      "33433019846165"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000038 (1990)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000038 (1990)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693377",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 39 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 39 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846173"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 39 (1991)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846173"
+                    ],
+                    "idBarcode": [
+                      "33433019846173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000039 (1991)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000039 (1991)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693378",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 40 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 40 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846181"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 40 (1992)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846181"
+                    ],
+                    "idBarcode": [
+                      "33433019846181"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000040 (1992)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000040 (1992)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693379",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 41 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 41 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846199"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 41 (1993)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846199"
+                    ],
+                    "idBarcode": [
+                      "33433019846199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000041 (1993)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000041 (1993)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693380",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 42 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 42 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846207"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 42 (1994)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846207"
+                    ],
+                    "idBarcode": [
+                      "33433019846207"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000042 (1994)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000042 (1994)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693381",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 43-45 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 43-45 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846215"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 43-45 (1995-1997)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846215"
+                    ],
+                    "idBarcode": [
+                      "33433019846215"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000043-45 (1995-1997)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000043-45 (1995-1997)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693382",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 46-47 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 46-47 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846223"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 46-47 (1998-1999)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846223"
+                    ],
+                    "idBarcode": [
+                      "33433019846223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000046-47 (1998-1999)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000046-47 (1998-1999)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 48 (2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 48 (2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255578"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2000)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255578"
+                    ],
+                    "idBarcode": [
+                      "33433105255578"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000048 (2000)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000048 (2000)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 49 (2001) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 49 (2001) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526143"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2001) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526143"
+                    ],
+                    "idBarcode": [
+                      "33433071526143"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000049 (2001) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000049 (2001) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508058",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 50 (2002) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 50 (2002) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526218"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2002) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526218"
+                    ],
+                    "idBarcode": [
+                      "33433071526218"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000050 (2002) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000050 (2002) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508059",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 51 (2003) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 51 (2003) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526226"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2003) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526226"
+                    ],
+                    "idBarcode": [
+                      "33433071526226"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000051 (2003) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000051 (2003) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508060",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 52 (2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 52 (2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526234"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 52 (2004)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526234"
+                    ],
+                    "idBarcode": [
+                      "33433071526234"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000052 (2004)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000052 (2004)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508061",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 53 (2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 53 (2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526242"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2005)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526242"
+                    ],
+                    "idBarcode": [
+                      "33433071526242"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000053 (2005)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000053 (2005)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756731",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 54 (2006) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 54 (2006) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2006) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608188"
+                    ],
+                    "idBarcode": [
+                      "33433099608188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000054 (2006) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000054 (2006) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756751",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 55 (2007) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 55 (2007) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608063"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2007) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608063"
+                    ],
+                    "idBarcode": [
+                      "33433099608063"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000055 (2007) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000055 (2007) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757051",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 56 (2008) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 56 (2008) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099607917"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2008) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099607917"
+                    ],
+                    "idBarcode": [
+                      "33433099607917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000056 (2008) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000056 (2008) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757661",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 57 (2009) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 57 (2009) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608055"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2009) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608055"
+                    ],
+                    "idBarcode": [
+                      "33433099608055"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000057 (2009) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000057 (2009) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757665",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 58 (2010) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 58 (2010) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608048"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 58 (2010) & Index"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608048"
+                    ],
+                    "idBarcode": [
+                      "33433099608048"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000058 (2010) & Index"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000058 (2010) & Index"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36975113",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:29",
+                        "label": "bundled materials (vols.)"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:29||bundled materials (vols.)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124984265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124984265"
+                    ],
+                    "idBarcode": [
+                      "33433124984265"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587267",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 1 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 1 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930839"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 1 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930839"
+                    ],
+                    "idBarcode": [
+                      "33433124930839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 1 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 1 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 2 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 2 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938352"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 2 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938352"
+                    ],
+                    "idBarcode": [
+                      "33433124938352"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 2 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 2 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809085",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 3 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 3 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938360"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 3 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938360"
+                    ],
+                    "idBarcode": [
+                      "33433124938360"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 3 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 3 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 4 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 4 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938378"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 4 (2011)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938378"
+                    ],
+                    "idBarcode": [
+                      "33433124938378"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 4 (2011)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000059, no. 4 (2011)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 1 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 1 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938386"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 1 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938386"
+                    ],
+                    "idBarcode": [
+                      "33433124938386"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 1 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 1 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809089",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 2 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 2 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938394"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 2 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938394"
+                    ],
+                    "idBarcode": [
+                      "33433124938394"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 2 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 2 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809091",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 3 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 3 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938402"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 3 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938402"
+                    ],
+                    "idBarcode": [
+                      "33433124938402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 3 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 3 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809092",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 4 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 4 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938410"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 4 (2012)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938410"
+                    ],
+                    "idBarcode": [
+                      "33433124938410"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 4 (2012)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000060, no. 4 (2012)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809095",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 1 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 1 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938428"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 1 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938428"
+                    ],
+                    "idBarcode": [
+                      "33433124938428"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 1 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 1 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 2 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 2 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938436"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 2 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938436"
+                    ],
+                    "idBarcode": [
+                      "33433124938436"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 2 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 2 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 3 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 3 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938444"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 3 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938444"
+                    ],
+                    "idBarcode": [
+                      "33433124938444"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 3 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 3 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 4 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 4 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938451"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 4 (2013)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938451"
+                    ],
+                    "idBarcode": [
+                      "33433124938451"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 4 (2013)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000061, no. 4 (2013)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587273",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 1 (2014) "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 1 (2014) ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930854"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 1 (2014) "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930854"
+                    ],
+                    "idBarcode": [
+                      "33433124930854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 1 (2014) "
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 1 (2014) "
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 2 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 2 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938469"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 2 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938469"
+                    ],
+                    "idBarcode": [
+                      "33433124938469"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 2 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 2 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 3 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 3 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938477"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 3 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938477"
+                    ],
+                    "idBarcode": [
+                      "33433124938477"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 3 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 3 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 4 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 4 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938485"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 4 (2014)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938485"
+                    ],
+                    "idBarcode": [
+                      "33433124938485"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 4 (2014)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000062, no. 4 (2014)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 1 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 1 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 1 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938568"
+                    ],
+                    "idBarcode": [
+                      "33433124938568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 1 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 1 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809110",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 2 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 2 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938550"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 2 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938550"
+                    ],
+                    "idBarcode": [
+                      "33433124938550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 2 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 2 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809112",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 3 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 3 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938543"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 3 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938543"
+                    ],
+                    "idBarcode": [
+                      "33433124938543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 3 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 3 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 50
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 4 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 4 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938535"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 4 (2015)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938535"
+                    ],
+                    "idBarcode": [
+                      "33433124938535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 4 (2015)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000063, no. 4 (2015)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809118",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 1 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 1 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938493"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 1 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938493"
+                    ],
+                    "idBarcode": [
+                      "33433124938493"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 1 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 1 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809120",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 2 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 2 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938501"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 2 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938501"
+                    ],
+                    "idBarcode": [
+                      "33433124938501"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 2 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 2 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809121",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 3 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 3 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938519"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 3 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938519"
+                    ],
+                    "idBarcode": [
+                      "33433124938519"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 3 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 3 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809123",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 4 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 4 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938527"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 4 (2016)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938527"
+                    ],
+                    "idBarcode": [
+                      "33433124938527"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 4 (2016)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000064, no. 4 (2016)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587336",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 1 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 1 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930862"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 1 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930862"
+                    ],
+                    "idBarcode": [
+                      "33433124930862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 1 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 1 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809126",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 2 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 2 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938592"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 2 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938592"
+                    ],
+                    "idBarcode": [
+                      "33433124938592"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 2 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 2 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 3 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 3 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938584"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 3 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938584"
+                    ],
+                    "idBarcode": [
+                      "33433124938584"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 3 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 3 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809132",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 4 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 4 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938576"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 4 (2017)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938576"
+                    ],
+                    "idBarcode": [
+                      "33433124938576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 4 (2017)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000065, no. 4 (2017)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36842152",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 1 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 1 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121700144"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 1 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121700144"
+                    ],
+                    "idBarcode": [
+                      "33433121700144"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 1 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066 no. 1 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36785774",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 4 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 4 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121696201"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 4 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121696201"
+                    ],
+                    "idBarcode": [
+                      "33433121696201"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 4 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066 no. 4 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587546",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 2  (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 2  (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611381"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 2  (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611381"
+                    ],
+                    "idBarcode": [
+                      "33433122611381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 2 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066, no. 2 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587547",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 3 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 3 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 3 (2018)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611373"
+                    ],
+                    "idBarcode": [
+                      "33433122611373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 3 (2018)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000066, no. 3 (2018)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37012009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67 no. 1 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67 no. 1 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121711620"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67 no. 1 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121711620"
+                    ],
+                    "idBarcode": [
+                      "33433121711620"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067 no. 1 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067 no. 1 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37379200",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 2 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 2 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121962835"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 2 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121962835"
+                    ],
+                    "idBarcode": [
+                      "33433121962835"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 2 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067, no. 2 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37528681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 3 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 3 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128509571"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 3 (2019)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128509571"
+                    ],
+                    "idBarcode": [
+                      "33433128509571"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 3 (2019)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000067, no. 3 (2019)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094662",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68 no. 3 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68 no. 3 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132313184"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 68 no. 3 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132313184"
+                    ],
+                    "idBarcode": [
+                      "33433132313184"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068 no. 3 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000068 no. 3 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 67
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38109693",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68, no. 2 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68, no. 2 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128589565"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 68, no. 2 (2020)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128589565"
+                    ],
+                    "idBarcode": [
+                      "33433128589565"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068, no. 2 (2020)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000068, no. 2 (2020)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 68
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094674",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 69 no. 3 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 69 no. 3 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132312749"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 no. 3 (2021)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132312749"
+                    ],
+                    "idBarcode": [
+                      "33433132312749"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000069 no. 3 (2021)"
+                  },
+                  "sort": [
+                    "aJQL 08-19 v. 000069 no. 3 (2021)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-3512ffa42f5f5985a632d6f69f11153f.json
+++ b/test/fixtures/query-3512ffa42f5f5985a632d6f69f11153f.json
@@ -1,0 +1,905 @@
+{
+  "took": 27,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015755,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015755,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-3f969a30b6ab7a24cc32d218d4974baf.json
+++ b/test/fixtures/query-3f969a30b6ab7a24cc32d218d4974baf.json
@@ -1,0 +1,222 @@
+{
+  "took": 34,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 31.71587,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "pb1717",
+        "_score": 31.71587,
+        "_source": {
+          "extent": [
+            "x, 340 p. : ill. ;"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Fiction",
+            "Cats"
+          ],
+          "publisherLiteral": [
+            "Lothrop, Lee & Shepard Books,"
+          ],
+          "description": [
+            "More than 40 stories and essays about cats by famous writers."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cat encounters : a cat-lover's anthology /"
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "   79002437 "
+          ],
+          "contributorLiteral": [
+            "Lewis, Gogo.",
+            "Manley, Seon."
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1717"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0688419143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   79002437 "
+            }
+          ],
+          "updatedAt": 1523549727960,
+          "publicationStatement": [
+            "New York : Lothrop, Lee & Shepard Books, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:1717",
+            "urn:isbn:0688419143",
+            "urn:lccn:   79002437 "
+          ],
+          "idIsbn": [
+            "0688419143"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats -- Fiction.",
+            "Cats."
+          ],
+          "titleDisplay": [
+            "Cat encounters : a cat-lover's anthology / selected by Seon Manley & Gogo Lewis."
+          ],
+          "uri": "pb1717",
+          "lccClassification": [
+            "SF445.5 .C378"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32101087644330"
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "pi2775",
+                    "shelfMark": [
+                      "SF445.5 .C378"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "SF445.5 .C378"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101087644330"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101087644330"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available "
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-44997de69bc8289662039c7eab4a2442.json
+++ b/test/fixtures/query-44997de69bc8289662039c7eab4a2442.json
@@ -1,0 +1,905 @@
+{
+  "took": 37,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 28.766958,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 28.766958,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-4a58eaba212914a89f92e83a0b382bc3.json
+++ b/test/fixtures/query-4a58eaba212914a89f92e83a0b382bc3.json
@@ -1,0 +1,211 @@
+{
+  "took": 140,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 107.89515,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12709113",
+        "_score": 107.89515,
+        "_source": {
+          "extent": [
+            "iv, 350 p. : ill., port. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington County (Neb.)",
+            "Washington County (Neb.) -- History"
+          ],
+          "publisherLiteral": [
+            "Magic city printing co.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1937
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A history of Washington county, Nebraska"
+          ],
+          "shelfMark": [
+            "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+          ],
+          "creatorLiteral": [
+            "Shrader, Forrest B."
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "dateStartYear": [
+            1937
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12709113"
+            }
+          ],
+          "updatedAt": 1636332069027,
+          "publicationStatement": [
+            "[Omaha, : Magic city printing co., 1937]"
+          ],
+          "identifier": [
+            "urn:bnum:12709113"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington County (Neb.) -- History."
+          ],
+          "titleDisplay": [
+            "A history of Washington county, Nebraska / by Forrest B. Shrader."
+          ],
+          "uri": "b12709113",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Omaha, :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16202472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099509238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099509238"
+                    ],
+                    "idBarcode": [
+                      "33433099509238"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aIWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                  },
+                  "sort": [
+                    "aIWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-4aedfd7afe673b1e865855164d30d8dc.json
+++ b/test/fixtures/query-4aedfd7afe673b1e865855164d30d8dc.json
@@ -1,0 +1,905 @@
+{
+  "took": 163,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015755,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015755,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-4b83089d242d1928f44902eed1b2e16b.json
+++ b/test/fixtures/query-4b83089d242d1928f44902eed1b2e16b.json
@@ -1,0 +1,905 @@
+{
+  "took": 97,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 28.198421,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 28.198421,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-504fff29e59b3478f3dd7a301e7e696a.json
+++ b/test/fixtures/query-504fff29e59b3478f3dd7a301e7e696a.json
@@ -1,0 +1,905 @@
+{
+  "took": 54,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.756217,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.756217,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-605d22a1e58b3d98d92a792089647496.json
+++ b/test/fixtures/query-605d22a1e58b3d98d92a792089647496.json
@@ -1,0 +1,240 @@
+{
+  "took": 105,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 120.675415,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13627363",
+        "_score": 120.675415,
+        "_source": {
+          "extent": [
+            "128 p. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Creative age press, inc."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1947
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cats, cats, & cats,"
+          ],
+          "shelfMark": [
+            "VPS (Rice, E. Cats, cats, & cats)"
+          ],
+          "creatorLiteral": [
+            "Rice, Edward, 1917-"
+          ],
+          "createdString": [
+            "1947"
+          ],
+          "idLccn": [
+            "agr47000211"
+          ],
+          "contributorLiteral": [
+            "Gleason, Jean, 1917-"
+          ],
+          "dateStartYear": [
+            1947
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VPS (Rice, E. Cats, cats, & cats)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13627363"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "agr47000211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3600714"
+            }
+          ],
+          "updatedAt": 1636428476541,
+          "publicationStatement": [
+            "New York, Creative age press, inc. [c1947]"
+          ],
+          "identifier": [
+            "urn:bnum:13627363",
+            "urn:lccn:agr47000211",
+            "urn:undefined:(WaOLN)nyp3600714"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1947"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats -- Pictorial works.",
+            "Cats."
+          ],
+          "titleDisplay": [
+            "Cats, cats, & cats, by Edward Rice and Jean Gleason."
+          ],
+          "uri": "b13627363",
+          "lccClassification": [
+            "SF447 .R5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10754478",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VPS (Rice, E. Cats, cats, & cats)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006598316"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006598316"
+                    ],
+                    "idBarcode": [
+                      "33433006598316"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aVPS (Rice, E. Cats, cats, & cats)"
+                  },
+                  "sort": [
+                    "aVPS (Rice, E. Cats, cats, & cats)"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-7790a65ecf18f25745b76f8df3c1f2e2.json
+++ b/test/fixtures/query-7790a65ecf18f25745b76f8df3c1f2e2.json
@@ -1,0 +1,905 @@
+{
+  "took": 47,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.241729,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.241729,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-7d4f8a076bd525d377328be71fc5c48d.json
+++ b/test/fixtures/query-7d4f8a076bd525d377328be71fc5c48d.json
@@ -1,0 +1,905 @@
+{
+  "took": 85,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.383479,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.383479,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-8537ef286ebc2e7b8514d750fa978685.json
+++ b/test/fixtures/query-8537ef286ebc2e7b8514d750fa978685.json
@@ -1,0 +1,905 @@
+{
+  "took": 36,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015755,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015755,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-8e2944aa3a7773c0cece2aded78b9299.json
+++ b/test/fixtures/query-8e2944aa3a7773c0cece2aded78b9299.json
@@ -1,0 +1,905 @@
+{
+  "took": 315,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 50.978718,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 50.978718,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c57b18166c37c50230b70ad9c5006142.json
+++ b/test/fixtures/query-c57b18166c37c50230b70ad9c5006142.json
@@ -1,0 +1,276 @@
+{
+  "took": 171,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 92.047386,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13565153",
+        "_score": 92.047386,
+        "_source": {
+          "extent": [
+            "430 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: Ladies companion to the flower garden.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Ladies' companion to the flower-garden (p. [97]-340), has half- title page.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Monthly calendar of work to be done in the flower-garden: p. [425]-430.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Flower gardening",
+            "Gardening"
+          ],
+          "publisherLiteral": [
+            "John Wiley,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1853"
+          ],
+          "createdYear": [
+            1854
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gardening for ladies : and, Companion to the flower-garden"
+          ],
+          "shelfMark": [
+            "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+          ],
+          "creatorLiteral": [
+            "Loudon, Mrs. (Jane), 1807-1858."
+          ],
+          "createdString": [
+            "1854"
+          ],
+          "contributorLiteral": [
+            "Downing, A. J. (Andrew Jackson), 1815-1852."
+          ],
+          "dateStartYear": [
+            1854
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13565153"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3539974"
+            }
+          ],
+          "dateEndYear": [
+            1853
+          ],
+          "updatedAt": 1636445026964,
+          "publicationStatement": [
+            "New York : John Wiley, 1854, c1853."
+          ],
+          "identifier": [
+            "urn:bnum:13565153",
+            "urn:undefined:(WaOLN)nyp3539974"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1854"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Flower gardening.",
+            "Gardening."
+          ],
+          "titleDisplay": [
+            "Gardening for ladies : and, Companion to the flower-garden / by Mrs. Loudon."
+          ],
+          "uri": "b13565153",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Companion to the flower-garden.",
+            "Ladies' companion to the flower garden."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10708577",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006564110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006564110"
+                    ],
+                    "idBarcode": [
+                      "33433006564110"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aVQG (Loudon, J. W. Gardening for ladies. 1854)"
+                  },
+                  "sort": [
+                    "aVQG (Loudon, J. W. Gardening for ladies. 1854)"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13565153-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433006564110",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "shelfMark_sort": "bi13565153-e"
+                  },
+                  "sort": [
+                    "bi13565153-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-cccdac770a369afc97ea4a5db7ef0ac2.json
+++ b/test/fixtures/query-cccdac770a369afc97ea4a5db7ef0ac2.json
@@ -1,0 +1,905 @@
+{
+  "took": 94,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.756217,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.756217,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d71eb9e08c1fe060174aaf6d60a52b7a.json
+++ b/test/fixtures/query-d71eb9e08c1fe060174aaf6d60a52b7a.json
@@ -1,0 +1,905 @@
+{
+  "took": 17,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.015755,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.015755,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-f6a318a458593840a3a291d4d1a52e27.json
+++ b/test/fixtures/query-f6a318a458593840a3a291d4d1a52e27.json
@@ -1,0 +1,905 @@
+{
+  "took": 107,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.756217,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 13.756217,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b],",
+            "CopyCat pub. co. -- 260 bb,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1649949827924,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b, "
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948- ,",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey,",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            3
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.] :",
+            "Long Island CIty, N.Y. :",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  },
+                  "sort": [
+                    "bi22144813-e"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -146,15 +146,24 @@ describe('Resources query', function () {
       expect(query.bool.should[0].query_string).to.be.a('object')
       expect(query.bool.should[0].query_string.fields).to.be.a('array')
       expect(query.bool.should[0].query_string.fields).to.include('shelfMark')
+      expect(query.bool.should[0].query_string.query).to.equal('fladeedle')
+      console.log('should: ', JSON.stringify(query.bool.should, null, 2))
 
-      // Second clause is a nested query_string query on items fields:
+      // Second clause is a query_string query across multiple root level fields, with literal query
       expect(query.bool.should[1]).to.be.a('object')
-      expect(query.bool.should[1].nested).to.be.a('object')
-      expect(query.bool.should[1].nested.path).to.eq('items')
-      expect(query.bool.should[1].nested.query).to.be.a('object')
-      expect(query.bool.should[1].nested.query.query_string).to.be.a('object')
-      expect(query.bool.should[1].nested.query.query_string.fields).to.be.a('array')
-      expect(query.bool.should[1].nested.query.query_string.fields).to.include('items.shelfMark')
+      expect(query.bool.should[1].query_string).to.be.a('object')
+      expect(query.bool.should[1].query_string.fields).to.be.a('array')
+      expect(query.bool.should[1].query_string.fields).to.include('shelfMark')
+      expect(query.bool.should[1].query_string.query).to.equal('"fladeedle"')
+
+      // Third clause is a nested query_string query on items fields:
+      expect(query.bool.should[2]).to.be.a('object')
+      expect(query.bool.should[2].nested).to.be.a('object')
+      expect(query.bool.should[2].nested.path).to.eq('items')
+      expect(query.bool.should[2].nested.query).to.be.a('object')
+      expect(query.bool.should[2].nested.query.query_string).to.be.a('object')
+      expect(query.bool.should[2].nested.query.query_string.fields).to.be.a('array')
+      expect(query.bool.should[2].nested.query.query_string.fields).to.include('items.shelfMark')
     })
   })
 


### PR DESCRIPTION
- Adds an extra `should` clause to capture complex ISBNs in `standard_number` searches.
- Fixes tests