### PR TITLE
add numitemsmatched

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -251,11 +251,7 @@ module.exports = function (app, _private = null) {
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
-      if (resp && resp.hits && resp.hits.hits && resp.hits.hits[0] &&
-        resp.hits.hits[0]._source && resp.hits.hits[0].inner_hits &&
-        resp.hits.hits[0].inner_hits.items && resp.hits.hits[0].inner_hits.items.hits &&
-        resp.hits.hits[0].inner_hits.items.hits.hits
-      ) {
+      if (util.checkForNestedHitsAndSource(resp)) {
         resp.hits.hits[0]._source.items = resp.hits.hits[0].inner_hits.items.hits.hits.map((item) => item._source)
       }
       // Mindfully throw errors for known issues:

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -8,7 +8,10 @@ class ResponseMassager {
   }
 
   massagedResponse (request, options) {
-    const updatedWithParallelFields = parallelFieldsExtractor(this.elasticSearchResponse)
+    const tempResponse = this.elasticSearchResponse
+    tempResponse.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
+    const updatedWithNumItemsMatched = tempResponse
+    const updatedWithParallelFields = parallelFieldsExtractor(updatedWithNumItemsMatched)
     const availabilityResolver = new AvailabilityResolver(updatedWithParallelFields)
     const updatedWithAvailability = availabilityResolver.responseWithUpdatedAvailability(request, options)
     const updatedWithNewestLabels = updatedWithAvailability.then((resp) => {

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -9,7 +9,9 @@ class ResponseMassager {
 
   massagedResponse (request, options) {
     const tempResponse = this.elasticSearchResponse
-    tempResponse.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
+    if (this.elasticSearchResponse.hits.hits[0].inner_hits && this.elasticSearchResponse.hits.hits[0].inner_hits.items) {
+      tempResponse.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
+    }
     const updatedWithNumItemsMatched = tempResponse
     const updatedWithParallelFields = parallelFieldsExtractor(updatedWithNumItemsMatched)
     const availabilityResolver = new AvailabilityResolver(updatedWithParallelFields)

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -1,6 +1,7 @@
 const LocationLabelUpdater = require('./location_label_updater')
 const AvailabilityResolver = require('./availability_resolver.js')
 const parallelFieldsExtractor = require('./parallel-fields-extractor')
+const util = require('../lib/util')
 
 class ResponseMassager {
   constructor (responseReceived) {
@@ -9,7 +10,7 @@ class ResponseMassager {
 
   massagedResponse (request, options) {
     let updatedWithNumItemsMatched = this.elasticSearchResponse
-    if (this.elasticSearchResponse.hits.hits[0].inner_hits && this.elasticSearchResponse.hits.hits[0].inner_hits.items) {
+    if (util.checkForNestedHitsAndSource(updatedWithNumItemsMatched)) {
       updatedWithNumItemsMatched.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
     }
     const updatedWithParallelFields = parallelFieldsExtractor(updatedWithNumItemsMatched)

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -8,11 +8,10 @@ class ResponseMassager {
   }
 
   massagedResponse (request, options) {
-    const tempResponse = this.elasticSearchResponse
+    let updatedWithNumItemsMatched = this.elasticSearchResponse
     if (this.elasticSearchResponse.hits.hits[0].inner_hits && this.elasticSearchResponse.hits.hits[0].inner_hits.items) {
-      tempResponse.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
+      updatedWithNumItemsMatched.hits.hits[0]._source.numItemsMatched = [this.elasticSearchResponse.hits.hits[0].inner_hits.items.hits.total]
     }
-    const updatedWithNumItemsMatched = tempResponse
     const updatedWithParallelFields = parallelFieldsExtractor(updatedWithNumItemsMatched)
     const availabilityResolver = new AvailabilityResolver(updatedWithParallelFields)
     const updatedWithAvailability = availabilityResolver.responseWithUpdatedAvailability(request, options)

--- a/lib/util.js
+++ b/lib/util.js
@@ -341,3 +341,10 @@ exports.backslashes = (phrase, count = 1) => {
       .join('')
   }
 }
+
+exports.checkForNestedHitsAndSource = (resp) => {
+  return resp && resp.hits && resp.hits.hits && resp.hits.hits[0] &&
+    resp.hits.hits[0]._source && resp.hits.hits[0].inner_hits &&
+    resp.hits.hits[0].inner_hits.items && resp.hits.hits[0].inner_hits.items.hits &&
+    resp.hits.hits[0].inner_hits.items.hits.hits
+}

--- a/test/fixtures/query-9d132316d716e55d76d247d1d3050812.json
+++ b/test/fixtures/query-9d132316d716e55d76d247d1d3050812.json
@@ -1,0 +1,13046 @@
+{
+  "took": 1195,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.985339,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.985339,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            884
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            890
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            820
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 50 (Feb. 13, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 51 (Feb. 20, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 52 (Feb. 27, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 53 (Mar. 6, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1675375564674,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            196
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            694
+          ],
+          "numAvailable": [
+            835
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 694,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 889
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37530724",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201161"
+                    ],
+                    "idBarcode": [
+                      "33433128201161"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (Oct.-Nov. 2018)"
+                  },
+                  "sort": [
+                    "        94-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 888
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37539307",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (May-June 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (May-June 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (May-June 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201310"
+                    ],
+                    "idBarcode": [
+                      "33433128201310"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (May-June 2018)"
+                  },
+                  "sort": [
+                    "        94-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 887
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37539308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (July-Sept. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (July-Sept. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (July-Sept. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201302"
+                    ],
+                    "idBarcode": [
+                      "33433128201302"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (July-Sept. 2018)"
+                  },
+                  "sort": [
+                    "        94-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 886
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37529511",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (Feb. 12-Apr. 30, 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (Feb. 12-Apr. 30, 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128200965"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (Feb. 12-Apr. 30, 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128200965"
+                    ],
+                    "idBarcode": [
+                      "33433128200965"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (Feb. 12-Apr. 30, 2018)"
+                  },
+                  "sort": [
+                    "        94-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 885
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37529513",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (Dec. 3, 2018-Feb. 11, 2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (Dec. 3, 2018-Feb. 11, 2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128200973"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (Dec. 3, 2018-Feb. 11, 2019)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128200973"
+                    ],
+                    "idBarcode": [
+                      "33433128200973"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (Dec. 3, 2018-Feb. 11, 2019)"
+                  },
+                  "sort": [
+                    "        94-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 884
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36790458",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 93 (Nov. 6, 2017-Feb. 5, 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 93 (Nov. 6, 2017-Feb. 5, 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121911253"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 93 (Nov. 6, 2017-Feb. 5, 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121911253"
+                    ],
+                    "idBarcode": [
+                      "33433121911253"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 93,
+                        "lte": 93
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        93-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000093 (Nov. 6, 2017-Feb. 5, 2018)"
+                  },
+                  "sort": [
+                    "        93-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 883
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36790460",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 93 (May-July 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 93 (May-July 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121911105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 93 (May-July 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121911105"
+                    ],
+                    "idBarcode": [
+                      "33433121911105"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 93,
+                        "lte": 93
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        93-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000093 (May-July 2017)"
+                  },
+                  "sort": [
+                    "        93-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 882
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36790455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 93 (Feb. 13-Apr. 24, 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 93 (Feb. 13-Apr. 24, 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121911246"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 93 (Feb. 13-Apr. 24, 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121911246"
+                    ],
+                    "idBarcode": [
+                      "33433121911246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 93,
+                        "lte": 93
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        93-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000093 (Feb. 13-Apr. 24, 2017)"
+                  },
+                  "sort": [
+                    "        93-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 881
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36790462",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 93 (Aug-Oct 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 93 (Aug-Oct 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121911097"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 93 (Aug-Oct 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121911097"
+                    ],
+                    "idBarcode": [
+                      "33433121911097"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 93,
+                        "lte": 93
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        93-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000093 (Aug-Oct 2017)"
+                  },
+                  "sort": [
+                    "        93-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 880
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36118780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (Oct. -Nov. 2016) Inc. "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (Oct. -Nov. 2016) Inc. ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119892341"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (Oct. -Nov. 2016) Inc. "
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119892341"
+                    ],
+                    "idBarcode": [
+                      "33433119892341"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (Oct. -Nov. 2016) Inc. "
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 879
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36058799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (May-June 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (May-June 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119855561"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (May-June 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119855561"
+                    ],
+                    "idBarcode": [
+                      "33433119855561"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (May-June 2016)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 878
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060542",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (July-Sept. 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (July-Sept. 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872095"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (July-Sept. 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872095"
+                    ],
+                    "idBarcode": [
+                      "33433119872095"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (July-Sept. 2016)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 877
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060543",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (Feb. 8-April 25, 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (Feb. 8-April 25, 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872103"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (Feb. 8-April 25, 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872103"
+                    ],
+                    "idBarcode": [
+                      "33433119872103"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (Feb. 8-April 25, 2016)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 876
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36118763",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (Dec. 5, 2016-Feb. 6, 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (Dec. 5, 2016-Feb. 6, 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119892333"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (Dec. 5, 2016-Feb. 6, 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119892333"
+                    ],
+                    "idBarcode": [
+                      "33433119892333"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (Dec. 5, 2016-Feb. 6, 2017)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 875
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060538",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872087"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872087"
+                    ],
+                    "idBarcode": [
+                      "33433119872087"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000091 (Sept.-Oct. 2015)"
+                  },
+                  "sort": [
+                    "        91-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 874
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36058800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 91 (Nov. 2, 2015- Feb. 1, 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 91 (Nov. 2, 2015- Feb. 1, 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119855579"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 (Nov. 2, 2015- Feb. 1, 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119855579"
+                    ],
+                    "idBarcode": [
+                      "33433119855579"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000091 (Nov. 2, 2015- Feb. 1, 2016)"
+                  },
+                  "sort": [
+                    "        91-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 873
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36118736",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 91 (Mar. 23-Aug. 31, 2015) Inc. "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 91 (Mar. 23-Aug. 31, 2015) Inc. ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119892317"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 (Mar. 23-Aug. 31, 2015) Inc. "
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119892317"
+                    ],
+                    "idBarcode": [
+                      "33433119892317"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000091 (Mar. 23-Aug. 31, 2015) Inc. "
+                  },
+                  "sort": [
+                    "        91-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 872
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34327846",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 90 (Oct. 6-Dec. 1 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 90 (Oct. 6-Dec. 1 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114102134"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 90 (Oct. 6-Dec. 1 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433114102134"
+                    ],
+                    "idBarcode": [
+                      "33433114102134"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 90,
+                        "lte": 90
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        90-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000090 (Oct. 6-Dec. 1 2014)"
+                  },
+                  "sort": [
+                    "        90-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 871
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34325260",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 90 (May-June 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 90 (May-June 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114101987"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 90 (May-June 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433114101987"
+                    ],
+                    "idBarcode": [
+                      "33433114101987"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 90,
+                        "lte": 90
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        90-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000090 (May-June 2014)"
+                  },
+                  "sort": [
+                    "        90-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 870
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34327829",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 90 (July-Sept 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 90 (July-Sept 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114102084"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 90 (July-Sept 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433114102084"
+                    ],
+                    "idBarcode": [
+                      "33433114102084"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 90,
+                        "lte": 90
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        90-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000090 (July-Sept 2014)"
+                  },
+                  "sort": [
+                    "        90-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 869
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34327008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89-90 (Feb. 10-Apr. 28 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89-90 (Feb. 10-Apr. 28 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433114102043"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89-90 (Feb. 10-Apr. 28 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433114102043"
+                    ],
+                    "idBarcode": [
+                      "33433114102043"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 90
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089-90 (Feb. 10-Apr. 28 2014)"
+                  },
+                  "sort": [
+                    "        89-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 864
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414227",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (Jan. 6-Feb. 3, 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (Jan. 6-Feb. 3, 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762741"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (Jan. 6-Feb. 3, 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762741"
+                    ],
+                    "idBarcode": [
+                      "33433110762741"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (Jan. 6-Feb. 3, 2014)"
+                  },
+                  "sort": [
+                    "        89-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 868
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414253",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (Sept-Oct 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (Sept-Oct 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762709"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (Sept-Oct 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762709"
+                    ],
+                    "idBarcode": [
+                      "33433110762709"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (Sept-Oct 2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 867
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414254",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (Nov-Dec 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (Nov-Dec 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762691"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (Nov-Dec 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762691"
+                    ],
+                    "idBarcode": [
+                      "33433110762691"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (Nov-Dec 2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 866
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414248",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (May-June 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (May-June 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762725"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (May-June 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762725"
+                    ],
+                    "idBarcode": [
+                      "33433110762725"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (May-June 2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 865
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414252",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (July-Aug 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (July-Aug 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762717"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (July-Aug 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762717"
+                    ],
+                    "idBarcode": [
+                      "33433110762717"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (July-Aug 2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 863
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32414245",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 89 (Feb. 11-Apr. 29 , 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 89 (Feb. 11-Apr. 29 , 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110762733"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 (Feb. 11-Apr. 29 , 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110762733"
+                    ],
+                    "idBarcode": [
+                      "33433110762733"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000089 (Feb. 11-Apr. 29 , 2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 862
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31482936",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 88 (June 4-July 16, 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 88 (June 4-July 16, 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108528393"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 (June 4-July 16, 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108528393"
+                    ],
+                    "idBarcode": [
+                      "33433108528393"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 88,
+                        "lte": 88
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        88-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000088 (June 4-July 16, 2012)"
+                  },
+                  "sort": [
+                    "        88-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 861
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31482935",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 88 (Feb. 13-Mar. 26, 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 88 (Feb. 13-Mar. 26, 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108528385"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 (Feb. 13-Mar. 26, 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108528385"
+                    ],
+                    "idBarcode": [
+                      "33433108528385"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 88,
+                        "lte": 88
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        88-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000088 (Feb. 13-Mar. 26, 2012)"
+                  },
+                  "sort": [
+                    "        88-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 860
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31482938",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 88 (Dec. 10, 2012-Feb. 4, 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 88 (Dec. 10, 2012-Feb. 4, 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108528401"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 (Dec. 10, 2012-Feb. 4, 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108528401"
+                    ],
+                    "idBarcode": [
+                      "33433108528401"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 88,
+                        "lte": 88
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        88-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000088 (Dec. 10, 2012-Feb. 4, 2013)"
+                  },
+                  "sort": [
+                    "        88-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 859
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31482930",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 88 (Apr.-May 2012) Inc."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 88 (Apr.-May 2012) Inc.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108528377"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 (Apr.-May 2012) Inc."
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108528377"
+                    ],
+                    "idBarcode": [
+                      "33433108528377"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 88,
+                        "lte": 88
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        88-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000088 (Apr.-May 2012) Inc."
+                  },
+                  "sort": [
+                    "        88-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 858
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878991",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610952"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Oct-Nov 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610952"
+                    ],
+                    "idBarcode": [
+                      "33433099610952"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Oct-Nov 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 857
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (June-July 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (June-July 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611083"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (June-July 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611083"
+                    ],
+                    "idBarcode": [
+                      "33433099611083"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (June-July 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 856
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878974",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611109"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611109"
+                    ],
+                    "idBarcode": [
+                      "33433099611109"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Feb. 14-Mar. 28, 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 855
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28879000",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610945"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610945"
+                    ],
+                    "idBarcode": [
+                      "33433099610945"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Dec. 5, 2011-Feb. 6, 2012)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 854
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878989",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611075"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Aug-Sept 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611075"
+                    ],
+                    "idBarcode": [
+                      "33433099611075"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Aug-Sept 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 853
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878981",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Apr-May 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Apr-May 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611091"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Apr-May 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611091"
+                    ],
+                    "idBarcode": [
+                      "33433099611091"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Apr-May 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 852
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28974701",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 inc. (May-July 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 inc. (May-July 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099612925"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 inc. (May-July 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099612925"
+                    ],
+                    "idBarcode": [
+                      "33433099612925"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 inc. (May-July 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 851
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878958",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611125"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Oct-Nov 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611125"
+                    ],
+                    "idBarcode": [
+                      "33433099611125"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Oct-Nov 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 850
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611141"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611141"
+                    ],
+                    "idBarcode": [
+                      "33433099611141"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Feb. 15-Apr. 26, 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 849
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878970",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611117"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611117"
+                    ],
+                    "idBarcode": [
+                      "33433099611117"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Dec. 6, 2010-Feb. 7, 2011)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 848
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878953",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611133"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Aug-Sept 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611133"
+                    ],
+                    "idBarcode": [
+                      "33433099611133"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Aug-Sept 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 847
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878932",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611166"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Oct-Nov 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611166"
+                    ],
+                    "idBarcode": [
+                      "33433099611166"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Oct-Nov 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 846
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (May-June 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (May-June 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611182"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (May-June 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611182"
+                    ],
+                    "idBarcode": [
+                      "33433099611182"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (May-June 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 845
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611190"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611190"
+                    ],
+                    "idBarcode": [
+                      "33433099611190"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Feb. 9-Apr. 27, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 844
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878925",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611174"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611174"
+                    ],
+                    "idBarcode": [
+                      "33433099611174"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Aug. 10-Sept. 28, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 843
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589223",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063992"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Oct-Nov 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063992"
+                    ],
+                    "idBarcode": [
+                      "33433085063992"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Oct-Nov 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 842
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589214",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (June-July 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (June-July 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064008"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (June-July 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064008"
+                    ],
+                    "idBarcode": [
+                      "33433085064008"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (June-July 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 841
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589272",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063950"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063950"
+                    ],
+                    "idBarcode": [
+                      "33433085063950"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Feb. 11-Mar. 31 , 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 840
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063976"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063976"
+                    ],
+                    "idBarcode": [
+                      "33433085063976"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Dec 1, 2008-Feb 2, 2009)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 839
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589287",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064172"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064172"
+                    ],
+                    "idBarcode": [
+                      "33433085064172"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Aug-Sept 2008 & Suppl.)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 838
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589205",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Apr-May 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Apr-May 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Apr-May 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064214"
+                    ],
+                    "idBarcode": [
+                      "33433085064214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Apr-May 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 837
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589229",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063984"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063984"
+                    ],
+                    "idBarcode": [
+                      "33433085063984"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Oct-Nov 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 836
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589274",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063943"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063943"
+                    ],
+                    "idBarcode": [
+                      "33433085063943"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (June 25-July 30, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 835
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589278",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064180"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064180"
+                    ],
+                    "idBarcode": [
+                      "33433085064180"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Feb. 19-Mar. 26, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 834
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589263",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064206"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064206"
+                    ],
+                    "idBarcode": [
+                      "33433085064206"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Dec. 3, 2007-Feb. 4, 2008)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 833
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589251",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063968"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063968"
+                    ],
+                    "idBarcode": [
+                      "33433085063968"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Aug-Sept 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 832
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589269",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064198"
+                    ],
+                    "idBarcode": [
+                      "33433085064198"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Apr. 2-May 21, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 831
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474922",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240575"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240575"
+                    ],
+                    "idBarcode": [
+                      "33433084240575"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Oct.-Nov. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 830
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (May-June 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (May-June 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240559"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (May-June 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240559"
+                    ],
+                    "idBarcode": [
+                      "33433084240559"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (May-June 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 829
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474921",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240567"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240567"
+                    ],
+                    "idBarcode": [
+                      "33433084240567"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (July-Sept. & Suppl. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 828
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474919",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240542"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240542"
+                    ],
+                    "idBarcode": [
+                      "33433084240542"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Feb. 13-Apr. 24, 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 827
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474923",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240583"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240583"
+                    ],
+                    "idBarcode": [
+                      "33433084240583"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Dec. 4, 2006-Feb. 12, 2007)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 826
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474917",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240526"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240526"
+                    ],
+                    "idBarcode": [
+                      "33433084240526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Oct.-Nov. 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 825
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240518"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240518"
+                    ],
+                    "idBarcode": [
+                      "33433084240518"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (June 27-Sept.26,2005;Suppl.)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 824
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474914",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240492"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240492"
+                    ],
+                    "idBarcode": [
+                      "33433084240492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Feb. 14-Mar. 28, 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 823
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474918",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240534"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240534"
+                    ],
+                    "idBarcode": [
+                      "33433084240534"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Dec. 5, 2005-Feb. 6, 2006)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 822
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Apr.-May 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Apr.-May 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240500"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Apr.-May 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240500"
+                    ],
+                    "idBarcode": [
+                      "33433084240500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Apr.-May 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 821
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474912",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240476"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240476"
+                    ],
+                    "idBarcode": [
+                      "33433084240476"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Oct.-Nov. 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 820
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (May-June 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (May-June 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240468"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (May-June 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240468"
+                    ],
+                    "idBarcode": [
+                      "33433084240468"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (May-June 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 819
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474399",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (July-Sept 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (July-Sept 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078508037"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (July-Sept 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078508037"
+                    ],
+                    "idBarcode": [
+                      "33433078508037"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (July-Sept 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 818
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474447",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080028222"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080028222"
+                    ],
+                    "idBarcode": [
+                      "33433080028222"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Feb. 16- Apr. 26 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 817
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474913",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240484"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240484"
+                    ],
+                    "idBarcode": [
+                      "33433084240484"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Dec. 6, 2004-Feb. 7, 2005)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 816
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474909",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240443"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240443"
+                    ],
+                    "idBarcode": [
+                      "33433084240443"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Oct.-Nov. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 815
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474907",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (June-July 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (June-July 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240427"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (June-July 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240427"
+                    ],
+                    "idBarcode": [
+                      "33433084240427"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (June-July 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 814
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240401"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240401"
+                    ],
+                    "idBarcode": [
+                      "33433084240401"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Feb. 17-Mar. 31, 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 813
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240450"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240450"
+                    ],
+                    "idBarcode": [
+                      "33433084240450"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Dec. 1, 2003-Feb. 9, 2004)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 812
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474908",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240435"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240435"
+                    ],
+                    "idBarcode": [
+                      "33433084240435"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Aug-Sept. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 811
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Apr.-May 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Apr.-May 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240419"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Apr.-May 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240419"
+                    ],
+                    "idBarcode": [
+                      "33433084240419"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Apr.-May 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 810
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240385"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240385"
+                    ],
+                    "idBarcode": [
+                      "33433084240385"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Oct.-Nov. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 809
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (June-July 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (June-July 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240369"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (June-July 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240369"
+                    ],
+                    "idBarcode": [
+                      "33433084240369"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (June-July 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 808
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240344"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240344"
+                    ],
+                    "idBarcode": [
+                      "33433084240344"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Feb. 18-Mar. 25, 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 807
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240393"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240393"
+                    ],
+                    "idBarcode": [
+                      "33433084240393"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Dec. 2, 2002-Feb. 10, 2003)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 806
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240377"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240377"
+                    ],
+                    "idBarcode": [
+                      "33433084240377"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Aug.-Sept. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 805
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Apr.-May 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Apr.-May 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240351"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Apr.-May 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240351"
+                    ],
+                    "idBarcode": [
+                      "33433084240351"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Apr.-May 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 804
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240328"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240328"
+                    ],
+                    "idBarcode": [
+                      "33433084240328"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Oct. -Nov. 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 803
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474446",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (May-July 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (May-July 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079991612"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (May-July 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079991612"
+                    ],
+                    "idBarcode": [
+                      "33433079991612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (May-July 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 802
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240302"
+                    ],
+                    "idBarcode": [
+                      "33433084240302"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Feb. 19-Apr. 30, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 801
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240336"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240336"
+                    ],
+                    "idBarcode": [
+                      "33433084240336"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Dec. 3, 2001-Feb. 11, 2002)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 800
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240310"
+                    ],
+                    "idBarcode": [
+                      "33433084240310"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Aug. 6-Sept. 17, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 799
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240286"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240286"
+                    ],
+                    "idBarcode": [
+                      "33433084240286"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Sept.-Oct. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 798
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240294"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240294"
+                    ],
+                    "idBarcode": [
+                      "33433084240294"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Nov. 6, 2000-Feb. 5, 2001)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 797
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (July-Aug. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (July-Aug. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078639105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (July-Aug. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078639105"
+                    ],
+                    "idBarcode": [
+                      "33433078639105"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (July-Aug. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 796
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474434",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080426707"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080426707"
+                    ],
+                    "idBarcode": [
+                      "33433080426707"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Apr 24-June 26 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 795
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240211"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240211"
+                    ],
+                    "idBarcode": [
+                      "33433084240211"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075(Feb.22-May 3, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 794
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240245"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240245"
+                    ],
+                    "idBarcode": [
+                      "33433084240245"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Sept.-Oct. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 793
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Nov. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Nov. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240252"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Nov. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240252"
+                    ],
+                    "idBarcode": [
+                      "33433084240252"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Nov. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 792
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240229"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240229"
+                    ],
+                    "idBarcode": [
+                      "33433084240229"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (May 10-June 28, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 791
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (July-Aug. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (July-Aug. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240237"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (July-Aug. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240237"
+                    ],
+                    "idBarcode": [
+                      "33433084240237"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (July-Aug. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 790
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240260"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240260"
+                    ],
+                    "idBarcode": [
+                      "33433084240260"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Dec. 6, 1999-Feb. 14, 2000)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 562
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 196
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 694
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 835
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 7
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-acff79f7ffacb988cc0d8e2b2d3c4232.json
+++ b/test/fixtures/query-acff79f7ffacb988cc0d8e2b2d3c4232.json
@@ -1,0 +1,9559 @@
+{
+  "took": 1853,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.987814,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.987814,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            884
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            890
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            820
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 50 (Feb. 13, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 51 (Feb. 20, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 52 (Feb. 27, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 53 (Mar. 6, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1675375564674,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            196
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            694
+          ],
+          "numAvailable": [
+            835
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 890,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 195
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-0",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 53 (Mar. 6, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 53"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-03-06",
+                        "lte": "2023-03-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-03-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-03-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 194
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-1",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 52 (Feb. 27, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 52"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-27",
+                        "lte": "2023-02-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 193
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-2",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 51 (Feb. 20, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 51"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-20",
+                        "lte": "2023-02-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 192
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-3",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 50 (Feb. 13, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 50"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-13",
+                        "lte": "2023-02-13"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-13"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-13"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 191
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-4",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 49 (Feb. 6, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 49"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-06",
+                        "lte": "2023-02-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 190
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-5",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 48 (Jan. 30, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 48"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-01-30",
+                        "lte": "2023-01-30"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-01-30"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-01-30"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 189
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-6",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 47 (Jan. 23, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 47"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-01-23",
+                        "lte": "2023-01-23"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-01-23"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-01-23"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 188
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-7",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 45 (Jan. 16, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 45"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-01-16",
+                        "lte": "2023-01-16"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-01-16"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-01-16"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 187
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-8",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 44 (Jan. 2, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 44"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-01-02",
+                        "lte": "2023-01-02"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-01-02"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-01-02"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 186
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-9",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 43 (Dec. 26, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 43"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-26",
+                        "lte": "2022-12-26"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-26"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-26"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 185
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-10",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 42 (Dec. 19, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 42"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-19",
+                        "lte": "2022-12-19"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-19"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-19"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 184
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-11",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 41 (Dec. 12, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 41"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-12",
+                        "lte": "2022-12-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 183
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-12",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 40 (Dec. 5, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 40"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-05",
+                        "lte": "2022-12-05"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-05"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-05"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 180
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-15",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 39 (Nov. 28, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 39"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-11-28",
+                        "lte": "2022-11-28"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-11-28"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-11-28"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 182
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-13",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 38 (Nov. 21, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 38"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-11-21",
+                        "lte": "2022-11-21"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-11-21"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-11-21"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 179
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-16",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 37 (Nov. 14, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 37"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-11-14",
+                        "lte": "2022-11-14"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-11-14"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-11-14"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 178
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-17",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 36 (Nov. 7, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 36"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-11-07",
+                        "lte": "2022-11-07"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-11-07"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-11-07"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 181
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-14",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 35 (Oct. 31, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 35"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-10-31",
+                        "lte": "2022-10-31"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-10-31"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-10-31"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 171
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-24",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 34 (Oct. 24, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 34"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-10-24",
+                        "lte": "2022-10-24"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-10-24"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-10-24"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 170
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-25",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 33 (Oct. 17, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 33"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-10-17",
+                        "lte": "2022-10-17"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-10-17"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-10-17"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 169
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-26",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 32 (Oct. 10, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 32"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-10-10",
+                        "lte": "2022-10-10"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-10-10"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-10-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 168
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-27",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 31 (Oct. 3, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 31"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-10-03",
+                        "lte": "2022-10-03"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-10-03"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-10-03"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 177
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-18",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 30 (Sep. 26, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 30"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-09-26",
+                        "lte": "2022-09-26"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-09-26"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-09-26"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 167
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-28",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 29 (Sep. 19, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 29"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-09-19",
+                        "lte": "2022-09-19"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-09-19"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-09-19"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 166
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-29",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 28 (Sep. 12, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 28"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-09-12",
+                        "lte": "2022-09-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-09-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-09-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 165
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-30",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 27 (Sep. 5, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 27"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-09-05",
+                        "lte": "2022-09-05"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-09-05"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-09-05"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 173
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-22",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 26 (Aug. 29, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 26"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-08-29",
+                        "lte": "2022-08-29"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-08-29"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-08-29"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 172
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-23",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 25 (Aug. 22, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 25"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-08-22",
+                        "lte": "2022-08-22"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-08-22"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-08-22"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 164
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-31",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 24 (Aug. 15, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 24"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-08-15",
+                        "lte": "2022-08-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-08-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-08-15"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 176
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-19",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 23 (Aug. 8, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 23"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-08-08",
+                        "lte": "2022-08-08"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-08-08"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-08-08"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 175
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-20",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 22 (Aug. 1, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 22"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-08-01",
+                        "lte": "2022-08-01"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-08-01"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-08-01"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 174
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-21",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 21 (Jul. 25, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 21"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-07-25",
+                        "lte": "2022-07-25"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-07-25"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-07-25"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 163
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-32",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 20 (Jul. 11, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 20"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-07-11",
+                        "lte": "2022-07-11"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-07-11"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-07-11"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 162
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-33",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 19 (Jul. 4, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 19"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-07-04",
+                        "lte": "2022-07-04"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-07-04"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-07-04"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 161
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-34",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 18 (Jun. 27, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 18"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-06-27",
+                        "lte": "2022-06-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-06-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-06-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 160
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-35",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 17 (Jun. 20, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 17"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-06-20",
+                        "lte": "2022-06-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-06-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-06-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 159
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-36",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 16 (Jun. 13, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 16"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-06-13",
+                        "lte": "2022-06-13"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-06-13"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-06-13"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 158
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-37",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 15 (Jun. 6, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 15"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-06-06",
+                        "lte": "2022-06-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-06-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-06-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 157
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-38",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 14 (May. 30, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 14"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-05-30",
+                        "lte": "2022-05-30"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-05-30"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-05-30"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 156
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-39",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 13 (May. 23, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 13"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-05-23",
+                        "lte": "2022-05-23"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-05-23"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-05-23"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 155
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-40",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 12 (May. 16, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 12"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-05-16",
+                        "lte": "2022-05-16"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-05-16"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-05-16"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 154
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-41",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 11 (May. 9, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 11"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-05-09",
+                        "lte": "2022-05-09"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-05-09"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-05-09"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 153
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-42",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 10 (Apr. 25, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 10"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-04-25",
+                        "lte": "2022-04-25"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-04-25"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-04-25"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 152
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-43",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 9 (Apr. 18, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 9"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-04-18",
+                        "lte": "2022-04-18"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-04-18"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-04-18"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 151
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-44",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 8 (Apr. 11, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 8"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-04-11",
+                        "lte": "2022-04-11"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-04-11"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-04-11"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 150
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-45",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 7 (Apr. 4, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 7"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-04-04",
+                        "lte": "2022-04-04"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-04-04"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-04-04"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 149
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-46",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 6 (Mar. 28, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 6"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-03-28",
+                        "lte": "2022-03-28"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-03-28"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-03-28"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 148
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-47",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 5 (Mar. 21, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 5"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-03-21",
+                        "lte": "2022-03-21"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-03-21"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-03-21"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 147
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-48",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 4 (Mar. 14, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 4"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-03-14",
+                        "lte": "2022-03-14"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-03-14"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-03-14"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 146
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-49",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 3 (Mar. 7, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 3"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-03-07",
+                        "lte": "2022-03-07"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-03-07"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-03-07"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 145
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-50",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 2 (Feb. 28, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 2"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-02-28",
+                        "lte": "2022-02-28"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-02-28"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-02-28"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 144
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-51",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 1 (Feb. 14, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 1"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-02-14",
+                        "lte": "2022-02-14"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-02-14"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-02-14"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 140
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-55",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 48 (Feb. 7, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 48"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-02-07",
+                        "lte": "2022-02-07"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2022-02-07"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2022-02-07"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 139
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-56",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 47 (Jan. 31, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 47"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-01-31",
+                        "lte": "2022-01-31"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2022-01-31"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2022-01-31"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 138
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-57",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 46 (Jan. 24, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 46"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-01-24",
+                        "lte": "2022-01-24"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2022-01-24"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2022-01-24"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 137
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-58",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 45 (Jan. 10, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 45"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-01-10",
+                        "lte": "2022-01-10"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2022-01-10"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2022-01-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 136
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-59",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 44"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-01-03",
+                        "lte": "2022-01-10"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2022-01-03"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2022-01-03"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 135
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-60",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 43 (Dec. 27, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 43"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-27",
+                        "lte": "2021-12-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 134
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-61",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 42 (Dec. 20, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 42"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-20",
+                        "lte": "2021-12-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 133
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-62",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 41 (Dec. 13, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 41"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-13",
+                        "lte": "2021-12-13"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-13"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-13"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 132
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-63",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 40 (Dec. 6, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 40"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-06",
+                        "lte": "2021-12-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 143
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-52",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 39 (Nov. 29, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 39"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-11-29",
+                        "lte": "2021-11-29"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-11-29"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-11-29"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 131
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-64",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 38 (Nov. 22, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 38"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-11-22",
+                        "lte": "2021-11-22"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-11-22"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-11-22"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 130
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-65",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 37 (Nov. 15, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 37"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-11-15",
+                        "lte": "2021-11-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-11-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-11-15"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 129
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-66",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 36 (Nov. 8, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 36"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-11-08",
+                        "lte": "2021-11-08"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-11-08"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-11-08"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 128
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-67",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 35 (Nov. 1, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 35"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-11-01",
+                        "lte": "2021-11-01"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-11-01"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-11-01"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 127
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-68",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 34 (Oct. 25, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 34"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-10-25",
+                        "lte": "2021-10-25"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-10-25"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-10-25"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 126
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-69",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 33 (Oct. 18, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 33"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-10-18",
+                        "lte": "2021-10-18"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-10-18"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-10-18"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 125
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-70",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 32 (Oct. 11, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 32"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-10-11",
+                        "lte": "2021-10-11"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-10-11"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-10-11"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 124
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-71",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 31 (Oct. 4, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 31"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-10-04",
+                        "lte": "2021-10-04"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-10-04"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-10-04"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 142
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-53",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 30 (Sep. 27, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 30"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-09-27",
+                        "lte": "2021-09-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-09-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-09-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 123
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-72",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 29 (Sep. 20, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 29"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-09-20",
+                        "lte": "2021-09-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-09-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-09-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 122
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-73",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 28 (Sep. 13, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 28"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-09-13",
+                        "lte": "2021-09-13"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-09-13"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-09-13"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 121
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-74",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 27 (Sep. 6, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 27"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-09-06",
+                        "lte": "2021-09-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-09-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-09-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 120
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-75",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 26 (Aug. 30, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 26"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-08-30",
+                        "lte": "2021-08-30"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-08-30"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-08-30"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 141
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-54",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 25 (Aug. 23, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 25"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-08-23",
+                        "lte": "2021-08-23"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-08-23"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-08-23"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 119
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-0",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 24 (Aug. 16, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 24"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-08-16",
+                        "lte": "2021-08-16"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-08-16"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-08-16"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 117
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-2",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 23 (Aug. 9, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 23"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-08-09",
+                        "lte": "2021-08-09"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-08-09"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-08-09"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 118
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-1",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 22 (Aug. 2, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 22"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-08-02",
+                        "lte": "2021-08-02"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-08-02"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-08-02"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 116
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-3",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 21 (Jul. 26, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 21"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-07-26",
+                        "lte": "2021-07-26"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-07-26"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-07-26"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 114
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-5",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 20 (Jul. 12, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 20"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-07-12",
+                        "lte": "2021-07-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-07-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-07-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 115
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-4",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 19 (Jul. 5, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 19"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-07-05",
+                        "lte": "2021-07-05"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-07-05"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-07-05"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 113
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-6",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 18 (Jun. 28, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 18"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-06-28",
+                        "lte": "2021-06-28"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-06-28"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-06-28"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 112
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-7",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 17 (Jun. 21, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 17"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-06-21",
+                        "lte": "2021-06-21"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-06-21"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-06-21"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 111
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-8",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 16 (Jun. 14, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 16"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-06-14",
+                        "lte": "2021-06-14"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-06-14"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-06-14"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 110
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-9",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 15 (Jun. 7, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 15"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-06-07",
+                        "lte": "2021-06-07"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-06-07"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-06-07"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 108
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-11",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 14 (May. 31, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 14"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-05-31",
+                        "lte": "2021-05-31"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-05-31"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-05-31"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 109
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-10",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 13 (May. 24, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 13"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-05-24",
+                        "lte": "2021-05-24"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-05-24"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-05-24"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 107
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-12",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 12 (May. 17, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 12"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-05-17",
+                        "lte": "2021-05-17"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-05-17"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-05-17"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 105
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-14",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 11 (May. 10, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 11"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-05-10",
+                        "lte": "2021-05-10"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-05-10"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-05-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 106
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-13",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 10"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-04-26",
+                        "lte": "2021-05-03"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-04-26"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-04-26"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 104
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-15",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 9 (Apr. 19, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 9"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-04-19",
+                        "lte": "2021-04-19"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-04-19"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-04-19"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 103
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-16",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 8 (Apr. 12, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 8"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-04-12",
+                        "lte": "2021-04-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-04-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-04-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 102
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-17",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 7 (Apr. 5, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 7"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-04-05",
+                        "lte": "2021-04-05"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-04-05"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-04-05"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 101
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-18",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 6 (Mar. 29, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 6"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-03-29",
+                        "lte": "2021-03-29"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-03-29"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-03-29"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 100
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-19",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 5 (Mar. 22, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 5"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-03-22",
+                        "lte": "2021-03-22"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-03-22"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-03-22"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 99
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-20",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 4 (Mar. 15, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 4"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-03-15",
+                        "lte": "2021-03-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-03-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-03-15"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 96
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-23",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 3 (Mar. 8, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 3"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-03-08",
+                        "lte": "2021-03-08"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-03-08"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-03-08"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 95
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-24",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 2 (Mar. 1, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 2"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-03-01",
+                        "lte": "2021-03-01"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-03-01"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-03-01"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 98
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-21",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 1 (Feb. 15, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 1"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-02-15",
+                        "lte": "2021-02-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-02-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-02-15"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 562
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 196
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 694
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 835
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 7
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-b2a92c26916d9758306bd995d2c70bd5.json
+++ b/test/fixtures/query-b2a92c26916d9758306bd995d2c70bd5.json
@@ -1,0 +1,2677 @@
+{
+  "took": 143,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.987814,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.987814,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            884
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            890
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            820
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 50 (Feb. 13, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 51 (Feb. 20, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 52 (Feb. 27, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 53 (Mar. 6, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1675375564674,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            196
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            694
+          ],
+          "numAvailable": [
+            835
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 195
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-0",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 53 (Mar. 6, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 53"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-03-06",
+                        "lte": "2023-03-06"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-03-06"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-03-06"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 194
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-1",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 52 (Feb. 27, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 52"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-27",
+                        "lte": "2023-02-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 193
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-2",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 51 (Feb. 20, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 51"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-20",
+                        "lte": "2023-02-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 192
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-3",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 50 (Feb. 13, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 50"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-02-13",
+                        "lte": "2023-02-13"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2023-02-13"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2023-02-13"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 184
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-11",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 41 (Dec. 12, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 41"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-12",
+                        "lte": "2022-12-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 134
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-61",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 42 (Dec. 20, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 42"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-20",
+                        "lte": "2021-12-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-65",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 96 No. 18 (Jun. 15, 2020)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 96 No. 18"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 96,
+                        "lte": 96
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2020-06-15",
+                        "lte": "2020-06-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        96-2020-06-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        96-2020-06-15"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 562
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 196
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 694
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 835
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 7
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-e500ca390f2655fe2a78d514665afb1d.json
+++ b/test/fixtures/query-e500ca390f2655fe2a78d514665afb1d.json
@@ -1,0 +1,12953 @@
+{
+  "took": 966,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.987813,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.987813,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            884
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            890
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            820
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 50 (Feb. 13, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 51 (Feb. 20, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 52 (Feb. 27, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 53 (Mar. 6, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1675375564674,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            196
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            694
+          ],
+          "numAvailable": [
+            835
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 562,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 878
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060542",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (July-Sept. 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (July-Sept. 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872095"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (July-Sept. 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872095"
+                    ],
+                    "idBarcode": [
+                      "33433119872095"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (July-Sept. 2016)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 875
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060538",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872087"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872087"
+                    ],
+                    "idBarcode": [
+                      "33433119872087"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000091 (Sept.-Oct. 2015)"
+                  },
+                  "sort": [
+                    "        91-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 858
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878991",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610952"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Oct-Nov 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610952"
+                    ],
+                    "idBarcode": [
+                      "33433099610952"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Oct-Nov 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 857
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (June-July 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (June-July 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611083"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (June-July 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611083"
+                    ],
+                    "idBarcode": [
+                      "33433099611083"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (June-July 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 856
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878974",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611109"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611109"
+                    ],
+                    "idBarcode": [
+                      "33433099611109"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Feb. 14-Mar. 28, 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 855
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28879000",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610945"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610945"
+                    ],
+                    "idBarcode": [
+                      "33433099610945"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Dec. 5, 2011-Feb. 6, 2012)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 854
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878989",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611075"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Aug-Sept 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611075"
+                    ],
+                    "idBarcode": [
+                      "33433099611075"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Aug-Sept 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 853
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878981",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Apr-May 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Apr-May 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611091"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Apr-May 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611091"
+                    ],
+                    "idBarcode": [
+                      "33433099611091"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Apr-May 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 852
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28974701",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 inc. (May-July 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 inc. (May-July 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099612925"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 inc. (May-July 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099612925"
+                    ],
+                    "idBarcode": [
+                      "33433099612925"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 inc. (May-July 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 851
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878958",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611125"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Oct-Nov 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611125"
+                    ],
+                    "idBarcode": [
+                      "33433099611125"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Oct-Nov 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 850
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611141"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611141"
+                    ],
+                    "idBarcode": [
+                      "33433099611141"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Feb. 15-Apr. 26, 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 849
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878970",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611117"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611117"
+                    ],
+                    "idBarcode": [
+                      "33433099611117"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Dec. 6, 2010-Feb. 7, 2011)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 848
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878953",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611133"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Aug-Sept 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611133"
+                    ],
+                    "idBarcode": [
+                      "33433099611133"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Aug-Sept 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 847
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878932",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611166"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Oct-Nov 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611166"
+                    ],
+                    "idBarcode": [
+                      "33433099611166"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Oct-Nov 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 846
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (May-June 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (May-June 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611182"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (May-June 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611182"
+                    ],
+                    "idBarcode": [
+                      "33433099611182"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (May-June 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 845
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611190"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611190"
+                    ],
+                    "idBarcode": [
+                      "33433099611190"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Feb. 9-Apr. 27, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 844
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878925",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611174"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611174"
+                    ],
+                    "idBarcode": [
+                      "33433099611174"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Aug. 10-Sept. 28, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 843
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589223",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063992"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Oct-Nov 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063992"
+                    ],
+                    "idBarcode": [
+                      "33433085063992"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Oct-Nov 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 842
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589214",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (June-July 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (June-July 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064008"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (June-July 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064008"
+                    ],
+                    "idBarcode": [
+                      "33433085064008"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (June-July 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 841
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589272",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063950"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063950"
+                    ],
+                    "idBarcode": [
+                      "33433085063950"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Feb. 11-Mar. 31 , 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 840
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063976"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063976"
+                    ],
+                    "idBarcode": [
+                      "33433085063976"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Dec 1, 2008-Feb 2, 2009)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 839
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589287",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064172"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064172"
+                    ],
+                    "idBarcode": [
+                      "33433085064172"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Aug-Sept 2008 & Suppl.)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 838
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589205",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Apr-May 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Apr-May 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Apr-May 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064214"
+                    ],
+                    "idBarcode": [
+                      "33433085064214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Apr-May 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 837
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589229",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063984"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063984"
+                    ],
+                    "idBarcode": [
+                      "33433085063984"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Oct-Nov 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 836
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589274",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063943"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063943"
+                    ],
+                    "idBarcode": [
+                      "33433085063943"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (June 25-July 30, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 835
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589278",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064180"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064180"
+                    ],
+                    "idBarcode": [
+                      "33433085064180"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Feb. 19-Mar. 26, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 834
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589263",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064206"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064206"
+                    ],
+                    "idBarcode": [
+                      "33433085064206"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Dec. 3, 2007-Feb. 4, 2008)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 833
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589251",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063968"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063968"
+                    ],
+                    "idBarcode": [
+                      "33433085063968"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Aug-Sept 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 832
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589269",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064198"
+                    ],
+                    "idBarcode": [
+                      "33433085064198"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Apr. 2-May 21, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 831
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474922",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240575"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240575"
+                    ],
+                    "idBarcode": [
+                      "33433084240575"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Oct.-Nov. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 830
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (May-June 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (May-June 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240559"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (May-June 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240559"
+                    ],
+                    "idBarcode": [
+                      "33433084240559"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (May-June 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 829
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474921",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240567"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240567"
+                    ],
+                    "idBarcode": [
+                      "33433084240567"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (July-Sept. & Suppl. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 828
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474919",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240542"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240542"
+                    ],
+                    "idBarcode": [
+                      "33433084240542"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Feb. 13-Apr. 24, 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 827
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474923",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240583"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240583"
+                    ],
+                    "idBarcode": [
+                      "33433084240583"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Dec. 4, 2006-Feb. 12, 2007)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 826
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474917",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240526"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240526"
+                    ],
+                    "idBarcode": [
+                      "33433084240526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Oct.-Nov. 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 825
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240518"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240518"
+                    ],
+                    "idBarcode": [
+                      "33433084240518"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (June 27-Sept.26,2005;Suppl.)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 824
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474914",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240492"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240492"
+                    ],
+                    "idBarcode": [
+                      "33433084240492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Feb. 14-Mar. 28, 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 823
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474918",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240534"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240534"
+                    ],
+                    "idBarcode": [
+                      "33433084240534"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Dec. 5, 2005-Feb. 6, 2006)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 822
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Apr.-May 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Apr.-May 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240500"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Apr.-May 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240500"
+                    ],
+                    "idBarcode": [
+                      "33433084240500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Apr.-May 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 821
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474912",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240476"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240476"
+                    ],
+                    "idBarcode": [
+                      "33433084240476"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Oct.-Nov. 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 820
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (May-June 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (May-June 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240468"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (May-June 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240468"
+                    ],
+                    "idBarcode": [
+                      "33433084240468"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (May-June 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 819
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474399",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (July-Sept 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (July-Sept 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078508037"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (July-Sept 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078508037"
+                    ],
+                    "idBarcode": [
+                      "33433078508037"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (July-Sept 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 818
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474447",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080028222"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080028222"
+                    ],
+                    "idBarcode": [
+                      "33433080028222"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Feb. 16- Apr. 26 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 817
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474913",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240484"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240484"
+                    ],
+                    "idBarcode": [
+                      "33433084240484"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Dec. 6, 2004-Feb. 7, 2005)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 816
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474909",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240443"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240443"
+                    ],
+                    "idBarcode": [
+                      "33433084240443"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Oct.-Nov. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 815
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474907",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (June-July 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (June-July 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240427"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (June-July 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240427"
+                    ],
+                    "idBarcode": [
+                      "33433084240427"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (June-July 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 814
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240401"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240401"
+                    ],
+                    "idBarcode": [
+                      "33433084240401"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Feb. 17-Mar. 31, 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 813
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240450"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240450"
+                    ],
+                    "idBarcode": [
+                      "33433084240450"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Dec. 1, 2003-Feb. 9, 2004)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 812
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474908",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240435"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240435"
+                    ],
+                    "idBarcode": [
+                      "33433084240435"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Aug-Sept. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 811
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Apr.-May 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Apr.-May 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240419"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Apr.-May 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240419"
+                    ],
+                    "idBarcode": [
+                      "33433084240419"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Apr.-May 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 810
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240385"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240385"
+                    ],
+                    "idBarcode": [
+                      "33433084240385"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Oct.-Nov. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 809
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (June-July 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (June-July 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240369"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (June-July 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240369"
+                    ],
+                    "idBarcode": [
+                      "33433084240369"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (June-July 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 808
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240344"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240344"
+                    ],
+                    "idBarcode": [
+                      "33433084240344"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Feb. 18-Mar. 25, 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 807
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240393"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240393"
+                    ],
+                    "idBarcode": [
+                      "33433084240393"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Dec. 2, 2002-Feb. 10, 2003)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 806
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240377"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240377"
+                    ],
+                    "idBarcode": [
+                      "33433084240377"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Aug.-Sept. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 805
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Apr.-May 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Apr.-May 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240351"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Apr.-May 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240351"
+                    ],
+                    "idBarcode": [
+                      "33433084240351"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Apr.-May 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 804
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240328"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240328"
+                    ],
+                    "idBarcode": [
+                      "33433084240328"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Oct. -Nov. 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 803
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474446",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (May-July 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (May-July 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079991612"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (May-July 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079991612"
+                    ],
+                    "idBarcode": [
+                      "33433079991612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (May-July 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 802
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240302"
+                    ],
+                    "idBarcode": [
+                      "33433084240302"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Feb. 19-Apr. 30, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 801
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240336"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240336"
+                    ],
+                    "idBarcode": [
+                      "33433084240336"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Dec. 3, 2001-Feb. 11, 2002)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 800
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240310"
+                    ],
+                    "idBarcode": [
+                      "33433084240310"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Aug. 6-Sept. 17, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 799
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240286"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240286"
+                    ],
+                    "idBarcode": [
+                      "33433084240286"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Sept.-Oct. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 798
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240294"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240294"
+                    ],
+                    "idBarcode": [
+                      "33433084240294"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Nov. 6, 2000-Feb. 5, 2001)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 797
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (July-Aug. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (July-Aug. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078639105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (July-Aug. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078639105"
+                    ],
+                    "idBarcode": [
+                      "33433078639105"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (July-Aug. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 796
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474434",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080426707"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080426707"
+                    ],
+                    "idBarcode": [
+                      "33433080426707"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Apr 24-June 26 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 795
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240211"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240211"
+                    ],
+                    "idBarcode": [
+                      "33433084240211"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075(Feb.22-May 3, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 794
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240245"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240245"
+                    ],
+                    "idBarcode": [
+                      "33433084240245"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Sept.-Oct. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 793
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Nov. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Nov. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240252"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Nov. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240252"
+                    ],
+                    "idBarcode": [
+                      "33433084240252"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Nov. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 792
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240229"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240229"
+                    ],
+                    "idBarcode": [
+                      "33433084240229"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (May 10-June 28, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 791
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (July-Aug. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (July-Aug. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240237"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (July-Aug. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240237"
+                    ],
+                    "idBarcode": [
+                      "33433084240237"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (July-Aug. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 790
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240260"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240260"
+                    ],
+                    "idBarcode": [
+                      "33433084240260"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Dec. 6, 1999-Feb. 14, 2000)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 789
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474886",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (Sept. 7-Nov. 2, 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (Sept. 7-Nov. 2, 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240203"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (Sept. 7-Nov. 2, 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240203"
+                    ],
+                    "idBarcode": [
+                      "33433084240203"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (Sept. 7-Nov. 2, 1998)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 788
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474403",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (Nov. 9, 1998-Feb. 15, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (Nov. 9, 1998-Feb. 15, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078660671"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (Nov. 9, 1998-Feb. 15, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078660671"
+                    ],
+                    "idBarcode": [
+                      "33433078660671"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (Nov. 9, 1998-Feb. 15, 1999)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 787
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (June- Aug. 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (June- Aug. 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240195"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (June- Aug. 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240195"
+                    ],
+                    "idBarcode": [
+                      "33433084240195"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (June- Aug. 1998)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 786
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474453",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080030616"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080030616"
+                    ],
+                    "idBarcode": [
+                      "33433080030616"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074"
+                  },
+                  "sort": [
+                    "        74-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 785
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17142393",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Nov. 3, 1997-Feb. 9, 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Nov. 3, 1997-Feb. 9, 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078530031"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Nov. 3, 1997-Feb. 9, 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078530031"
+                    ],
+                    "idBarcode": [
+                      "33433078530031"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Nov. 3, 1997-Feb. 9, 1998)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 784
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16700889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (May 12-July 28, 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (May 12-July 28, 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433081121117"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (May 12-July 28, 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433081121117"
+                    ],
+                    "idBarcode": [
+                      "33433081121117"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (May 12-July 28, 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 783
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474429",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Feb 17-May 5 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Feb 17-May 5 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Feb 17-May 5 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658105"
+                    ],
+                    "idBarcode": [
+                      "33433078658105"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Feb 17-May 5 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 782
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Aug-Oct 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Aug-Oct 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658113"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Aug-Oct 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658113"
+                    ],
+                    "idBarcode": [
+                      "33433078658113"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Aug-Oct 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 781
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474427",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Oct 7-Nov 25 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Oct 7-Nov 25 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658089"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Oct 7-Nov 25 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658089"
+                    ],
+                    "idBarcode": [
+                      "33433078658089"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Oct 7-Nov 25 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 780
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (July 8-Sept 30 1996 (inc))"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (July 8-Sept 30 1996 (inc))",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658071"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (July 8-Sept 30 1996 (inc))"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658071"
+                    ],
+                    "idBarcode": [
+                      "33433078658071"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (July 8-Sept 30 1996 (inc))"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 779
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474400",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Feb 19-Apr 22 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Feb 19-Apr 22 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078626128"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Feb 19-Apr 22 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078626128"
+                    ],
+                    "idBarcode": [
+                      "33433078626128"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Feb 19-Apr 22 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 778
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474428",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Dec 2 1996-Feb 10 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Dec 2 1996-Feb 10 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658097"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Dec 2 1996-Feb 10 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658097"
+                    ],
+                    "idBarcode": [
+                      "33433078658097"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Dec 2 1996-Feb 10 1997)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 777
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474425",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Apr 29-July 1 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Apr 29-July 1 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658063"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Apr 29-July 1 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658063"
+                    ],
+                    "idBarcode": [
+                      "33433078658063"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Apr 29-July 1 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 776
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Oct-Nov 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Oct-Nov 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658048"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Oct-Nov 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658048"
+                    ],
+                    "idBarcode": [
+                      "33433078658048"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Oct-Nov 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 775
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474421",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (June-July 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (June-July 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658022"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (June-July 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658022"
+                    ],
+                    "idBarcode": [
+                      "33433078658022"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (June-July 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 774
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474883",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Feb. 20-Mar. 27, 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Feb. 20-Mar. 27, 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240179"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Feb. 20-Mar. 27, 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240179"
+                    ],
+                    "idBarcode": [
+                      "33433084240179"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Feb. 20-Mar. 27, 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 773
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474424",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Dec 4 1995-Feb 12 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Dec 4 1995-Feb 12 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658055"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Dec 4 1995-Feb 12 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658055"
+                    ],
+                    "idBarcode": [
+                      "33433078658055"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Dec 4 1995-Feb 12 1996)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 772
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474422",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Aug-Sept 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Aug-Sept 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658030"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Aug-Sept 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658030"
+                    ],
+                    "idBarcode": [
+                      "33433078658030"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Aug-Sept 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 771
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Apr.-May 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Apr.-May 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240187"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Apr.-May 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240187"
+                    ],
+                    "idBarcode": [
+                      "33433084240187"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Apr.-May 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 766
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474882",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Jan. 9-Feb. 13, 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Jan. 9-Feb. 13, 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Jan. 9-Feb. 13, 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240161"
+                    ],
+                    "idBarcode": [
+                      "33433084240161"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Jan. 9-Feb. 13, 1995)"
+                  },
+                  "sort": [
+                    "        70-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 770
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474879",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Oct. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Oct. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240138"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Oct. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240138"
+                    ],
+                    "idBarcode": [
+                      "33433084240138"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Oct. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 769
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474880",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Nov. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Nov. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240146"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Nov. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240146"
+                    ],
+                    "idBarcode": [
+                      "33433084240146"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Nov. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 768
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474876",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (May 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (May 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240104"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (May 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240104"
+                    ],
+                    "idBarcode": [
+                      "33433084240104"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (May 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 767
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474877",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (June-July 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (June-July 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240112"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (June-July 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240112"
+                    ],
+                    "idBarcode": [
+                      "33433084240112"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (June-July 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 765
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474875",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Feb. 21-Mar. 28, 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Feb. 21-Mar. 28, 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240096"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Feb. 21-Mar. 28, 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240096"
+                    ],
+                    "idBarcode": [
+                      "33433084240096"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Feb. 21-Mar. 28, 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 764
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474881",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Dec. 5, 1994-Jan. 2,1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Dec. 5, 1994-Jan. 2,1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240153"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Dec. 5, 1994-Jan. 2,1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240153"
+                    ],
+                    "idBarcode": [
+                      "33433084240153"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Dec. 5, 1994-Jan. 2,1995)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 763
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474878",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Aug.-Sept. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Aug.-Sept. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240120"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Aug.-Sept. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240120"
+                    ],
+                    "idBarcode": [
+                      "33433084240120"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Aug.-Sept. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 757
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474874",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 69 (Jan. 10-Feb. 14, 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 69 (Jan. 10-Feb. 14, 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240088"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 (Jan. 10-Feb. 14, 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240088"
+                    ],
+                    "idBarcode": [
+                      "33433084240088"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 69,
+                        "lte": 69
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        69-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000069 (Jan. 10-Feb. 14, 1994)"
+                  },
+                  "sort": [
+                    "        69-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 762
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474870",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 69 (Sept. 1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 69 (Sept. 1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240047"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 (Sept. 1993)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240047"
+                    ],
+                    "idBarcode": [
+                      "33433084240047"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 69,
+                        "lte": 69
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1993"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        69-1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000069 (Sept. 1993)"
+                  },
+                  "sort": [
+                    "        69-1993"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 562
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 196
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 694
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 890,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 835
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 7
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-e6e92d2e59fab6c9dcc237f8948b453f.json
+++ b/test/fixtures/query-e6e92d2e59fab6c9dcc237f8948b453f.json
@@ -1,0 +1,14 @@
+{
+  "took": 13,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 0,
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/scsb-by-barcode-67fa66ab15f427cffba996ccf6c7122b.json
+++ b/test/fixtures/scsb-by-barcode-67fa66ab15f427cffba996ccf6c7122b.json
@@ -1,0 +1,502 @@
+[
+  {
+    "itemBarcode": "33433128201161",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128201310",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128201302",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128200965",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433128200973",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121911253",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121911105",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121911246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433121911097",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119892341",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119855561",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119872095",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119872103",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119892333",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119872087",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119855579",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119892317",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114102134",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114101987",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114102084",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433114102043",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762741",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762709",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762691",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762725",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762717",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433110762733",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108528393",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108528385",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108528401",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433108528377",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610952",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611083",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611109",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610945",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611075",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611091",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099612925",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611125",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611141",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611117",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611133",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611166",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611182",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611190",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611174",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063992",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064008",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063950",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063976",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064172",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063984",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063943",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064180",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064206",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063968",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064198",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240575",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240559",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240567",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240542",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240583",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240518",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240492",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240534",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240500",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240476",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240468",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078508037",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080028222",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240484",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240443",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240427",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240401",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240450",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240435",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240419",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240385",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240369",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240344",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240393",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240377",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240351",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240328",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079991612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240302",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240336",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240310",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240286",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240294",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078639105",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080426707",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240211",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240245",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240252",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240229",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240237",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240260",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-d9c8e4f34cf54f45a6bf43ba3ffc88a8.json
+++ b/test/fixtures/scsb-by-barcode-d9c8e4f34cf54f45a6bf43ba3ffc88a8.json
@@ -1,0 +1,502 @@
+[
+  {
+    "itemBarcode": "33433119872095",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119872087",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610952",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611083",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611109",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610945",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611075",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611091",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099612925",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611125",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611141",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611117",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611133",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611166",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611182",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611190",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611174",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063992",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064008",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063950",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063976",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064172",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063984",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063943",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064180",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064206",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063968",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064198",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240575",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240559",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240567",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240542",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240583",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240518",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240492",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240534",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240500",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240476",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240468",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078508037",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080028222",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240484",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240443",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240427",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240401",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240450",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240435",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240419",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240385",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240369",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240344",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240393",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240377",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240351",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240328",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079991612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240302",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240336",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240310",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240286",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240294",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078639105",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080426707",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240211",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240245",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240252",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240229",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240237",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240260",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240203",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078660671",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240195",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080030616",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078530031",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433081121117",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658105",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658113",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658089",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658071",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078626128",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658097",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658063",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658048",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658022",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240179",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658055",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658030",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240187",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240161",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240138",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240146",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240104",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240112",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240096",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240153",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240120",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240088",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240047",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -56,6 +56,15 @@ describe('Test Resources responses', function () {
         done()
       })
     })
+    it('does nothing to a search query with no hits', (done) => {
+      const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources?q=fladeedle'
+      request.get(url, (err, res, body) => {
+        if (err) throw err
+        const doc = JSON.parse(body)
+        expect(doc.numItemsMatched).to.equal(undefined)
+        done()
+      })
+    })
   })
 
   describe('GET sample resources', function () {

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -19,21 +19,41 @@ describe('Test Resources responses', function () {
     fixtures.disableScsbFixtures()
   })
 
-  describe.only('GET numItemsMatched', function () {
-    it('returns numItemsMatched for blank bib query', () => {
+  describe.only('GET numItemsMatched', () => {
+    it('returns numItemsMatched for blank bib query', (done) => {
       const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141'
-      return request.get(url, (err, res, body) => {
+      request.get(url, (err, res, body) => {
         if (err) throw err
         const doc = JSON.parse(body)
-        expect(doc.numItemsMatched).to.equal(779)
+        expect(doc.numItemsMatched).to.equal(694)
+        done()
       })
     })
-    it('returns numItemsMatched for blank bib query merge check in cards', () => {
+    it('returns numItemsMatched for bib with location query', (done) => {
       const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141?item_location=loc:mal82'
-      return request.get(url, (err, res, body) => {
+      request.get(url, (err, res, body) => {
         if (err) throw err
         const doc = JSON.parse(body)
-        expect(doc.numItemsMatched).to.equal(779)
+        expect(doc.numItemsMatched).to.equal(562)
+        done()
+      })
+    })
+    it('returns numItemsMatched for blank bib query merge check in cards', (done) => {
+      const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141?merge_checkin_card_items=true'
+      request.get(url, (err, res, body) => {
+        if (err) throw err
+        const doc = JSON.parse(body)
+        expect(doc.numItemsMatched).to.equal(562)
+        done()
+      })
+    })
+    it('returns numItemsMatched for query merge check in cards and status:na', (done) => {
+      const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141?merge_checkin_card_items=true&item_status=status:na'
+      request.get(url, (err, res, body) => {
+        if (err) throw err
+        const doc = JSON.parse(body)
+        expect(doc.numItemsMatched).to.equal(7)
+        done()
       })
     })
   })

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -19,7 +19,7 @@ describe('Test Resources responses', function () {
     fixtures.disableScsbFixtures()
   })
 
-  describe.only('GET numItemsMatched', () => {
+  describe('GET numItemsMatched', () => {
     it('returns numItemsMatched for blank bib query', (done) => {
       const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141'
       request.get(url, (err, res, body) => {
@@ -43,7 +43,7 @@ describe('Test Resources responses', function () {
       request.get(url, (err, res, body) => {
         if (err) throw err
         const doc = JSON.parse(body)
-        expect(doc.numItemsMatched).to.equal(562)
+        expect(doc.numItemsMatched).to.equal(890)
         done()
       })
     })

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -19,6 +19,25 @@ describe('Test Resources responses', function () {
     fixtures.disableScsbFixtures()
   })
 
+  describe.only('GET numItemsMatched', function () {
+    it('returns numItemsMatched for blank bib query', () => {
+      const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141'
+      return request.get(url, (err, res, body) => {
+        if (err) throw err
+        const doc = JSON.parse(body)
+        expect(doc.numItemsMatched).to.equal(779)
+      })
+    })
+    it('returns numItemsMatched for blank bib query merge check in cards', () => {
+      const url = global.TEST_BASE_URL + '/api/v0.1/discovery/resources/b10833141?item_location=loc:mal82'
+      return request.get(url, (err, res, body) => {
+        if (err) throw err
+        const doc = JSON.parse(body)
+        expect(doc.numItemsMatched).to.equal(779)
+      })
+    })
+  })
+
   describe('GET sample resources', function () {
     sampleResources.forEach(function (spec) {
       it(`Resource ${spec.id} has correct type ${spec.type}`, function (done) {
@@ -440,9 +459,7 @@ describe('Test Resources responses', function () {
           nextUrl += `&filters[dateBefore]=${dates[1]}`
           return request.get(nextUrl, function (err, response, body) {
             if (err) throw err
-
             var doc = JSON.parse(body)
-
             // Ensure count decreased:
             expect(doc.totalResults).to.be.below(prevTotal)
 


### PR DESCRIPTION
extract resp.hits.hits[0].items.total and attach it to source so it can be serialized. this number reflects the number of items that match query params, including merge_checkin_cards and filters