### PR TITLE
Hide delivery loc.s when item not requestable

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -4,6 +4,8 @@ const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer
 const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
 const logger = require('./logger')
 const onsiteEddCriteria = require('../data/onsite-edd-criteria.json')
+const { requestableBasedOnHoldingLocation } = require('./requestability_determination')
+const { isItemNyplOwned } = require('./ownership_determination')
 
 class DeliveryLocationsResolver {
   // Currently, there is no physical delivery requests for onsite items through Discovery API
@@ -20,7 +22,6 @@ class DeliveryLocationsResolver {
         deliveryLocation.deliveryLocationTypes = sierraLocations[deliveryLocation.code].deliveryLocationTypes
         return deliveryLocation
       })
-
     // Either holdingLocation is null or code not matched; Fall back on mocked data:
     } else {
       // Mocked based on actual mapping for holdingLocation 'loc:scff2'
@@ -170,7 +171,11 @@ class DeliveryLocationsResolver {
           let sierraLocations = []
           // If recap has a customer code for this barcode, map it by recap cust code:
           if (barcodeToCustomerCode[barcode]) {
-            sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+            // Delivery locations are not valid if [NYPL] item's holding
+            // location is not requestable:
+            if (requestableBasedOnHoldingLocation(item) || !isItemNyplOwned(item)) {
+              sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+            }
             item.eddRequestable = this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])
 
           // Otherwise, it's not in recap

--- a/lib/requestability_determination.js
+++ b/lib/requestability_determination.js
@@ -6,26 +6,36 @@ const logger = require('./logger')
 // As of writing - this method is only meant to be called on:
  // * recap items owned by NYPL that are HTC has already told us is available
 let requestableBasedOnStatusAndHoldingLocation = (item) => {
-  let requestableViaHoldingLocation = false
-  let requestableViaStatus = false
-
-  // is this not requestable because of its holding location
-  try {
-    let holding_location_sierra_code = item.holdingLocation[0].id.split(':').pop()
-    requestableViaHoldingLocation = sierraLocations[holding_location_sierra_code].requestable
-  } catch (e) {
-    logger.warn('There is an item in the index with missing or malformed holdingLocation', item)
-  }
-
-  // is this not requestable because of its serialized status
-  try {
-    let serializedAvailability = item.status[0].id.split(':').pop()
-    requestableViaStatus = statusMapping[serializedAvailability].requestable
-  } catch (e) {
-    logger.warn('There is an item in the index with missing or malformed status', item)
-  }
+  const requestableViaHoldingLocation = requestableBasedOnHoldingLocation(item)
+  const requestableViaStatus = requestableBasedOnStatus(item)
 
   return (requestableViaHoldingLocation && requestableViaStatus)
 }
 
-module.exports = {requestableBasedOnStatusAndHoldingLocation}
+const requestableBasedOnStatus = (item) => {
+  // is this not requestable because of its serialized status
+  try {
+    const serializedAvailability = item.status[0].id.split(':').pop()
+    return statusMapping[serializedAvailability].requestable
+  } catch (e) {
+    logger.warn('There is an item in the index with missing or malformed status', item)
+    return false
+  }
+}
+
+const requestableBasedOnHoldingLocation = (item) => {
+  // Is this not requestable because of its holding location?
+  try {
+    const holding_location_sierra_code = item.holdingLocation[0].id.split(':').pop()
+    return sierraLocations[holding_location_sierra_code].requestable
+  } catch (e) {
+    logger.warn('There is an item in the index with missing or malformed holdingLocation', item)
+    return false
+  }
+}
+
+module.exports = {
+  requestableBasedOnHoldingLocation,
+  requestableBasedOnStatus,
+  requestableBasedOnStatusAndHoldingLocation
+}

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -50,19 +50,26 @@ var sampleItems = {
       'urn:bnum:cb1014551',
       'urn:barcode:CU56521537'
     ],
-    'uri': 'CU55057721'
+    'uri': 'ci9876'
   },
   offsiteNyplDeliverableToScholarRooms: {
     'identifier': [
       'urn:bnum:b11995155',
       'urn:barcode:33433011759648'
     ],
+    'holdingLocation': [
+      {
+        'id': 'loc:rcpm2',
+        'label': 'OFFSITE - Request in Advance for use at Performing Arts'
+      }
+    ],
     'uri': 'i10483065'
   },
   fakeNYPLMapDivisionItem: {
     'identifier': [
       'urn:barcode:made-up-barcode-that-recap-says-belongs-to-ND'
-    ]
+    ],
+    'uri': 'i7654'
   }
 }
 
