### PR TITLE
Fix bug in hasItemDates and hasItemVolumes

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -255,8 +255,16 @@ class ResourceSerializer extends JsonLdItemSerializer {
     }
 
     // Add hasVol and hasDate properties
-    stmts.hasItemVolumes = this.body.numItemVolumesParsed / this.body.numItems > parseFloat(process.env.BIB_HAS_VOLUMES_THRESHOLD)
-    stmts.hasItemDates = this.body.numItemDatesParsed / this.body.numItems > parseFloat(process.env.BIB_HAS_DATES_THRESHOLD)
+    stmts.hasItemVolumes = false
+    stmts.hasItemDates = false
+    if (Array.isArray(this.body.numItems)) {
+      if (Array.isArray(this.body.numItemVolumesParsed)) {
+        stmts.hasItemVolumes = this.body.numItemVolumesParsed[0] / this.body.numItems[0] > parseFloat(process.env.BIB_HAS_VOLUMES_THRESHOLD)
+      }
+      if (Array.isArray(this.body.numItemDatesParsed)) {
+        stmts.hasItemDates = this.body.numItemDatesParsed[0] / this.body.numItems[0] > parseFloat(process.env.BIB_HAS_DATES_THRESHOLD)
+      }
+    }
 
     return stmts
   }

--- a/test/fixtures/query-5ae3220a550f9229d91369cd1200a590.json
+++ b/test/fixtures/query-5ae3220a550f9229d91369cd1200a590.json
@@ -1,0 +1,356 @@
+{
+  "took": 25,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 29.754269,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11984689",
+        "_score": 29.754269,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Established 1900.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Most issues lack subtitle.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "v. 42, no. 1-v. 62, no. 7; Jan. 1942-July 1962."
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwork",
+            "Woodwork -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            19
+          ],
+          "publisherLiteral": [
+            "Southam-Maclean Publications [etc.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            19
+          ],
+          "createdYear": [
+            1942
+          ],
+          "dateEndString": [
+            "1962"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "shelfMark": [
+            "VMA (Canadian woodworker)"
+          ],
+          "numItemVolumesParsed": [
+            19
+          ],
+          "createdString": [
+            "1942"
+          ],
+          "idLccn": [
+            "cn 76300447"
+          ],
+          "idIssn": [
+            "0316-9669"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1942
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VMA (Canadian woodworker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11984689"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0316-9669"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cn 76300447"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG94-S11794"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1974025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-STC"
+            }
+          ],
+          "idOclc": [
+            "NYPG94-S11794"
+          ],
+          "dateEndYear": [
+            1962
+          ],
+          "updatedAt": 1674767176917,
+          "publicationStatement": [
+            "Don Mills, Ont. [etc.] Southam-Maclean Publications [etc.]"
+          ],
+          "identifier": [
+            "urn:bnum:11984689",
+            "urn:issn:0316-9669",
+            "urn:lccn:cn 76300447",
+            "urn:oclc:NYPG94-S11794",
+            "urn:undefined:(WaOLN)nyp1974025",
+            "urn:undefined:RCON-STC"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1942"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwork -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "uri": "b11984689",
+          "numItems": [
+            19
+          ],
+          "numAvailable": [
+            19
+          ],
+          "placeOfPublication": [
+            "Don Mills, Ont. [etc.]"
+          ],
+          "titleAlt": [
+            "Canadian woodworker (1942)",
+            "Canadian woodworker and furniture manufacturer Jan.-Mar. 1942"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": 15.104201,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": 15.104201,
+                  "_source": {
+                    "uri": "i29976055",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 44 (1944)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 44 (1944)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102812199"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 44 (1944)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102812199"
+                    ],
+                    "idBarcode": [
+                      "33433102812199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 44,
+                        "lte": 44
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1944",
+                        "lte": "1944"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        44-1944"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000044 (1944)"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 19
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/scsb-by-barcode-b4ab79b5bce17604bea7d6e8569a05d0.json
+++ b/test/fixtures/scsb-by-barcode-b4ab79b5bce17604bea7d6e8569a05d0.json
@@ -1,0 +1,7 @@
+[
+  {
+    "itemBarcode": "33433102812199",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -67,30 +67,26 @@ describe('Test Resources responses', function () {
       })
     })
 
-    // TODO: find a bib-item pair in production for the following test:
-    // it('Resource data for b21088122-i32086897 are what we expect', function (done) {
-    //   request.get(`${global.TEST_BASE_URL}/api/v0.1/discovery/resources/b21088122-i32086897`, function (err, response, body) {
-    //     if (err) throw err
-    //
-    //     assert.equal(200, response.statusCode)
-    //
-    //     var doc = JSON.parse(body)
-    //     console.log('items: ', doc.items.length, doc.hasItemVolumes, doc.hasItemDates, doc.itemAggregations)
-    //
-    //     expect(doc.items).to.be.a('array')
-    //
-    //     expect(doc.items.length).to.equal(1)
-    //
-    //     expect(doc.items[0].uri).to.equal('i32086897')
-    //
-    //     expect(doc.hasItemVolumes).to.equal(true)
-    //
-    //     expect(doc.hasItemDates).to.equal(true)
-    //
-    //     expect(doc.itemAggregations)
-    //     done()
-    //   })
-    // })
+    it('Resource data for b21088122-i32086897 are what we expect', function (done) {
+      request.get(`${global.TEST_BASE_URL}/api/v0.1/discovery/resources/b11984689-i29976055`, function (err, response, body) {
+        if (err) throw err
+
+        assert.equal(200, response.statusCode)
+
+        const doc = JSON.parse(body)
+
+        expect(doc.items).to.be.a('array')
+
+        expect(doc.items.length).to.equal(1)
+        expect(doc.items[0].uri).to.equal('i29976055')
+
+        expect(doc.hasItemVolumes).to.equal(true)
+        expect(doc.hasItemDates).to.equal(true)
+
+        expect(doc.itemAggregations)
+        done()
+      })
+    })
 
     it('extracts identifiers in ENTITY style if indexed as entity', function (done) {
       request.get(`${global.TEST_BASE_URL}/api/v0.1/discovery/resources/b10011374`, function (err, response, body) {


### PR DESCRIPTION
Fix bug calculating hasItemDates and hasItemVolumes to ensure it treats numItems and numItemVolumesParsed, etc as arrays (because all statements are indexed as arrays)