### PR TITLE
Fix order of customer code lookup and EDD determination

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -18,18 +18,24 @@ class AvailabilityResolver {
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
   responseWithUpdatedAvailability (request, options) {
-    return this._createSCSBBarcodeAvailbilityMapping(this.barcodes)
-      .then((barcodesAndAvailability) => {
+    // If this serialization is a result of a hold request initializing, we want
+    // to double check the recap customer code in SCSB
+    const updateRecapCustomerCodes = (options && options.queryRecapCustomerCode)
+      ? () => this._checkScsbForRecapCustomerCode()
+      : () => Promise.resolve()
+
+    // Get 1) barcode-availability mapping and 2) customer code query in
+    // parallel because they don't depend on each other:
+    return Promise.all([
+      this._createSCSBBarcodeAvailbilityMapping(this.barcodes),
+      updateRecapCustomerCodes()
+    ])
+      .then((barcodeMappingAndCustomerCodeResult) => {
+        // We only care about the result of the barcode lookup because
+        // _checkScsbForRecapCustomerCode updates this.elasticSearchResponse:
+        const [ barcodesAndAvailability ] = barcodeMappingAndCustomerCodeResult
         this._fixItemRequestabilityInResponse(barcodesAndAvailability, request, options)
         return this.elasticSearchResponse
-      }).then(() => {
-        // If this serialization is a result of a hold request initializing, we want
-        // to double check the recap customer code in SCSB
-        if (options && options.queryRecapCustomerCode) {
-          return this._checkScsbForRecapCustomerCode().then(() => {
-            return this.elasticSearchResponse
-          })
-        } else return this.elasticSearchResponse
       })
       .catch((error) => {
         logger.error('Error occurred while setting availability - ', error)
@@ -95,6 +101,7 @@ class AvailabilityResolver {
         return Promise.reject(error)
       })
   }
+
   _fixItemRequestabilityInResponse (barcodesAndAvailability, request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {


### PR DESCRIPTION
Fix order of 1) the live query on the SCSB API to look up item customer
codes (performed when bib is retrieved with a specific item id in the
path) and 2) the process to update the `eddRequestable` property based
on the retrieved customer code. Previously, the SCSB API query was being
performed _after_ updating `eddRequestable`. Now, the customer code
lookup is performed in parallel to building the barcode-availability
mapping (another SCSB API call that is independent of the customer code
lookup)

For example [this bib](https://qa-platform.nypl.org/api/v0.1/discovery/resources/b12332513-i30160109) should have `eddRequestable` of `true` because when retrieved on that URL, the customer code lookup should resolve "NA", which is edd-requestable.