@@ -156,6 +163,29 @@ describe('Delivery-locations-resolver', function () {
         expect(items[0].deliveryLocation).to.not.include(scholarRoom)
       })
     })
+  })
+
+  it('will serve deliveryLocations if item holdingLocation is requestable', function () {
+    // At writing, this sierra location (rcpm2) is marked requestable: true
+    const offsiteItemInNonRequestableLocation = sampleItems.offsiteNypl
+
+    return DeliveryLocationsResolver.resolveDeliveryLocations([offsiteItemInNonRequestableLocation])
+      .then((items) => {
+        expect(items[0].deliveryLocation).to.be.a('array')
+        expect(items[0].deliveryLocation).to.have.lengthOf(1)
+      })
+  })
+
+  it('will hide deliveryLocations if item holdingLocation is not requestable', function () {
+    const offsiteItemInNonRequestableLocation = JSON.parse(JSON.stringify(sampleItems.offsiteNypl))
+    // At writing, this sierra location is marked requestable: false
+    offsiteItemInNonRequestableLocation.holdingLocation[0].id = 'loc:rccd8'
+
+    return DeliveryLocationsResolver.resolveDeliveryLocations([offsiteItemInNonRequestableLocation])
+      .then((items) => {
+        expect(items[0].deliveryLocation).to.be.a('array')
+        expect(items[0].deliveryLocation).to.be.empty
+      })
   })
 
   it('will reveal "Scholar" deliveryLocation for scholars', function () {

--- a/test/requestability_determination.test.js
+++ b/test/requestability_determination.test.js
@@ -1,4 +1,8 @@
-const { requestableBasedOnStatusAndHoldingLocation } = require('../lib/requestability_determination')
+const {
+  requestableBasedOnHoldingLocation,
+  requestableBasedOnStatus,
+  requestableBasedOnStatusAndHoldingLocation
+} = require('../lib/requestability_determination')
 
 describe('requestableBasedOnStatusAndHoldingLocation', function () {
   it('will flip a requestable item to not-requestable if its holding location is requestable=false', function () {
@@ -16,5 +20,44 @@ describe('requestableBasedOnStatusAndHoldingLocation', function () {
     }
 
     expect(requestableBasedOnStatusAndHoldingLocation(notRequestableByStatus)).to.equal(false)
+  })
+})
+
+describe('requestableBasedOnHoldingLocation', function () {
+  // These expectations rely on the requestability of these locations being
+  // somewhat static, which has been generally true
+
+  it('identifies a non-requestable location', function () {
+    expect(
+      requestableBasedOnHoldingLocation({
+        holdingLocation: [ { id: 'loc:rccd8' } ]
+      })
+    ).to.equal(false)
+  })
+
+  it('identifies a requestable location', function () {
+    expect(
+      requestableBasedOnHoldingLocation({
+        holdingLocation: [ { id: 'loc:rcpm2' } ]
+      })
+    ).to.equal(true)
+  })
+})
+
+describe('requestableBasedOnStatus', function () {
+  it('identifies a non-requestable status', function () {
+    expect(
+      requestableBasedOnStatus({
+        status: [ { id: 'status:b' } ]
+      })
+    ).to.equal(false)
+  })
+
+  it('identifies a requestable status', function () {
+    expect(
+      requestableBasedOnStatus({
+        status: [ { id: 'status:a' } ]
+      })
+    ).to.equal(true)
   })
 })


### PR DESCRIPTION
Previously, item requestability of NYPL offsite items was
solely determined by ReCAP status and item holdingLocation
requestability (via NYPL-Core). See:
https://github.com/NYPL/discovery-api/blob/fecd95487027c7beb12234188d98de3a781e5805/lib/availability_resolver.js#L116

With separate request buttons, we now support three different notions of
requestability: eddRequestable, physRequestable, and specRequestable,
with `requestable` being true when any of the others are true. The
trouble is, the previous calculation of `requestable` did not take into
account EDD requestability (leading to many occasions where we did not
present a Request button for items that were EDD requestable but not
physically requestable). Now that that bug is patched, we allow patrons
to visit the Hold Request page on RC for items that are _only_ EDD
requestable in ReCAP. This is good, but uncovers another issue:

The delivery locations endpoint simply presents the valid
delivery locations based on the item's customer code regardless of the
item's phys requestability. Thus, an item in rccd8 (not requestable)
with customer code NS (deliverable to at least one other location),
appears to have at least one delivery location even though it's not
physRequestable

This fix adds a check to ensure, before providing delivery location
options, that the item is available for phys request (i.e. its status
and holdingLocation are requestable)