### PR TITLE
Fix: item location requestability versus eddRequestable

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -122,6 +122,11 @@ class AvailabilityResolver {
   _fixEddRequestability (item, isInRecap, request) {
     // If it's a recap item, determine edd based on code
     if (isInRecap) {
+      // Some of our items are in RC locations that we mark not EDD requestable
+      // regardless of what the customer code would otherwise say:
+      if (isItemNyplOwned(item) && !requestableBasedOnHoldingLocation(item)) {
+        return false
+      }
       if (Array.isArray(item.recapCustomerCode) && recapCustomerCodes[item.recapCustomerCode[0]]) {
         return recapCustomerCodes[item.recapCustomerCode[0]].eddRequestable
         // If item has not been indexed with recap code, default to true.

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -197,10 +197,11 @@ describe('Response with updated availability', function () {
           return item.uri === 'i10283664'
         })
         expect(availableItem.physRequestable).to.equal(true)
+        expect(availableItem.eddRequestable).to.equal(true)
       })
   })
 
-  it('marks ReCAP items that are in unrequestable locations as not physRequestable', function () {
+  it('marks ReCAP items that are in unrequestable locations as not eddRequestable nor physRequestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = new FakeRestClient()
 
@@ -215,6 +216,7 @@ describe('Response with updated availability', function () {
           return item.uri === 'i102836649-unrequestable'
         })
         expect(availableItem.physRequestable).to.equal(false)
+        expect(availableItem.eddRequestable).to.equal(false)
       })
   })
 


### PR DESCRIPTION
Fix bug where an item in an UNrequestable holding location may still be rendered with eddRequestable=true. An earlier fix addressed a similar bug with physRequestable. We need to apply the same check for eddRequestable.